### PR TITLE
Epsilon Greedy Strategy Wrapper

### DIFF
--- a/pybandits/strategy.py
+++ b/pybandits/strategy.py
@@ -292,6 +292,7 @@ class MultiObjectiveBandit(Strategy):
 
     Reference: Thompson Sampling for Multi-Objective Multi-Armed Bandits Problem (Yahyaa and Manderick, 2015)
                https://www.researchgate.net/publication/272823659_Thompson_Sampling_for_Multi-Objective_Multi-Armed_Bandits_Problem
+
     Parameters
     ----------
     n_objectives: int

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ ipykernel = "^6.21.3"
 jupyterlab = "^3.6.1"
 flake8-pyproject = "^1.2.2"
 pytest-cov = "^4.0.0"
+pytest_mock = "^3.14.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
 Change log:
 1. Added pytest_mock for mocking pytests in pyproject.toml
 2. Added _make_epsilon_greedy functionality as a static method of Strategy in base.py. The method wraps the native select_action of the strategy with epsilon_greedy approach.
 3. Added epsilon and default_action to all smab.py and cmab.py classes and cold start methods
 4. Added test suite for the epsilon greedy functionlity