### PR TITLE
Ruff Formatting

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -36,10 +36,6 @@ jobs:
           poetry install
       - name: Style check
         run: |
-          # stop the build if there are Python syntax errors or undefined names
-          poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
           # run pre-commit hooks
           poetry run pre-commit run --all-files
       - name: Run tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,22 +15,15 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
 
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.6
     hooks:
-      - id: flake8
-        additional_dependencies: [Flake8-pyproject]
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-
-  - repo: https://github.com/psf/black
-    rev: 23.1.0
-    hooks:
-      - id: black
-      - id: black-jupyter
+      - id: ruff-format
+        types_or: [ python, pyi, jupyter ]
+      - id: ruff
+        args: [ --fix, --exit-non-zero-on-fix ]
+        types_or: [ python, pyi, jupyter ]
+        require_serial: true
 
   - repo: https://github.com/fastai/nbdev
     rev: 2.3.11

--- a/docs/src/tutorials/cmab.ipynb
+++ b/docs/src/tutorials/cmab.ipynb
@@ -43,7 +43,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import pandas as pd\n",
+    "\n",
     "from pybandits.core.cmab import Cmab"
    ]
   },

--- a/docs/src/tutorials/simulation_cmab.ipynb
+++ b/docs/src/tutorials/simulation_cmab.ipynb
@@ -21,10 +21,10 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "import numpy as np\n",
     "from sklearn.datasets import make_classification\n",
-    "from pybandits.utils.simulation_cmab import SimulationCmab\n",
-    "from pybandits.core.cmab import Cmab"
+    "\n",
+    "from pybandits.core.cmab import Cmab\n",
+    "from pybandits.utils.simulation_cmab import SimulationCmab"
    ]
   },
   {

--- a/docs/src/tutorials/simulation_smab.ipynb
+++ b/docs/src/tutorials/simulation_smab.ipynb
@@ -22,7 +22,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "from pybandits.core.smab import Smab\n",
     "from pybandits.utils.simulation_smab import SimulationSmab"
    ]

--- a/docs/src/tutorials/smab.ipynb
+++ b/docs/src/tutorials/smab.ipynb
@@ -36,8 +36,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import random\n",
+    "\n",
     "from pybandits.core.smab import Smab"
    ]
   },

--- a/docs/tutorials/cmab.ipynb
+++ b/docs/tutorials/cmab.ipynb
@@ -43,7 +43,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import pandas as pd\n",
+    "\n",
     "from pybandits.core.cmab import Cmab"
    ]
   },

--- a/docs/tutorials/mab.ipynb
+++ b/docs/tutorials/mab.ipynb
@@ -17,11 +17,10 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "\n",
     "from rich import print\n",
     "\n",
-    "from pybandits.smab import SmabBernoulli, create_smab_bernoulli_cold_start\n",
-    "from pybandits.model import Beta"
+    "from pybandits.model import Beta\n",
+    "from pybandits.smab import SmabBernoulli, create_smab_bernoulli_cold_start"
    ]
   },
   {

--- a/docs/tutorials/simulation_cmab.ipynb
+++ b/docs/tutorials/simulation_cmab.ipynb
@@ -21,10 +21,10 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "import numpy as np\n",
     "from sklearn.datasets import make_classification\n",
-    "from pybandits.utils.simulation_cmab import SimulationCmab\n",
-    "from pybandits.core.cmab import Cmab"
+    "\n",
+    "from pybandits.core.cmab import Cmab\n",
+    "from pybandits.utils.simulation_cmab import SimulationCmab"
    ]
   },
   {

--- a/docs/tutorials/simulation_smab.ipynb
+++ b/docs/tutorials/simulation_smab.ipynb
@@ -22,7 +22,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "from pybandits.core.smab import Smab\n",
     "from pybandits.utils.simulation_smab import SimulationSmab"
    ]

--- a/docs/tutorials/smab.ipynb
+++ b/docs/tutorials/smab.ipynb
@@ -36,8 +36,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import random\n",
+    "\n",
     "from pybandits.core.smab import Smab"
    ]
   },

--- a/docs/tutorials/smab_mo_cc.ipynb
+++ b/docs/tutorials/smab_mo_cc.ipynb
@@ -17,11 +17,10 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "\n",
     "from rich import print\n",
     "\n",
-    "from pybandits.smab import SmabBernoulliMOCC, create_smab_bernoulli_mo_cc_cold_start\n",
-    "from pybandits.model import Beta, BetaMOCC"
+    "from pybandits.model import Beta, BetaMOCC\n",
+    "from pybandits.smab import SmabBernoulliMOCC, create_smab_bernoulli_mo_cc_cold_start"
    ]
   },
   {

--- a/pybandits/model.py
+++ b/pybandits/model.py
@@ -34,10 +34,9 @@ from pydantic import (
     model_validator,
     validate_call,
 )
-from pymc import Bernoulli, Data, Deterministic
+from pymc import Bernoulli, Data, Deterministic, sample
 from pymc import Model as PymcModel
 from pymc import StudentT as PymcStudentT
-from pymc import sample
 from pymc.math import sigmoid
 from pytensor.tensor import dot
 from scipy.stats import t

--- a/pybandits/simulation_cmab.py
+++ b/pybandits/simulation_cmab.py
@@ -257,8 +257,7 @@ class SimulationCmab:
             Matrix of the proportion of positive rewards per group/action.
         """
         return {
-            "group "
-            + str(i): (
+            "group " + str(i): (
                 self.results["action"].loc[(self.results["group"] == i) & (self.results["reward"] == 1)].value_counts()
                 / self.results["action"].loc[(self.results["group"] == i)].value_counts()
             ).to_dict()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     "Stefano Piazza <stefanop@playtika.com>",
     "Raphael Steinmann <raphaels@playtika.com>",
     "Armand Valsesia <armandv@playtika.com>",
-    ]
+]
 license = "MIT License"
 readme = "README.md"
 
@@ -22,10 +22,7 @@ pymc = "^5.3.0"
 scikit-learn = "^1.2.2"
 
 [tool.poetry.group.dev.dependencies]
-black = "^23.1.0"
-flake8 = "^6.0.0"
 hypothesis = "^6.68.2"
-pylint = "^2.17.0"
 pytest = "^7.2.2"
 tox = "^4.4.7"
 pandas = "^1.5.3"
@@ -35,42 +32,36 @@ rich = "^13.3.2"
 pyzmq = "25.0.0"
 ipykernel = "^6.21.3"
 jupyterlab = "^3.6.1"
-flake8-pyproject = "^1.2.2"
 pytest-cov = "^4.0.0"
 pytest_mock = "^3.14.0"
+ruff = "^0.5.6"
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.isort]
-profile = "black"
-
-[tool.black]
-line-length = 120
-
-[tool.pylint]
-
-[tool.pylint.format]
-max-line-length = 120
-
-[tool.pylint.master]
-extension-pkg-whitelist = "pydantic"
-# disable check for:
-# C0114: Missing module docstring
-# C0115: Missing class docstring
-# C0116: Missing function or method docstring
-# R0903: Too few public methods
-# R0913: Too many arguments
-disable = ["C0114", "C0115", "C0116", "R0903", "R0913"]
-
-[tool.pylint.basic]
-good-names = ["i", "j", "k", "r", "ex", "_", "a", "p", "v"]
-
 [tool.mypy]
 plugins = "pydantic.mypy"
 
-[tool.flake8]
-# exclude = [".git", "__pycache__", ".tox"]
-max-line-length = 120
-extend-ignore = "E203"
+[tool.ruff]
+line-length = 120
+extend-include = ["*.ipynb"]
+extend-ignore = ["E203"]
+
+# pylint configuration incorporated in Ruff
+[tool.ruff.lint]
+# Enable the isort rules.
+extend-select = ["I"]
+
+[tool.ruff.per-file-ignores]
+# disable check for:
+# D100: Missing docstring in public module (equivalent to C0114)
+# D101: Missing docstring in public class (equivalent to C0115)
+# D102: Missing docstring in public method (equivalent to C0116)
+# D103: Missing docstring in public function (equivalent to C0116)
+# D104: Missing docstring in public package (equivalent to C0114)
+# D105: Missing docstring in magic method (equivalent to C0116)
+# D106: Missing docstring in public nested class (equivalent to C0115)
+# Missing : Too few public methods (equivalent to R0903)
+# PLR0913: Too many arguments (equivalent to R0913)
+"*.py" = ["D100", "D101", "D102", "D103", "D104", "D105", "D106", "PLR0913"]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -126,7 +126,7 @@ def test_default_action_not_in_actions(p: Dict[ActionId, Probability]):
 
 def test_select_action_raises_exception(mocker: MockerFixture, p: Dict[ActionId, Probability]):
     mocker.patch.object(ClassicBandit, "select_action", side_effect=Exception("Test Exception"))
-    mab = DummyMab(actions={"a1": Beta(), "a2": Beta()}, strategy=ClassicBandit(), epsilon=0.1, default_action="a1")
+    mab = DummyMab(actions={"a1": Beta(), "a2": Beta()}, strategy=ClassicBandit(), epsilon=0.0, default_action=None)
 
     with pytest.raises(Exception) as excinfo:
         mab._select_epsilon_greedy_action(p)

--- a/tests/test_cmab.py
+++ b/tests/test_cmab.py
@@ -165,17 +165,17 @@ def test_cmab_update(n_samples=100, n_features=3):
 
     # context is numpy array
     context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
-    assert type(context) == np.ndarray
+    assert type(context) is np.ndarray
     run_update(context=context)
 
     # context is python list
     context = context.tolist()
-    assert type(context) == list
+    assert type(context) is list
     run_update(context=context)
 
     # context is pandas DataFrame
     context = pd.DataFrame(context)
-    assert type(context) == pd.DataFrame
+    assert type(context) is pd.DataFrame
     run_update(context=context)
 
 
@@ -226,17 +226,17 @@ def test_cmab_predict_cold_start(n_samples, n_features):
 
     # context is numpy array
     context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
-    assert type(context) == np.ndarray
+    assert type(context) is np.ndarray
     run_predict(context=context)
 
     # context is python list
     context = context.tolist()
-    assert type(context) == list
+    assert type(context) is list
     run_predict(context=context)
 
     # context is pandas DataFrame
     context = pd.DataFrame(context)
-    assert type(context) == pd.DataFrame
+    assert type(context) is pd.DataFrame
     run_predict(context=context)
 
 
@@ -256,17 +256,17 @@ def test_cmab_predict_not_cold_start(n_samples, n_features):
 
     # context is numpy array
     context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
-    assert type(context) == np.ndarray
+    assert type(context) is np.ndarray
     run_predict(context=context)
 
     # context is python list
     context = context.tolist()
-    assert type(context) == list
+    assert type(context) is list
     run_predict(context=context)
 
     # context is pandas DataFrame
     context = pd.DataFrame(context)
-    assert type(context) == pd.DataFrame
+    assert type(context) is pd.DataFrame
     run_predict(context=context)
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -259,17 +259,17 @@ def test_check_context_matrix(n_samples, n_features):
 
     # context is numpy array
     context = np.random.uniform(low=-100.0, high=100.0, size=(n_samples, n_features))
-    assert type(context) == np.ndarray
+    assert type(context) is np.ndarray
     blr.check_context_matrix(context=context)
 
     # context is python list
     context = context.tolist()
-    assert type(context) == list
+    assert type(context) is list
     blr.check_context_matrix(context=context)
 
     # context is pandas DataFrame
     context = pd.DataFrame(context)
-    assert type(context) == pd.DataFrame
+    assert type(context) is pd.DataFrame
     blr.check_context_matrix(context=context)
 
     # raise an error if len(context) != len(self.betas)
@@ -293,7 +293,7 @@ def test_blr_sample_proba(n_samples, n_features):
     def sample_proba(context):
         prob, weighted_sum = blr.sample_proba(context=context)
 
-        assert type(prob) == type(weighted_sum) == np.ndarray  # type of the returns must be np.ndarray
+        assert type(prob) is type(weighted_sum) is np.ndarray  # type of the returns must be np.ndarray
         assert len(prob) == len(weighted_sum) == n_samples  # return 1 sampled proba and ws per each sample
         assert all([0 <= p <= 1 for p in prob])  # probs must be in the interval [0, 1]
 
@@ -301,17 +301,17 @@ def test_blr_sample_proba(n_samples, n_features):
 
     # context is numpy array
     context = np.random.uniform(low=-100.0, high=100.0, size=(n_samples, n_features))
-    assert type(context) == np.ndarray
+    assert type(context) is np.ndarray
     sample_proba(context=context)
 
     # context is python list
     context = context.tolist()
-    assert type(context) == list
+    assert type(context) is list
     sample_proba(context=context)
 
     # context is pandas DataFrame
     context = pd.DataFrame(context)
-    assert type(context) == pd.DataFrame
+    assert type(context) is pd.DataFrame
     sample_proba(context=context)
 
 
@@ -338,17 +338,17 @@ def test_blr_update(n_samples=100, n_features=3):
 
     # context is numpy array
     context = np.random.uniform(low=-100.0, high=100.0, size=(n_samples, n_features))
-    assert type(context) == np.ndarray
+    assert type(context) is np.ndarray
     update(context=context, rewards=rewards)
 
     # context is python list
     context = context.tolist()
-    assert type(context) == list
+    assert type(context) is list
     update(context=context, rewards=rewards)
 
     # context is pandas DataFrame
     context = pd.DataFrame(context)
-    assert type(context) == pd.DataFrame
+    assert type(context) is pd.DataFrame
     update(context=context, rewards=rewards)
 
     # raise an error if len(context) != len(rewards)


### PR DESCRIPTION
 Change log:
 1. Removed black, pylint, flake8, and isort. Replaced all with ruff on .pre-commit-config.yaml.
 2. Added compatible ruff definitions on pyproject.toml. Only missing definitions are for pylint variable good names and for ignoring R0903.
 3. Formatting now applies to notebooks, so they were changed correspondngly.
 4. Reformatted simulation_cmab.py.
 5. Changed type tests on UTs to follow "type(...) is ...", rather than type(...) == ..."