### PR TITLE
Add offline policy evaluation module and update dependencies

### DIFF
--- a/.github/workflows/continuous_delivery.yml
+++ b/.github/workflows/continuous_delivery.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         pydantic-version: [ "1.10.*", "2.*" ]
 
     steps:
@@ -29,10 +29,23 @@ jobs:
           export PATH="$HOME/.poetry/bin:$PATH"
       - name: Backup pyproject.toml
         run: cp pyproject.toml pyproject.toml.bak
+      - name: Change pydantic version
+        run: |
+          poetry add pydantic@${{ matrix.pydantic-version }} --lock
+      - name: Cache Poetry virtualenv and dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pypoetry
+            ~/.local/share/pypoetry/virtualenvs
+          key: ${{ runner.os }}-poetry-${{ matrix.python-version }}-${{ matrix.pydantic-version }}-${{ hashFiles('poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-${{ matrix.python-version }}-${{ matrix.pydantic-version }}-
       - name: Install project dependencies with Poetry
         run: |
-          poetry add pydantic@${{ matrix.pydantic-version }}
           poetry install
+      - name: Restore pyproject.toml
+        run: |
           mv pyproject.toml.bak pyproject.toml
       - name: Style check
         run: |
@@ -62,7 +75,7 @@ jobs:
           git tag "${{ env.PACKAGE_VERSION }}"
           git push origin "${{ env.PACKAGE_VERSION }}"
       - name: Publish Draft Release
-        if: ${{ env.VERSION_CHANGED == 'true' && matrix.python-version == '3.8' && matrix.pydantic-version == '2.*' }}
+        if: ${{ env.VERSION_CHANGED == 'true' && matrix.python-version == '3.10' && matrix.pydantic-version == '2.*' }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10" ]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         pydantic-version: [ "1.10.*", "2.*" ]
 
     steps:
@@ -45,4 +45,4 @@ jobs:
           poetry run pre-commit run --all-files
       - name: Run tests
         run: |
-          poetry run pytest -n auto -vv
+          poetry run pytest -n auto -s -vv --durations=5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: check-added-large-files

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -18,6 +18,10 @@
   > - {mod}`pybandits.smab_simulator`
   > - {mod}`pybandits.cmab_simulator`
 
+- `pybandits` provides an OPE framework.
+  > - {mod}`pybandits.offline_policy_evaluator`
+  > - {mod}`pybandits.offline_policy_estimator`
+
 ## API
 
 Please visit the full [API](fullapi.md) for details.

--- a/docs/src/fullapi.md
+++ b/docs/src/fullapi.md
@@ -56,12 +56,33 @@
     :members:
     :undoc-members:
     :show-inheritance:
+
 ```
 
 ## pybandits.cmab_simulator
 
 ```{eval-rst}
 .. automodule:: pybandits.cmab_simulator
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+```
+
+## pybandits.offline_policy_evaluator
+
+```{eval-rst}
+.. automodule:: pybandits.cmab_simulator
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+```
+
+## pybandits.offline_policy_estimator
+
+```{eval-rst}
+.. automodule:: pybandits.offline_policy_estimator
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -7,4 +7,6 @@ tutorials/smab
 tutorials/cmab
 tutorials/smab_simulator
 tutorials/cmab_simulator
+tutorials/bnn
+tutorials/ope
 ```

--- a/docs/src/tutorials/ope.ipynb
+++ b/docs/src/tutorials/ope.ipynb
@@ -1,0 +1,211 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Introduction\n",
+    "\n",
+    "This notebook demonstrates the use of offline policy evaluation for MABs.\n",
+    "\n",
+    "### Objectives\n",
+    "\n",
+    "#### Evaluation:\n",
+    "\n",
+    "Evaluate the performance of a MAB using multiple offline policy estimators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from sklearn.preprocessing import MinMaxScaler\n",
+    "\n",
+    "from pybandits.cmab import CmabBernoulliCC\n",
+    "from pybandits.offline_policy_evaluator import OfflinePolicyEvaluator\n",
+    "\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We first generate a binarly labeled data set, with a two dimensional feature space, and is not lineraly seprabale.\n",
+    "We then split the data set to a training data setm and a test data set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_samples = 1000\n",
+    "n_actions = 2\n",
+    "n_batches = 3\n",
+    "n_rewards = 1\n",
+    "n_groups = 2\n",
+    "n_features = 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "unique_actions = [f\"a{i}\" for i in range(n_actions)]\n",
+    "action_ids = np.random.choice(unique_actions, n_samples * n_batches)\n",
+    "batches = [i for i in range(n_batches) for _ in range(n_samples)]\n",
+    "rewards = [np.random.randint(2, size=(n_samples * n_batches)) for _ in range(n_rewards)]\n",
+    "action_true_rewards = {(a, r): np.random.rand() for a in unique_actions for r in range(n_rewards)}\n",
+    "true_rewards = [\n",
+    "    np.array([action_true_rewards[(a, r)] for a in action_ids]).reshape(n_samples * n_batches) for r in range(n_rewards)\n",
+    "]\n",
+    "groups = np.random.randint(n_groups, size=n_samples * n_batches)\n",
+    "action_costs = {action: np.random.rand() for action in unique_actions}\n",
+    "costs = np.array([action_costs[a] for a in action_ids])\n",
+    "context = np.random.rand(n_samples * n_batches, n_features)\n",
+    "action_propensity_score = {action: np.random.rand() for action in unique_actions}\n",
+    "propensity_score = np.array([action_propensity_score[a] for a in action_ids])\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"batch\": batches,\n",
+    "        \"action_id\": action_ids,\n",
+    "        \"cost\": costs,\n",
+    "        \"group\": groups,\n",
+    "        **{f\"reward_{r}\": rewards[r] for r in range(n_rewards)},\n",
+    "        **{f\"true_reward_{r}\": true_rewards[r] for r in range(n_rewards)},\n",
+    "        **{f\"context_{i}\": context[:, i] for i in range(n_features)},\n",
+    "        \"propensity_score\": propensity_score,\n",
+    "    }\n",
+    ")\n",
+    "contextual_features = [col for col in df.columns if col.startswith(\"context\")]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using the cold_start method of CmabBernoulliCC, we can create a model to be used for offline policy evaluation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "action_ids_cost = {action_id: df[\"cost\"][df[\"action_id\"] == action_id].iloc[0] for action_id in unique_actions}\n",
+    "\n",
+    "mab = CmabBernoulliCC.cold_start(action_ids_cost=action_ids_cost, n_features=len(contextual_features))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## OPE"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Given the model and the OPE data from the logging policy, we can either evaluate the model using the logging policy, or update it with the logging policy data prior to the evaluation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "evaluator = OfflinePolicyEvaluator(\n",
+    "    logged_data=df,\n",
+    "    split_prop=0.5,\n",
+    "    n_trials=10,\n",
+    "    fast_fit=True,\n",
+    "    scaler=MinMaxScaler(),\n",
+    "    ope_estimators=None,\n",
+    "    verbose=True,\n",
+    "    propensity_score_model_type=\"batch_empirical\",\n",
+    "    expected_reward_model_type=\"gbm\",\n",
+    "    importance_weights_model_type=\"logreg\",\n",
+    "    batch_feature=\"batch\",\n",
+    "    action_feature=\"action_id\",\n",
+    "    reward_feature=\"reward_0\",\n",
+    "    true_reward_feature=\"true_reward_0\",\n",
+    "    contextual_features=contextual_features,\n",
+    "    group_feature=\"group\",\n",
+    "    cost_feature=\"cost\",\n",
+    "    propensity_score_feature=\"propensity_score\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "evaluator.evaluate(mab=mab, visualize=True, n_mc_experiments=1000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "evaluator.update_and_evaluate(mab=mab, visualize=True, n_mc_experiments=1000)"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pybandits/mab.py
+++ b/pybandits/mab.py
@@ -36,7 +36,7 @@ from pybandits.base import (
     Predictions,
     PyBanditsBaseModel,
 )
-from pybandits.model import BaseModel, Model
+from pybandits.model import BaseModel
 from pybandits.pydantic_version_compatibility import (
     PYDANTIC_VERSION_1,
     PYDANTIC_VERSION_2,
@@ -170,7 +170,7 @@ class BaseMab(PyBanditsBaseModel, ABC):
             raise ValueError("Adaptive window requires epsilon greedy super strategy with not default action.")
 
     @property
-    def actions(self) -> Dict[ActionId, Model]:
+    def actions(self) -> Dict[ActionId, BaseModel]:
         return self.actions_manager.actions
 
     @validate_call

--- a/pybandits/offline_policy_estimator.py
+++ b/pybandits/offline_policy_estimator.py
@@ -1,0 +1,804 @@
+"""
+Comprehensive Offline Policy Evaluation (OPE) estimators.
+
+This module provides a complete set of estimators for OPE.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, Callable, ClassVar, Dict, Optional, Tuple, Type
+
+import numpy as np
+from scipy.stats import bootstrap
+
+from pybandits.base import Float01, PyBanditsBaseModel
+from pybandits.pydantic_version_compatibility import (
+    NonNegativeFloat,
+    PositiveFloat,
+    PositiveInt,
+    PrivateAttr,
+    validate_call,
+)
+
+
+class BaseOfflinePolicyEstimator(PyBanditsBaseModel, ABC):
+    """Base class for all OPE estimators.
+
+    This class defines the interface for all OPE estimators and provides a common method for estimating the policy value.
+
+    Parameters
+    ----------
+    alpha : Float01, default=0.05
+        Significance level for confidence interval estimation.
+    n_bootstrap_samples : int, default=10000
+        Number of bootstrap samples for confidence interval estimation.
+    random_state : int, default=None
+        Random seed for bootstrap sampling.
+    """
+
+    alpha: Float01 = 0.05
+    n_bootstrap_samples: int = 10000
+    random_state: Optional[int] = None
+    name: ClassVar
+
+    @classmethod
+    def _check_array(
+        cls,
+        name: str,
+        data: Dict[str, np.ndarray],
+        ndim: PositiveInt,
+        dtype: type,
+        n_samples: PositiveInt,
+        n_actions: Optional[PositiveInt] = None,
+    ):
+        if name in data:
+            array = data[name]
+            if array.ndim != ndim:
+                raise ValueError(f"{name} must be a {ndim}D array.")
+            if array.shape[0] != n_samples:
+                raise ValueError(f"action and {name} must have the same length.")
+            if array.dtype != dtype:
+                raise ValueError(f"{name} must be a {dtype} array")
+            if ndim > 1:
+                if array.shape[1] != n_actions:
+                    raise ValueError(f"{name} must have the same number of actions as the action array.")
+
+    @classmethod
+    def _check_sum(cls, name: str, data: Dict[str, np.ndarray]):
+        if name in data:
+            array = data[name]
+            if not array.sum(axis=-1).all():
+                raise ValueError(f"{name} must have at least one non-zero element on each column.")
+
+    @classmethod
+    def _check_inputs(cls, action: np.ndarray, **kwargs):
+        """
+        Check the inputs for the estimator.
+
+        Parameters
+        ----------
+        action : np.ndarray
+            Array of actions taken.
+        """
+        if action.ndim != 1:
+            raise ValueError("action must be a 1D array.")
+        if action.dtype != int:
+            raise ValueError("action must be an integer array.")
+        n_samples = action.shape[0]
+        n_actions = np.unique(action).shape[0]
+
+        for name, dtype in zip(["reward", "propensity_score", "expected_importance_weight"], [int, float, float]):
+            cls._check_array(name, kwargs, 1, dtype, n_samples)
+
+        for name in ["estimated_policy", "expected_reward"]:
+            cls._check_array(name, kwargs, 2, float, n_samples, n_actions)
+
+        for name in ["propensity_score", "estimated_policy", "expected_importance_weight"]:
+            cls._check_sum(name, kwargs)
+
+    @validate_call(config=dict(arbitrary_types_allowed=True))
+    def estimate_policy_value_with_confidence_interval(self, **kwargs) -> Tuple[float, float, float, float]:
+        """
+        Estimate the policy value with a confidence interval.
+
+        Parameters
+        ----------
+        action : np.ndarray
+            Array of actions taken.
+
+        Returns
+        -------
+        Tuple[float, float, float, float]
+            Estimated policy value, mean, lower bound, and upper bound of the confidence interval.
+        """
+        self._check_inputs(**kwargs)
+        sample_reward = self.estimate_sample_rewards(**kwargs)
+        estimated_policy_value = sample_reward.mean()
+        bootstrap_result = bootstrap(
+            data=(sample_reward,),
+            statistic=np.mean,
+            confidence_level=1 - self.alpha,
+            n_resamples=self.n_bootstrap_samples,
+            random_state=self.random_state,
+        )
+        low, high = bootstrap_result.confidence_interval
+        std = bootstrap_result.standard_error
+        return estimated_policy_value, low, high, std
+
+    @abstractmethod
+    def estimate_sample_rewards(self, **kwargs) -> np.ndarray:
+        """
+        Estimate sample rewards.
+
+        Returns
+        -------
+        np.ndarray
+            Estimated sample rewards.
+        """
+        pass
+
+
+class ReplayMethod(BaseOfflinePolicyEstimator):
+    """
+    Replay Method estimator.
+
+    This estimator is a simple baseline that estimates the policy value by averaging the rewards of the matched samples.
+
+    References
+    ----------
+    Unbiased Offline Evaluation of Contextual-bandit-based News Article Recommendation Algorithms (Li, Chu, Langford, and Wang, 2011)
+    https://arxiv.org/pdf/1003.5956
+
+    Parameters
+    ----------
+    alpha : Float01, default=0.05
+        Significance level for confidence interval estimation.
+    n_bootstrap_samples : int, default=10000
+        Number of bootstrap samples for confidence interval estimation.
+    random_state : int, default=None
+        Random seed for bootstrap sampling.
+
+    """
+
+    name = "rep"
+
+    def estimate_sample_rewards(
+        self, action: np.ndarray, reward: np.ndarray, estimated_policy: np.ndarray, **kwargs
+    ) -> np.ndarray:
+        """
+        Estimate the sample rewards.
+
+        Parameters
+        ----------
+        action : np.ndarray
+            Array of actions taken.
+        reward : np.ndarray
+            Array of rewards corresponding to each action.
+        estimated_policy : np.ndarray
+            Array of action distributions.
+
+        Returns
+        -------
+        sample_reward : np.ndarray
+            Estimated sample rewards.
+        """
+        n_samples = action.shape[0]
+        matched_evaluation_policy = estimated_policy[np.arange(n_samples), action]
+        matched_action = matched_evaluation_policy == 1
+        sample_reward = (
+            reward * matched_action / matched_action.mean() if matched_action.any() else np.zeros_like(matched_action)
+        )
+        return sample_reward
+
+
+class GeneralizedInverseProbabilityWeighting(BaseOfflinePolicyEstimator, ABC):
+    """
+    Abstract generalization of the Inverse Probability Weighting (IPW) estimator.
+
+    References
+    ----------
+    Learning from Logged Implicit Exploration Data (Strehl, Langford, Li, and Kakade, 2010)
+    https://arxiv.org/pdf/1003.0120
+
+    Parameters
+    ----------
+    alpha : Float01, default=0.05
+        Significance level for confidence interval estimation.
+    n_bootstrap_samples : int, default=10000
+        Number of bootstrap samples for confidence interval estimation.
+    random_state : int, default=None
+        Random seed for bootstrap sampling.
+    """
+
+    @abstractmethod
+    def _get_importance_weights(self, **kwargs) -> np.ndarray:
+        """
+        Get the importance weights.
+
+        Returns
+        -------
+        np.ndarray
+            Array of importance weights.
+        """
+        pass
+
+    def estimate_sample_rewards(self, reward: np.ndarray, shrinkage_method: Optional[Callable], **kwargs) -> np.ndarray:
+        """
+        Estimate the sample rewards.
+
+        Parameters
+        ----------
+        reward : np.ndarray
+            Array of rewards corresponding to each action.
+        shrinkage_method : Optional[Callable]
+            Shrinkage method for the importance weights.
+
+        Returns
+        -------
+        sample_reward : np.ndarray
+            Estimated sample rewards.
+        """
+        importance_weight = self._get_importance_weights(**kwargs)
+        importance_weight = shrinkage_method(importance_weight) if shrinkage_method is not None else importance_weight
+        sample_reward = reward * importance_weight
+        return sample_reward
+
+
+class InverseProbabilityWeighting(GeneralizedInverseProbabilityWeighting):
+    """
+    Inverse Probability Weighing (IPW) estimator.
+
+    References
+    ----------
+    Learning from Logged Implicit Exploration Data (Strehl, Langford, Li, and Kakade, 2010)
+    https://arxiv.org/pdf/1003.0120
+
+    Parameters
+    ----------
+    alpha : Float01, default=0.05
+        Significance level for confidence interval estimation.
+    n_bootstrap_samples : int, default=10000
+        Number of bootstrap samples for confidence interval estimation.
+    random_state : int, default=None
+        Random seed for bootstrap sampling.
+    """
+
+    name = "ipw"
+
+    def estimate_sample_rewards(
+        self,
+        action: np.ndarray,
+        reward: np.ndarray,
+        propensity_score: np.ndarray,
+        estimated_policy: np.ndarray,
+        shrinkage_method: Optional[Callable] = None,
+        **kwargs,
+    ) -> np.ndarray:
+        """
+        Estimate the sample rewards.
+
+        Parameters
+        ----------
+        action : np.ndarray
+            Array of actions taken.
+        reward : np.ndarray
+            Array of rewards corresponding to each action.
+        propensity_score : np.ndarray
+            Array of propensity scores.
+        estimated_policy : np.ndarray
+            Array of action distributions.
+
+        Returns
+        -------
+        sample_reward : np.ndarray
+            Estimated sample rewards.
+        """
+        return super().estimate_sample_rewards(
+            reward=reward,
+            action=action,
+            propensity_score=propensity_score,
+            estimated_policy=estimated_policy,
+            shrinkage_method=shrinkage_method,
+        )
+
+    def _get_importance_weights(
+        self,
+        action: np.ndarray,
+        propensity_score: np.ndarray,
+        estimated_policy: np.ndarray,
+        **kwargs,
+    ) -> np.ndarray:
+        """
+        Get the importance weights.
+
+        Parameters
+        ----------
+        action : np.ndarray
+            Array of actions taken
+        propensity_score : np.ndarray
+            Array of propensity scores.
+        estimated_policy : np.ndarray
+            Array of action distributions.
+
+        Returns
+        -------
+        importance_weight : np.ndarray
+            Array of importance weights.
+        """
+        n_samples = action.shape[0]
+        importance_weight = estimated_policy[np.arange(n_samples), action] / propensity_score
+        return importance_weight
+
+
+class SelfNormalizedInverseProbabilityWeighting(InverseProbabilityWeighting):
+    """
+    Self-Normalized Inverse Propensity Score (SNIPS) estimator.
+
+    References
+    ----------
+    The Self-normalized Estimator for Counterfactual Learning (Swaminathan and Joachims, 2015)
+    https://papers.nips.cc/paper_files/paper/2015/file/39027dfad5138c9ca0c474d71db915c3-Paper.pdf
+
+    Parameters
+    ----------
+    alpha : Float01, default=0.05
+        Significance level for confidence interval estimation.
+    n_bootstrap_samples : int, default=10000
+        Number of bootstrap samples for confidence interval estimation.
+    random_state : int, default=None
+        Random seed for bootstrap sampling.
+    """
+
+    name = "snips"
+
+    def estimate_sample_rewards(
+        self,
+        action: np.ndarray,
+        reward: np.ndarray,
+        propensity_score: np.ndarray,
+        estimated_policy: np.ndarray,
+        shrinkage_method: Optional[Callable] = None,
+        **kwargs,
+    ) -> np.ndarray:
+        """
+        Estimate the sample rewards.
+
+        Parameters
+        ----------
+        action : np.ndarray
+            Array of actions taken.
+        reward : np.ndarray
+            Array of rewards corresponding to each action.
+        propensity_score : np.ndarray
+            Array of propensity scores.
+        estimated_policy : np.ndarray
+            Array of action distributions.
+        shrinkage_method : Optional[Callable]
+            Shrinkage method for the importance weights.
+
+        Returns
+        -------
+        sample_reward : np.ndarray
+            Estimated sample rewards.
+        """
+
+        def self_normalized_shrink_weights(importance_weight: np.ndarray) -> np.ndarray:
+            importance_weight = (
+                shrinkage_method(importance_weight) if shrinkage_method is not None else importance_weight
+            )
+            return importance_weight / importance_weight.mean()
+
+        sample_reward = super().estimate_sample_rewards(
+            action=action,
+            reward=reward,
+            propensity_score=propensity_score,
+            estimated_policy=estimated_policy,
+            shrinkage_method=self_normalized_shrink_weights,
+        )
+        return sample_reward
+
+
+class DirectMethod(BaseOfflinePolicyEstimator):
+    """
+    Direct Method (DM) estimator.
+
+    This estimator uses the evaluation policy to Estimate the sample rewards.
+
+    References
+    ----------
+    The Offset Tree for Learning with Partial Labels (Beygelzimer and Langford, 2009)
+    https://arxiv.org/pdf/0812.4044
+
+
+    Parameters
+    ----------
+    alpha : Float01, default=0.05
+        Significance level for confidence interval estimation.
+    n_bootstrap_samples : int, default=10000
+        Number of bootstrap samples for confidence interval estimation.
+    random_state : int, default=None
+        Random seed for bootstrap sampling.
+    """
+
+    name = "dm"
+
+    def estimate_sample_rewards(
+        self,
+        estimated_policy: np.ndarray,
+        expected_reward: np.ndarray,
+        **kwargs,
+    ) -> np.ndarray:
+        """
+        Estimate the sample rewards.
+
+        Parameters
+        ----------
+        estimated_policy : np.ndarray
+            Array of action distributions.
+        expected_reward : np.ndarray
+            Array of expected rewards.
+
+        Returns
+        -------
+        sample_reward : np.ndarray
+            Estimated sample rewards.
+        """
+        n_samples = expected_reward.shape[0]
+        base_expected_reward = expected_reward[np.arange(n_samples), :]
+        evaluation_policy = estimated_policy[np.arange(n_samples), :]
+        expected_reward = np.average(
+            base_expected_reward,
+            weights=evaluation_policy,
+            axis=1,
+        )
+        return expected_reward
+
+
+class GeneralizedDoublyRobust(BaseOfflinePolicyEstimator, ABC):
+    """
+    Abstract generalization of the Doubly Robust (DR) estimator.
+
+    References
+    ----------
+    Doubly Robust Policy Evaluation and Optimization (Dudík, Erhan, Langford, and Li, 2014)
+    https://arxiv.org/pdf/1503.02834
+
+    More Robust Doubly Robust Off-policy Evaluation (Farajtabar, Chow, and Ghavamzadeh, 2018)
+    https://arxiv.org/pdf/1802.03493
+
+
+    Parameters
+    ----------
+    alpha : Float01, default=0.05
+        Significance level for confidence interval estimation.
+    n_bootstrap_samples : int, default=10000
+        Number of bootstrap samples for confidence interval estimation.
+    random_state : int, default=None
+        Random seed for bootstrap sampling.
+    """
+
+    _alternative_method_cls: Type[InverseProbabilityWeighting]
+    _dm: DirectMethod = PrivateAttr()
+    _other_method: BaseOfflinePolicyEstimator = PrivateAttr()
+
+    def model_post_init(self, __context: Any) -> None:
+        self._dm = DirectMethod(
+            alpha=self.alpha, n_bootstrap_samples=self.n_bootstrap_samples, random_state=self.random_state
+        )
+        self._other_method = self._alternative_method_cls(
+            alpha=self.alpha, n_bootstrap_samples=self.n_bootstrap_samples, random_state=self.random_state
+        )
+
+    def estimate_sample_rewards(
+        self,
+        action: np.ndarray,
+        reward: np.ndarray,
+        propensity_score: np.ndarray,
+        estimated_policy: np.ndarray,
+        expected_reward: np.ndarray,
+        **kwargs,
+    ) -> np.ndarray:
+        """
+        Estimate the sample rewards.
+
+        Parameters
+        ----------
+        action : np.ndarray
+            Array of actions taken.
+        reward : np.ndarray
+            Array of rewards corresponding to each action.
+        propensity_score : np.ndarray
+            Array of propensity scores.
+        estimated_policy : np.ndarray
+            Array of action distributions.
+        expected_reward : np.ndarray
+            Array of expected rewards.
+
+        Returns
+        -------
+        sample_reward : np.ndarray
+            Estimated rewards.
+        """
+        dm_sample_reward = self._dm.estimate_sample_rewards(
+            action=action, estimated_policy=estimated_policy, expected_reward=expected_reward
+        )
+        other_sample_reward = self._other_method.estimate_sample_rewards(
+            action=action,
+            reward=reward - dm_sample_reward,
+            propensity_score=propensity_score,
+            estimated_policy=estimated_policy,
+            shrinkage_method=self._shrink_weights,
+        )
+        sample_reward = dm_sample_reward + other_sample_reward
+        return sample_reward
+
+    def _shrink_weights(self, importance_weight: np.ndarray) -> np.ndarray:
+        return importance_weight
+
+
+class DoublyRobust(GeneralizedDoublyRobust):
+    """
+     Doubly Robust (DR) estimator.
+
+     References
+     ----------
+     Doubly Robust Policy Evaluation and Optimization (Dudík, Erhan, Langford, and Li, 2014)
+     https://arxiv.org/pdf/1503.02834
+
+    More Robust Doubly Robust Off-policy Evaluation (Farajtabar, Chow, and Ghavamzadeh, 2018)
+    https://arxiv.org/pdf/1802.03493
+
+
+     Parameters
+     ----------
+     alpha : Float01, default=0.05
+         Significance level for confidence interval estimation.
+     n_bootstrap_samples : int, default=10000
+         Number of bootstrap samples for confidence interval estimation.
+     random_state : int, default=None
+         Random seed for bootstrap sampling.
+    """
+
+    name = "dr"
+    _alternative_method_cls = InverseProbabilityWeighting
+
+
+class SelfNormalizedDoublyRobust(GeneralizedDoublyRobust):
+    """
+    Self-Normalized Doubly Robust (SNDR) estimator.
+
+    This estimator uses the self-normalized importance weights to combine the DR and IPS estimators.
+
+    References
+    ----------
+    Intrinsically Efficient, Stable, and Bounded Off-Policy Evaluation for Reinforcement Learning (Kallus and Uehara, 2019)
+    https://arxiv.org/pdf/1906.03735
+
+    Parameters
+    ----------
+    alpha : Float01, default=0.05
+        Significance level for confidence interval estimation.
+    n_bootstrap_samples : int, default=10000
+        Number of bootstrap samples for confidence interval estimation.
+    random_state : int, default=None
+        Random seed for bootstrap sampling.
+    """
+
+    name = "sndr"
+    _alternative_method_cls = SelfNormalizedInverseProbabilityWeighting
+
+
+class SwitchDoublyRobust(DoublyRobust):
+    """
+    Switch Doubly Robust (Switch-DR) estimator.
+
+    This estimator uses a switching rule based on the propensity score to combine the DR and IPS estimators.
+
+    References
+    ----------
+    Optimal and Adaptive Off-policy Evaluation in Contextual Bandits (Wang, Agarwal, and Dudik, 2017)
+    https://arxiv.org/pdf/1507.02646
+
+    Parameters
+    ----------
+    alpha : Float01, default=0.05
+        Significance level for confidence interval estimation.
+    n_bootstrap_samples : int, default=10000
+        Number of bootstrap samples for confidence interval estimation.
+    random_state : Optional[int], default=None
+        Random seed for bootstrap sampling.
+    switch_threshold : float, default=inf
+        Threshold for the importance weight to switch between the DR and IPS estimators.
+    """
+
+    name = "switch-dr"
+    switch_threshold: float = float("inf")
+
+    def _shrink_weights(self, importance_weight: np.ndarray) -> np.ndarray:
+        switch_indicator = importance_weight >= self.switch_threshold
+        return switch_indicator * importance_weight
+
+
+class DoublyRobustWithOptimisticShrinkage(DoublyRobust):
+    """
+    Optimistic version of DRos estimator.
+
+    This estimator uses a shrinkage factor to shrink the importance weight in the native DR.
+
+    References
+    ----------
+    Doubly Robust Off-Policy Evaluation with Shrinkage (Su, Dimakopoulou, Krishnamurthy, and Dudik, 2020)
+    https://arxiv.org/pdf/1907.09623
+
+    Parameters
+    ----------
+    alpha : Float01, default=0.05
+        Significance level for confidence interval estimation.
+    n_bootstrap_samples : int, default=10000
+        Number of bootstrap samples for confidence interval estimation.
+    random_state : int, default=None
+        Random seed for bootstrap sampling.
+    shrinkage_factor : float, default=0.0
+        Shrinkage factor for the importance weights.
+        If set to 0 or infinity, the estimator is equivalent to the native DM or DR estimators, respectively.
+    """
+
+    shrinkage_factor: NonNegativeFloat = 0.0
+    name = "dros-opt"
+
+    def _shrink_weights(self, importance_weight: np.ndarray) -> np.ndarray:
+        if self.shrinkage_factor == 0:
+            return np.zeros_like(importance_weight)
+        elif self.shrinkage_factor == float("inf"):
+            return importance_weight
+        return self.shrinkage_factor * importance_weight / (importance_weight**2 + self.shrinkage_factor)
+
+
+class DoublyRobustWithPessimisticShrinkage(DoublyRobust):
+    """
+    Pessimistic version of DRos estimator.
+
+    This estimator uses a shrinkage factor to shrink the importance weight in the native DR.
+
+    References
+    ----------
+    Doubly Robust Off-Policy Evaluation with Shrinkage (Su, Dimakopoulou, Krishnamurthy, and Dudik, 2020)
+    https://arxiv.org/pdf/1907.09623
+
+    Parameters
+    ----------
+    alpha : Float01, default=0.05
+        Significance level for confidence interval estimation.
+    n_bootstrap_samples : int, default=10000
+        Number of bootstrap samples for confidence interval estimation.
+    random_state : int, default=None
+        Random seed for bootstrap sampling.
+    shrinkage_factor : float, default=0.0
+        Shrinkage factor for the importance weights.
+    """
+
+    name = "dros-pess"
+    shrinkage_factor: PositiveFloat = float("inf")
+
+    def _shrink_weights(self, importance_weight: np.ndarray) -> np.ndarray:
+        importance_weight = np.minimum(self.shrinkage_factor, importance_weight)
+        return importance_weight
+
+
+class SubGaussianInverseProbabilityWeighting(InverseProbabilityWeighting):
+    """
+    SubGaussian Inverse Probability Weighing estimator.
+
+    References
+    ----------
+    Subgaussian and Differentiable Importance Sampling for Off-Policy Evaluation and Learning (Metelli, Russo, and Restelli, 2021)
+    https://proceedings.neurips.cc/paper_files/paper/2021/file/4476b929e30dd0c4e8bdbcc82c6ba23a-Paper.pdf
+
+    Parameters
+    ----------
+    alpha : Float01, defaults to 0.05
+        Significance level for confidence interval estimation.
+    n_bootstrap_samples : int, defaults to 10000
+        Number of bootstrap samples for confidence interval estimation.
+    random_state : int, defaults to None
+        Random seed for bootstrap sampling.
+    shrinkage_factor : Float01, defaults to 0.0
+        Shrinkage factor for the importance weights.
+
+    """
+
+    name = "sg-ipw"
+    shrinkage_factor: Float01 = 0.0
+
+    def _shrink_weights(self, importance_weight: np.ndarray) -> np.ndarray:
+        return importance_weight / (1 - self.shrinkage_factor + self.shrinkage_factor * importance_weight)
+
+
+class SubGaussianDoublyRobust(GeneralizedDoublyRobust):
+    """
+    SubGaussian Doubly Robust estimator.
+
+    References
+    ----------
+    Subgaussian and Differentiable Importance Sampling for Off-Policy Evaluation and Learning (Metelli, Russo, and Restelli, 2021)
+    https://proceedings.neurips.cc/paper_files/paper/2021/file/4476b929e30dd0c4e8bdbcc82c6ba23a-Paper.pdf
+
+    Parameters
+    ----------
+    alpha : Float01, defaults to 0.05
+        Significance level for confidence interval estimation.
+    n_bootstrap_samples : int, defaults to 10000
+        Number of bootstrap samples for confidence interval estimation.
+    random_state : int, defaults to None
+        Random seed for bootstrap sampling.
+    """
+
+    name = "sg-dr"
+    _alternative_method_cls = SubGaussianInverseProbabilityWeighting
+
+
+class BalancedInverseProbabilityWeighting(GeneralizedInverseProbabilityWeighting):
+    """
+    Balanced Inverse Probability Weighing estimator.
+
+    References
+    ----------
+    Balanced Off-Policy Evaluation in General Action Spaces (Sondhi, Arbour, and Dimmery, 2020)
+    https://arxiv.org/pdf/1906.03694
+
+
+    Parameters
+    ----------
+    alpha : Float01, defaults to 0.05
+        Significance level for confidence interval estimation.
+    n_bootstrap_samples : int, defaults to 10000
+        Number of bootstrap samples for confidence interval estimation.
+    random_state : int, defaults to None
+        Random seed for bootstrap sampling.
+
+    ----------
+    Arjun Sondhi, David Arbour, and Drew Dimmery
+    "Balanced Off-Policy Evaluation in General Action Spaces.", 2020.
+    """
+
+    name = "b-ipw"
+
+    def _get_importance_weights(self, expected_importance_weight: np.ndarray, **kwargs) -> np.ndarray:
+        """
+        Get the importance weights.
+
+        Parameters
+        ----------
+        expected_importance_weight : np.ndarray
+            Array of expected importance weights.
+
+        Returns
+        -------
+        expected_importance_weight : np.ndarray
+            Array of expected importance weights.
+        """
+        return expected_importance_weight
+
+    def estimate_sample_rewards(
+        self,
+        reward: np.ndarray,
+        expected_importance_weight: np.ndarray,
+        **kwargs,
+    ) -> np.ndarray:
+        """
+        Estimate the sample rewards.
+
+        Parameters
+        ----------
+        reward : np.ndarray
+            Array of rewards corresponding to each action.
+        expected_importance_weight : np.ndarray
+            Array of expected importance weights.
+
+        Returns
+        -------
+        sample_reward : np.ndarray
+            Estimated rewards.
+        """
+        return super().estimate_sample_rewards(
+            reward=reward, expected_importance_weight=expected_importance_weight, shrinkage_method=None
+        )

--- a/pybandits/offline_policy_evaluator.py
+++ b/pybandits/offline_policy_evaluator.py
@@ -1,0 +1,1115 @@
+import os
+from copy import deepcopy
+from functools import partial
+from itertools import product
+from math import floor
+from multiprocessing import Pool, cpu_count
+from sys import version_info
+from typing import Any, Dict, List, Literal, Optional, Union
+
+import numpy as np
+import optuna
+import pandas as pd
+from bokeh.models import ColumnDataSource, TabPanel
+from bokeh.plotting import figure
+from loguru import logger
+from optuna import Trial
+from sklearn.base import ClassifierMixin, TransformerMixin
+from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import cross_val_score
+from sklearn.neural_network import MLPClassifier
+from sklearn.preprocessing import LabelEncoder, OneHotEncoder
+from tqdm import tqdm
+
+from pybandits.pydantic_version_compatibility import (
+    NonNegativeInt,
+    PositiveInt,
+    PrivateAttr,
+    field_validator,
+    model_validator,
+    validate_call,
+)
+
+if version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+from pybandits import offline_policy_estimator
+from pybandits.base import ActionId, Float01, PyBanditsBaseModel
+from pybandits.mab import BaseMab
+from pybandits.offline_policy_estimator import BaseOfflinePolicyEstimator
+from pybandits.utils import (
+    extract_argument_names_from_function,
+    get_non_abstract_classes,
+    in_jupyter_notebook,
+    visualize_via_bokeh,
+)
+
+optuna.logging.enable_propagation()  # Propagate logs to the root logger.
+optuna.logging.disable_default_handler()  # Stop showing logs in sys.stderr.
+
+
+class _FunctionEstimator(PyBanditsBaseModel, ClassifierMixin, arbitrary_types_allowed=True):
+    """
+    This class provides functionality for model optimization using hyperparameter tuning via Optuna,
+    and prediction with optimized or default machine learning models.
+    It is used to estimate the propensity score and expected reward.
+
+
+    Parameters
+    ----------
+    estimator_type : Optional[Literal["logreg", "gbm", "rf", "mlp"]]
+        The model type to optimize.
+
+    fast_fit : bool
+        Whether to use the default parameter set for the model.
+
+    action_one_hot_encoder : OneHotEncoder
+        Fitted one hot encoder for action encoding.
+
+    n_trials : int
+        Number of trials for the Optuna optimization process.
+
+    verbose : bool
+        Whether to log detailed information during the optimization process.
+
+    study_name : Optional[str]
+        Name of the study to be created by Optuna.
+
+    multi_action_prediction : bool
+        Whether to predict for all actions or only for real action.
+
+    """
+
+    estimator_type: Literal["logreg", "gbm", "rf", "mlp"]
+    fast_fit: bool
+    action_one_hot_encoder: OneHotEncoder = OneHotEncoder(sparse_output=False)
+    n_trials: int
+    verbose: bool
+    study_name: Optional[str] = None
+    multi_action_prediction: bool
+    _model: Union[LogisticRegression, GradientBoostingClassifier, RandomForestClassifier, MLPClassifier] = PrivateAttr()
+    _model_mapping = {
+        "mlp": MLPClassifier,
+        "rf": RandomForestClassifier,
+        "logreg": LogisticRegression,
+        "gbm": GradientBoostingClassifier,
+    }
+
+    def _pre_process(self, batch: Dict[str, Any]) -> np.ndarray:
+        """
+        Preprocess the feature vectors to be used for regression model training.
+        This method concatenates the context vector and action context vectors.
+
+        Parameters
+        ----------
+        batch : Dict[str, Any]
+            The batch of data containing context, action, and action context.
+
+        Returns
+        -------
+        np.ndarray
+            A concatenated array of context and action context, shape (n_rounds, n_features_context + dim_action_context).
+        """
+        context = batch["context"]
+        action = batch["action_ids"]
+        return np.concatenate([context, self.action_one_hot_encoder.transform(action.reshape((-1, 1)))], axis=1)
+
+    def _sample_parameter_space(self, trial: Trial) -> Dict[str, Union[str, int, float]]:
+        """
+        Define the hyperparameter search space for a given model type in Optuna.
+
+        The search space is dynamically selected based on the model type being optimized.
+
+        Parameters
+        ----------
+        trial : optuna.Trial
+            A single trial in the Optuna optimization process.
+
+        Returns
+        -------
+        dict
+            A dictionary representing the search space for the model's hyperparameters.
+        """
+
+        if self.estimator_type == "mlp":
+            return {
+                "hidden_layer_sizes": 2 ** trial.suggest_int("hidden_layer_sizes", 2, 6),
+                "activation": trial.suggest_categorical("activation", ["relu", "logistic", "tanh"]),
+                "solver": trial.suggest_categorical("solver", ["lbfgs", "sgd", "adam"]),
+                "alpha": np.sqrt(10) ** -trial.suggest_int("learning_rate_init", 0, 10),
+                "max_iter": 1000,
+                "learning_rate_init": np.sqrt(10) ** -trial.suggest_int("learning_rate_init", 0, 6),
+            }
+        elif self.estimator_type == "rf":
+            return {
+                "max_depth": trial.suggest_int("max_depth", 2, 5),
+                "criterion": trial.suggest_categorical("criterion", ["gini", "entropy"]),
+                "max_features": trial.suggest_int("max_features", 1, 3),
+                "n_estimators": trial.suggest_int("n_estimators", 10, 50),
+                "n_jobs": -1,
+            }
+        elif self.estimator_type == "logreg":
+            return {
+                "tol": trial.suggest_float("tol", 0.00001, 0.0001),
+                "C": trial.suggest_float("C", 0.05, 3),
+                "solver": trial.suggest_categorical("solver", ["newton-cg", "lbfgs", "liblinear", "sag", "saga"]),
+                "max_iter": 1000,
+                "n_jobs": -1,
+            }
+        elif self.estimator_type == "gbm":
+            return {
+                "n_estimators": trial.suggest_int("n_estimators", 10, 100),
+                "learning_rate": np.sqrt(10) ** -trial.suggest_int("learning_rate_init", 0, 6),
+                "max_depth": trial.suggest_int("max_depth", 2, 10),
+            }
+
+    def _objective(self, trial: Trial, feature_set: np.ndarray, label: np.ndarray) -> float:
+        """
+        Objective function for Optuna optimization.
+
+        This function trains a model using cross-validation and returns the negative accuracy
+        to be minimized.
+
+        Parameters
+        ----------
+        trial : Trial
+            A single trial in the Optuna optimization process.
+
+        feature_set : np.ndarray
+            The training dataset, containing context and encoded actions.
+
+        label : np.ndarray
+            The labels for the dataset.
+
+        Returns
+        -------
+        score : float
+            The score to be maximized by Optuna.
+        """
+        params = self._sample_parameter_space(trial)
+        model = self._model_mapping[self.estimator_type](**params)
+        score = cross_val_score(model, feature_set, label).mean()
+        trial.set_user_attr("model_params", params)
+
+        return score
+
+    def _optimize(self, feature_set: np.ndarray, label: np.ndarray, study: optuna.Study) -> dict:
+        """
+        Optimize the model's hyperparameters using Optuna.
+
+        Parameters
+        ----------
+        feature_set : np.ndarray
+            The training dataset, containing 'context' and 'action_ids' keys.
+
+        study : optuna.Study
+            The Optuna study object to store optimization results.
+
+        Returns
+        -------
+        best_params : dict
+            The best set of hyperparameters found by Optuna.
+        """
+
+        study.optimize(lambda trial: self._objective(trial, feature_set, label), n_trials=self.n_trials)
+
+        best_params = study.best_trial.user_attrs["model_params"]
+        if self.verbose:
+            logger.info(f"Optuna best model with optimized parameters for {self.estimator_type}:\n {best_params}")
+
+        return best_params
+
+    @validate_call(config=dict(arbitrary_types_allowed=True))
+    def fit(self, X: dict, y: np.ndarray) -> Self:
+        """
+        Fit the model using the given dataset X and labels y.
+
+        Parameters
+        ----------
+        X : dict
+            The dataset containing 'context' and 'action_ids' keys.
+        y : np.ndarray
+            The labels for the dataset.
+
+        Returns
+        -------
+        self : _FunctionEstimator
+            The fitted model.
+        """
+        feature_set = self._pre_process(X)
+        if self.fast_fit:
+            model_parameters = {}
+        else:
+            pruner = optuna.pruners.MedianPruner()
+            sampler = optuna.samplers.TPESampler(multivariate=True, group=True)
+            study = optuna.create_study(
+                direction="maximize", study_name=self.study_name, pruner=pruner, sampler=sampler
+            )
+            model_parameters = self._optimize(feature_set, y, study)
+
+        model = self._model_mapping[self.estimator_type](**model_parameters)
+        model.fit(feature_set, y)
+        self._model = model
+        return self
+
+    @validate_call
+    def predict(self, X: dict) -> np.ndarray:
+        """
+        Predict the labels for the given dataset X.
+
+        Parameters
+        ----------
+        X : dict
+            The dataset containing 'context' and 'action_ids' keys.
+
+        Returns
+        -------
+        prediction : np.ndarray
+            The predicted labels for the dataset.
+        """
+        if not self._model:
+            raise AttributeError("Model has not been fitted yet.")
+
+        if self.multi_action_prediction:
+            specific_action_X = X.copy()
+            prediction = np.empty((X["n_rounds"], len(X["unique_actions"])))
+            for action_index, action in enumerate(X["unique_actions"]):
+                specific_action_X["action_ids"] = np.array([action] * X["n_rounds"])
+                specific_action_feature_set = self._pre_process(specific_action_X)
+                specific_action_prediction = self._model.predict_proba(specific_action_feature_set)[:, 1]
+                prediction[:, action_index] = specific_action_prediction
+        else:
+            feature_set = self._pre_process(X)
+            prediction = self._model.predict_proba(feature_set)[:, 1]
+        return prediction
+
+
+class OfflinePolicyEvaluator(PyBanditsBaseModel, arbitrary_types_allowed=True):
+    """
+    Class to conduct OPE with multiple OPE estimators
+
+    References
+    ----------
+    Open Bandit Dataset and Pipeline: Towards Realistic and Reproducible Off-Policy Evaluation
+    https://arxiv.org/abs/2008.07146
+
+    Parameters
+    ----------
+    logged_data : pd.DataFrame
+        Logging data set
+    split_prop: Float01
+        Proportion of dataset used as training set
+    propensity_score_model_type: Literal["logreg", "gbm", "rf", "mlp", "batch_empirical", "empirical", "propensity_score"]
+        Method used to compute/estimate propensity score pi_b (propensity_score, logging / behavioral policy).
+    expected_reward_model_type: Literal["logreg", "gbm", "rf", "mlp"]
+        Method used to estimate expected reward for each action a in the training set.
+    n_trials : Optional[int]
+        Number of trials for the Optuna optimization process.
+    fast_fit : bool
+        Whether to use the default parameter set for the function estimator models.
+    ope_estimators: Optional[List[BaseOfflinePolicyEstimator]]
+        List of OPE estimators used to evaluate the policy value of evaluation policy.
+        All available estimators are if not specified.
+    shuffle : bool
+        Whether to shuffle batches before splitting. Defaults to no shuffling.
+    batch_feature : str
+        Column name for batch as available in logged_data
+    action_feature : str
+        Column name for action as available in logged_data
+    reward_feature : Union[str, List[str]]
+        Column name for reward as available in logged_data
+    contextual_features : Optional[List[str]]
+        Column names for contextual features as available in logged_data
+    cost_feature : Optional[str]
+        Column name for cost as available in logged_data; used for bandit with cost control
+    group_feature : Optional[str]
+        Column name for group definition feature as available in logged_data; available from simulated data
+        to define samples with similar contextual profile
+    true_reward_feature : Optional[Union[str, List[str]]]
+        Column names for reward proba distribution features as available in simulated logged_data. Used to compute ground truth
+    propensity_score_feature  : Optional[str]
+        Column name for propensity score as available in logged_data; used for evaluation of the policy value
+    verbose : bool
+        Whether to log detailed information during the optimization process.
+    """
+
+    logged_data: pd.DataFrame
+    split_prop: Float01
+    propensity_score_model_type: Literal[
+        "logreg", "gbm", "rf", "mlp", "batch_empirical", "empirical", "propensity_score"
+    ]
+    expected_reward_model_type: Literal["logreg", "gbm", "rf", "mlp"]
+    importance_weights_model_type: Literal["logreg", "gbm", "rf", "mlp"]
+    scaler: Optional[Union[TransformerMixin, Dict[str, TransformerMixin]]] = None
+    n_trials: Optional[int] = 100
+    fast_fit: bool = False
+    ope_estimators: Optional[List[BaseOfflinePolicyEstimator]]
+    shuffle: bool = False
+    batch_feature: str
+    action_feature: str
+    reward_feature: Union[str, List[str]]
+    contextual_features: Optional[List[str]] = None
+    cost_feature: Optional[str] = None
+    group_feature: Optional[str] = None
+    true_reward_feature: Optional[Union[str, List[str]]] = None
+    propensity_score_feature: Optional[str] = None
+    verbose: bool = False
+    _train_data: Optional[Dict[str, Any]] = PrivateAttr()
+    _test_data: Optional[Dict[str, Any]] = PrivateAttr()
+    _estimated_expected_reward: Optional[Dict[str, np.ndarray]] = PrivateAttr(default=None)
+    _action_one_hot_encoder = OneHotEncoder(sparse_output=False)
+    _propensity_score_epsilon = 1e-08
+
+    @field_validator("split_prop", mode="before")
+    @classmethod
+    def check_split_prop(cls, value):
+        if value == 0 or value == 1:
+            raise ValueError("split_prop should be strictly between 0 and 1")
+        return value
+
+    @field_validator("ope_estimators", mode="before")
+    @classmethod
+    def populate_ope_metrics(cls, value):
+        return (
+            value if value is not None else [class_() for class_ in get_non_abstract_classes(offline_policy_estimator)]
+        )
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_batch_feature(cls, values):
+        if values["batch_feature"] not in values["logged_data"]:
+            raise AttributeError("Batch feature missing from logged data.")
+        if not (
+            pd.api.types.is_datetime64_ns_dtype(values["logged_data"][values["batch_feature"]])
+            or pd.api.types.is_integer_dtype(values["logged_data"][values["batch_feature"]])
+        ):
+            raise TypeError(f"Column {values['batch_feature']} should be either date or int type")
+        return values
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_action_feature(cls, values):
+        if values["action_feature"] not in values["logged_data"]:
+            raise AttributeError("Action feature missing from logged data.")
+        return values
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_propensity_score_estimation_method(cls, values):
+        if values["propensity_score_model_type"] == "propensity_score":
+            if cls._get_value_with_default("propensity_score_feature", values) is None:
+                raise ValueError(
+                    "Propensity score feature should be defined when using it as propensity_score_model_type"
+                )
+        return values
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_reward_features(cls, values):
+        reward_feature = values["reward_feature"]
+        reward_feature = reward_feature if isinstance(reward_feature, list) else [reward_feature]
+        if not all([reward in values["logged_data"] for reward in reward_feature]):
+            raise AttributeError("Reward feature missing from logged data.")
+        values["reward_feature"] = reward_feature
+        if "true_reward_feature" in values:
+            true_reward_feature = values["true_reward_feature"]
+            true_reward_feature = (
+                true_reward_feature
+                if isinstance(true_reward_feature, list)
+                else [true_reward_feature]
+                if true_reward_feature is not None
+                else None
+            )
+            if not all([true_reward in values["logged_data"] for true_reward in true_reward_feature]):
+                raise AttributeError("True reward feature missing from logged data.")
+            if len(reward_feature) != len(true_reward_feature):
+                raise ValueError("Reward and true reward features should have the same length")
+            values["true_reward_feature"] = true_reward_feature
+
+        return values
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_optional_scalar_features(cls, values):
+        for feature in [
+            "cost_feature",
+            "group_feature",
+            "propensity_score_feature",
+        ]:
+            value = cls._get_value_with_default(feature, values)
+            if value is not None and value not in values["logged_data"]:
+                raise AttributeError(f"{feature} missing from logged data.")
+        return values
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_contextual_features(cls, values):
+        value = cls._get_value_with_default("contextual_features", values)
+        if value is not None and not set(value).issubset(values["logged_data"].columns):
+            raise AttributeError("contextual_features missing from logged data.")
+        return values
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_model_optimization(cls, values):
+        n_trials_value = cls._get_value_with_default("n_trials", values)
+        fast_fit_value = cls._get_value_with_default("fast_fit", values)
+
+        if (n_trials_value is None or fast_fit_value is None) and values["propensity_score_model_type"] not in [
+            "logreg",
+            "gbm",
+            "rf",
+            "mlp",
+        ]:
+            raise ValueError("The requested propensity score model requires n_trials and fast_fit to be well defined")
+        if (n_trials_value is None or fast_fit_value is None) and cls._check_argument_required_by_estimators(
+            "expected_reward", values["ope_estimators"]
+        ):
+            raise ValueError(
+                "The requested offline policy evaluation metrics model require estimation of the expected reward. "
+                "Thus, n_trials and fast_fit need to be well defined."
+            )
+        return values
+
+    @classmethod
+    def _check_argument_required_by_estimators(cls, argument: str, ope_estimators: List[BaseOfflinePolicyEstimator]):
+        """
+        Check if argument is required by OPE estimators.
+
+        Parameters
+        ----------
+        argument : str
+            Argument to check if required by OPE estimators.
+        ope_estimators : List[BaseOfflinePolicyEstimator]
+            List of OPE estimators.
+
+        Returns
+        -------
+        bool
+            True if argument is required by OPE estimators, False otherwise.
+        """
+        return any(
+            [
+                argument
+                in extract_argument_names_from_function(ope_estimator.estimate_sample_rewards)
+                + extract_argument_names_from_function(ope_estimator.estimate_policy_value_with_confidence_interval)
+                for ope_estimator in ope_estimators
+            ]
+        )
+
+    def model_post_init(self, __context: Any) -> None:
+        # Extract batches for train and test set
+        self._extract_batches()
+
+        # Estimate propensity score in the train and test set
+        self._estimate_propensity_score()
+
+        # Estimate expected reward estimator and predict in the test set, when required by OPE estimators
+        if self._check_argument_required_by_estimators("expected_reward", self.ope_estimators):
+            self._estimate_expected_reward()
+
+    def _extract_batches(self):
+        """
+        Create training and test sets in dictionary form.
+
+        """
+        logged_data = self.logged_data.sort_values(by=self.batch_feature)
+        unique_batch = logged_data[self.batch_feature].unique()
+        split_batch = unique_batch[int(floor(len(unique_batch) * self.split_prop))]
+
+        # add list of actions in dict in order to avoid test set with n_actions
+        # lower than nb of total actions
+        unique_actions = sorted(self.logged_data[self.action_feature].unique().tolist())
+        action_label_encoder = LabelEncoder()
+        if self.shuffle:
+            logged_data[self.batch_feature] = np.random.permutation(logged_data[self.batch_feature].values)
+        for batch_idx in tqdm(range(2)):
+            # extract samples batch
+            if batch_idx == 0:
+                extracted_batch = self.logged_data[self.logged_data[self.batch_feature] <= split_batch]
+            else:
+                extracted_batch = self.logged_data[self.logged_data[self.batch_feature] > split_batch]
+            extracted_batch = extracted_batch.reset_index(drop=True)
+
+            # dict data set information for OPE
+            action_ids = extracted_batch[self.action_feature].values
+            if batch_idx == 0:
+                self._action_one_hot_encoder.fit(np.array(unique_actions).reshape((-1, 1)))
+            reward = extracted_batch[self.reward_feature].values
+
+            # if cost control bandit
+            if self.cost_feature is not None:
+                cost = extracted_batch[self.cost_feature].values
+            else:
+                cost = None
+
+            # if contextual information required
+            if self.contextual_features is not None:
+                if self.scaler is not None:
+                    if type(self.scaler) is dict:
+                        if batch_idx == 0:
+                            x_scale = np.array(
+                                pd.concat(
+                                    [
+                                        self.scaler[feature].fit_transform(np.array(extracted_batch[[feature]]))
+                                        for feature in self.contextual_features
+                                    ],
+                                    axis=1,
+                                )
+                            )
+                        else:
+                            x_scale = np.array(
+                                pd.concat(
+                                    [
+                                        self.scaler[feature].transform(np.array(extracted_batch[[feature]]))
+                                        for feature in self.contextual_features
+                                    ],
+                                    axis=1,
+                                )
+                            )
+                    else:
+                        if batch_idx == 0:
+                            x_scale = self.scaler.fit_transform(np.array(extracted_batch[self.contextual_features]))
+                        else:
+                            x_scale = self.scaler.transform(np.array(extracted_batch[self.contextual_features]))
+                else:
+                    x_scale = np.array(extracted_batch[self.contextual_features])
+            else:
+                x_scale = np.zeros((len(action_ids), 0))  # zero-columns 2d array to allow concatenation later
+
+            # extract data for policy information
+            policy_information_cols = [
+                self.batch_feature,
+                self.action_feature,
+            ] + self.reward_feature
+            if self.group_feature:
+                policy_information_cols.append(self.group_feature)
+
+            policy_information = extracted_batch[policy_information_cols]
+
+            # reward probability distribution as used during simulation process if available
+            ground_truth = extracted_batch[self.true_reward_feature] if self.true_reward_feature else None
+
+            # propensity_score may be available from simulation: propensity_score is added to the dict
+            propensity_score = (
+                extracted_batch[self.propensity_score_feature].values if self.propensity_score_feature else None
+            )
+            if batch_idx == 0:
+                action_label_encoder.fit(unique_actions)
+            actions = action_label_encoder.transform(action_ids)
+
+            # Store information in a dictionary as required by obp package
+            data_batch = {
+                "n_rounds": len(action_ids),  # number of samples
+                "n_action": len(unique_actions),  # number of actions
+                "unique_actions": unique_actions,  # list of actions in the whole data set
+                "action_ids": action_ids,  # action identifiers
+                "action": actions,  # encoded action identifiers
+                "reward": reward,  # samples' reward
+                "propensity_score": propensity_score,  # propensity score, pi_b(a|x), vector
+                "context": x_scale,  # the matrix of features i.e. context
+                "data": policy_information,  # data array with informative features
+                "ground_truth": ground_truth,  # true reward probability for each action and samples, list of list
+                "cost": cost,  # samples' action cost for bandit with cost control
+            }
+            if batch_idx == 0:
+                self._train_data = data_batch
+            else:
+                self._test_data = data_batch
+
+    def _estimate_propensity_score_empirical(
+        self, batch: Dict[str, Any], groupby_cols: List[str], inner_groupby_cols: Optional[List[str]] = None
+    ) -> np.ndarray:
+        """
+        Empirical propensity score computation based on batches average
+
+        Parameters
+        ----------
+        batch: Dict[str, Any]
+            Dataset dictionary
+        groupby_cols : List[str]
+            Columns to group by
+        inner_groupby_cols : Optional[List[str]]
+            Columns to group by after the first groupby
+
+        Returns
+        -------
+        propensity_score : np.ndarray
+            computed propensity score for each of the objectives
+        """
+        inner_groupby_cols = [] if inner_groupby_cols is None else inner_groupby_cols
+        overall_groupby_cols = groupby_cols + inner_groupby_cols
+        # number of recommended actions per group and batch
+        grouped_data = batch["data"].groupby(overall_groupby_cols)[self.reward_feature[0]].count()
+
+        # proportion of recommended actions per group
+        if inner_groupby_cols:
+            empirical_distribution = pd.DataFrame(
+                grouped_data / grouped_data.groupby(inner_groupby_cols).sum()
+            ).reset_index()
+        else:
+            empirical_distribution = pd.DataFrame(grouped_data / grouped_data.sum()).reset_index()
+
+        empirical_distribution.columns = overall_groupby_cols + ["propensity_score"]
+
+        # deal with missing segment after group by
+        if len(overall_groupby_cols) > 1:
+            all_combinations = pd.DataFrame(
+                list(product(*[empirical_distribution[col].unique() for col in overall_groupby_cols])),
+                columns=overall_groupby_cols,
+            )
+
+            # Merge with the original dataframe, filling missing values in 'c' with 0
+            empirical_distribution = pd.merge(
+                all_combinations, empirical_distribution, on=groupby_cols + inner_groupby_cols, how="left"
+            ).fillna(0)
+
+        # extract propensity_score in the test set for user according to group and action recommended
+        matching_df = pd.DataFrame({k: batch["data"][k] for k in overall_groupby_cols})
+        merged_df = pd.merge(
+            matching_df,
+            empirical_distribution[overall_groupby_cols + ["propensity_score"]],
+            how="left",  # left join to ensure we get all rows from the batch
+            on=overall_groupby_cols,
+        )
+        propensity_score = merged_df["propensity_score"].values
+
+        return propensity_score
+
+    def _empirical_averaged_propensity_score(self, batch: Dict[str, Any]) -> np.ndarray:
+        """
+        Empirical propensity score computation based on batches average
+
+        Parameters
+        ----------
+        batch : Dict[str, Any]
+            dataset.
+
+        Returns
+        ------
+        : np.ndarray
+            estimated propensity_score
+        """
+
+        return self._estimate_propensity_score_empirical(
+            batch=batch, groupby_cols=[self.action_feature], inner_groupby_cols=[self.batch_feature]
+        )
+
+    def _empirical_propensity_score(self, batch: Dict[str, Any]) -> np.ndarray:
+        """
+        Propensity score empirical computation based on data set average
+
+        Parameters
+        ----------
+        batch : Dict[str, Any]
+            dataset.
+
+        Return
+        ------
+        np.ndarray
+            estimated propensity_score
+        """
+
+        return self._estimate_propensity_score_empirical(batch=batch, groupby_cols=[self.action_feature])
+
+    def _estimate_propensity_score(self):
+        """
+        Compute/approximate propensity score based on different methods in the train and test set.
+        Different approaches may be evaluated when logging policy is unknown.
+        """
+        if not self.contextual_features:
+            # if no contextual features, propensity score is directly defined by the action taken,
+            # thus uniformly set to 1
+            train_propensity_score = np.ones(self._train_data["n_rounds"])
+            test_propensity_score = np.ones(self._test_data["n_rounds"])
+            logger.warning(
+                f"No contextual features available, "
+                f"overriding the requested propensity_score_model_type={self.propensity_score_model_type} "
+                f"using uniform propensity score"
+            )
+        else:
+            if self.propensity_score_model_type == "batch_empirical":
+                if self.verbose:
+                    logger.info("Data batch-empirical estimation of propensity score.")
+
+                # Empirical approach: propensity score pi_b computed as action means per samples batch
+                train_propensity_score = self._empirical_propensity_score(self._train_data)
+                test_propensity_score = self._empirical_propensity_score(self._test_data)
+
+            elif self.propensity_score_model_type == "empirical":
+                if self.verbose:
+                    logger.info("Data empirical estimation of propensity score.")
+
+                # Empirical approach: propensity score pi_b computed as action means per samples batch
+                train_propensity_score = self._empirical_averaged_propensity_score(self._train_data)
+                test_propensity_score = self._empirical_averaged_propensity_score(self._test_data)
+
+            elif self.propensity_score_model_type == "propensity_score":
+                if self.verbose:
+                    logger.info("Data given value of propensity score.")
+
+                train_propensity_score = self._train_data["propensity_score"]
+                test_propensity_score = self._test_data["propensity_score"]
+
+            else:  # self.propensity_score_model_type in ["gbm", "rf", "logreg", "mlp"]
+                if self.verbose:
+                    logger.info(
+                        f"Data prediction of propensity score based on {self.propensity_score_model_type} model."
+                    )
+                propensity_score_estimator = _FunctionEstimator(
+                    estimator_type=self.propensity_score_model_type,
+                    fast_fit=self.fast_fit,
+                    action_one_hot_encoder=self._action_one_hot_encoder,
+                    n_trials=self.n_trials,
+                    verbose=self.verbose,
+                    study_name=f"{self.propensity_score_model_type}_propensity_score",
+                    multi_action_prediction=False,
+                )
+                propensity_score_estimator.fit(X=self._train_data, y=self._train_data["action"])
+                train_propensity_score = np.clip(
+                    propensity_score_estimator.predict(self._train_data), self._propensity_score_epsilon, 1
+                )
+                test_propensity_score = np.clip(
+                    propensity_score_estimator.predict(self._test_data), self._propensity_score_epsilon, 1
+                )
+        self._train_data["propensity_score"] = train_propensity_score
+        self._test_data["propensity_score"] = test_propensity_score
+
+    def _estimate_expected_reward(self):
+        """
+        Compute expected reward for each round and action.
+        """
+        if self.verbose:
+            logger.info(f"Data prediction of expected reward based on {self.expected_reward_model_type} model.")
+        estimated_expected_reward = {}
+        for reward_feature, reward in zip(self.reward_feature, self._train_data["reward"].T):
+            expected_reward_model = _FunctionEstimator(
+                estimator_type=self.expected_reward_model_type,
+                fast_fit=self.fast_fit,
+                action_one_hot_encoder=self._action_one_hot_encoder,
+                n_trials=self.n_trials,
+                verbose=self.verbose,
+                study_name=f"{self.expected_reward_model_type}_expected_reward",
+                multi_action_prediction=True,
+            )
+
+            expected_reward_model.fit(X=self._train_data, y=reward.T)
+
+            # predict in test set
+            estimated_expected_reward[reward_feature] = expected_reward_model.predict(self._test_data)
+        self._estimated_expected_reward = estimated_expected_reward
+
+    def _estimate_importance_weight(self, mab: BaseMab) -> np.ndarray:
+        """
+        Compute importance weights induced by the behavior and evaluation policies.
+
+        References
+        ----------
+        Balanced Off-Policy Evaluation in General Action Spaces (Sondhi, Arbour, and Dimmery, 2020)
+        https://arxiv.org/pdf/1906.03694
+
+        Parameters
+        ----------
+        mab : BaseMab
+            Multi-armed bandit to be evaluated
+
+        Return
+        ------
+        expected_importance_weights : np.ndarray
+            estimated importance weights
+        """
+        if self.verbose:
+            logger.info(f"Data prediction of importance weights based on {self.importance_weights_model_type} model.")
+
+        importance_weights_model = _FunctionEstimator(
+            estimator_type=self.importance_weights_model_type,
+            fast_fit=self.fast_fit,
+            action_one_hot_encoder=self._action_one_hot_encoder,
+            n_trials=self.n_trials,
+            verbose=self.verbose,
+            study_name=f"{self.importance_weights_model_type}_importance_weights",
+            multi_action_prediction=False,
+        )
+        train_data = deepcopy(self._train_data)
+        mab_data = self._train_data["context"] if self.contextual_features else self._train_data["n_rounds"]
+        selected_actions = _mab_predict(mab, mab_data)
+        train_data["action_ids"] = np.concatenate((train_data["action_ids"], selected_actions), axis=0)
+        train_data["context"] = np.concatenate((train_data["context"], train_data["context"]), axis=0)
+        y = np.concatenate((np.zeros(len(selected_actions)), np.ones(len(selected_actions))), axis=0)
+        importance_weights_model.fit(X=train_data, y=y)
+
+        # predict in test set
+        estimated_proba = importance_weights_model.predict(self._test_data)
+        expected_importance_weights = estimated_proba / (1 - estimated_proba)
+        return expected_importance_weights
+
+    def estimate_policy(
+        self,
+        mab: BaseMab,
+        n_mc_experiments: PositiveInt = 1000,
+        n_cores: Optional[NonNegativeInt] = None,
+    ) -> pd.DataFrame:
+        """
+        Estimate policy via Monte Carlo (MC) sampling based on sampling distribution of each action a in the test set.
+
+        References
+        ----------
+        Estimation Considerations in Contextual Bandit
+        https://arxiv.org/pdf/1711.07077.pdf
+        Debiased Off-Policy Evaluation for Recommendation Systems
+        https://arxiv.org/pdf/2002.08536.pdf
+        CAB: Continuous Adaptive Blending for Policy Evaluation and Learning
+        https://arxiv.org/pdf/1811.02672.pdf
+
+        Parameters
+        ----------
+        mab : BaseMab
+            Multi-armed bandit to be evaluated
+        n_mc_experiments: PositiveInt
+            Number of MC sampling rounds. Default: 1000
+        n_cores: Optional[NonNegativeInt], all available cores if not specified.
+            Number of cores used for multiprocessing
+
+        Returns
+        -------
+        estimated_policy: np.ndarray (nb samples, nb actions)
+            action probabilities for each action and samples
+        """
+        if self.verbose:
+            logger.info("Data prediction of expected policy based on Monte Carlo experiments.")
+        n_cores = n_cores or cpu_count()
+
+        # using MC, create a () best actions matrix
+        mc_actions = []
+        mab_data = self._test_data["context"] if self.contextual_features else self._test_data["n_rounds"]
+        predict_func = partial(_mab_predict, mab, mab_data)
+        # predict best action for a new prior parameters draw
+        # using argmax(p(r|a, x)) with a in the list of actions
+        if n_cores:
+            with Pool(processes=n_cores) as pool:
+                for mc_action in tqdm(pool.imap_unordered(predict_func, range(n_mc_experiments))):
+                    mc_actions.append(mc_action)
+        else:
+            for mc_action in tqdm(range(n_mc_experiments)):
+                mc_actions.append(predict_func(mc_action))
+
+        # finalize the dataframe shape to #samples X #mc experiments
+        mc_actions = pd.DataFrame(mc_actions).T
+
+        # for each sample / each action, count the occurrence frequency during MC iteration
+        mc_action_counts = pd.DataFrame(0, index=mc_actions.index, columns=self._test_data["unique_actions"])
+        for action in self._test_data["unique_actions"]:
+            mc_action_counts[action] = (mc_actions == action).sum(axis=1)
+        estimated_policy = mc_action_counts / n_mc_experiments
+
+        return estimated_policy
+
+    def evaluate(
+        self,
+        mab: BaseMab,
+        n_mc_experiments: int = 1000,
+        save_path: Optional[str] = None,
+        visualize: bool = True,
+    ) -> pd.DataFrame:
+        """
+        Execute the OPE process with multiple estimators simultaneously.
+
+        Parameters
+        ----------
+        mab : BaseMab
+            Multi-armed bandit model to be evaluated
+        n_mc_experiments : int
+            Number of Monte Carlo experiments for policy estimation
+        save_path : Optional[str], defaults to None.
+            Path to save the results. Nothing is saved if not specified.
+        visualize : bool, defaults to True.
+            Whether to visualize the results of the OPE process
+
+        Returns
+        -------
+        estimated_policy_value_df : pd.DataFrame
+            Estimated policy values and confidence intervals
+        """
+        if visualize and not save_path and not in_jupyter_notebook():
+            raise ValueError("save_path is required for visualization when not running in a Jupyter notebook")
+
+        # Define OPE keyword arguments
+        kwargs = {}
+        if self._check_argument_required_by_estimators("action", self.ope_estimators):
+            kwargs["action"] = self._test_data["action"]
+        if self._check_argument_required_by_estimators("estimated_policy", self.ope_estimators):
+            kwargs["estimated_policy"] = self.estimate_policy(mab=mab, n_mc_experiments=n_mc_experiments).values
+        if self._check_argument_required_by_estimators("propensity_score", self.ope_estimators):
+            kwargs["propensity_score"] = self._test_data["propensity_score"]
+        if self._check_argument_required_by_estimators("expected_importance_weight", self.ope_estimators):
+            kwargs["expected_importance_weight"] = self._estimate_importance_weight(mab)
+
+        # Instantiate class to conduct OPE by multiple estimators simultaneously
+        multi_objective_estimated_policy_value_df = pd.DataFrame()
+        results = {"value": [], "lower": [], "upper": [], "std": [], "estimator": [], "objective": []}
+        for reward_feature in self.reward_feature:
+            if self.verbose:
+                logger.info(f"Offline Policy Evaluation for {reward_feature}.")
+
+            if self._check_argument_required_by_estimators("reward", self.ope_estimators):
+                kwargs["reward"] = self._test_data["reward"][:, self.reward_feature.index(reward_feature)]
+            if self._check_argument_required_by_estimators("expected_reward", self.ope_estimators):
+                kwargs["expected_reward"] = self._estimated_expected_reward[reward_feature]
+
+            # Summarize policy values and their confidence intervals estimated by OPE estimators
+            for ope_estimator in self.ope_estimators:
+                estimated_policy_value, low, high, std = ope_estimator.estimate_policy_value_with_confidence_interval(
+                    **kwargs,
+                )
+                results["value"].append(estimated_policy_value)
+                results["lower"].append(low)
+                results["upper"].append(high)
+                results["std"].append(std)
+                results["estimator"].append(ope_estimator.name)
+                results["objective"].append(reward_feature)
+
+            multi_objective_estimated_policy_value_df = pd.concat(
+                [multi_objective_estimated_policy_value_df, pd.DataFrame.from_dict(results)],
+                axis=0,
+            )
+        if save_path:
+            multi_objective_estimated_policy_value_df.to_csv(os.path.join(save_path, "estimated_policy_value.csv"))
+
+        if visualize:
+            self._visualize_results(save_path, multi_objective_estimated_policy_value_df)
+
+        return multi_objective_estimated_policy_value_df
+
+    def update_and_evaluate(
+        self,
+        mab: BaseMab,
+        n_mc_experiments: int = 1000,
+        save_path: Optional[str] = None,
+        visualize: bool = True,
+        with_test: bool = False,
+    ) -> pd.DataFrame:
+        """
+        Execute update of the multi-armed bandit based on the logged data,
+        followed by the OPE process with multiple estimators simultaneously.
+
+        Parameters
+        ----------
+        mab : BaseMab
+            Multi-armed bandit model to be updated and evaluated
+        n_mc_experiments : int
+            Number of Monte Carlo experiments for policy estimation
+        save_path : Optional[str]
+            Path to save the results. Nothing is saved if not specified.
+        visualize : bool
+            Whether to visualize the results of the OPE process
+        with_test : bool
+            Whether to update the bandit model with the test data
+
+        Returns
+        -------
+        estimated_policy_value_df : pd.DataFrame
+            Estimated policy values
+        """
+        self._update_mab(mab, self._train_data)
+        if with_test:
+            self._update_mab(mab, self._test_data)
+        estimated_policy_value_df = self.evaluate(mab, n_mc_experiments, save_path, visualize)
+        return estimated_policy_value_df
+
+    def _update_mab(self, mab: BaseMab, data: Dict[str, Any]):
+        """
+        Update the multi-armed bandit model based on the logged data.
+
+        Parameters
+        ----------
+        mab : BaseMab
+            Multi-armed bandit model to be updated.
+        data : Dict[str, Any]
+            Data used to update the bandit model.
+        """
+        if self.verbose:
+            logger.info(f"Offline policy update for {type(mab)}.")
+        kwargs = {"context": data["context"]} if self.contextual_features else {}
+        mab.update(actions=data["action_ids"].tolist(), rewards=np.squeeze(data["reward"]).tolist(), **kwargs)
+
+    def _visualize_results(self, save_path: Optional[str], multi_objective_estimated_policy_value_df: pd.DataFrame):
+        """
+        Visualize the results of the OPE process.
+
+        Parameters
+        ----------
+        save_path : Optional[str]
+            Path to save the visualization results. Required if not running in a Jupyter notebook.
+        multi_objective_estimated_policy_value_df : pd.DataFrame
+            Estimated confidence intervals
+        """
+
+        tabs = []
+        grouped_df = multi_objective_estimated_policy_value_df.groupby("objective")
+        tools = "crosshair, pan, wheel_zoom, box_zoom, reset, hover, save"
+
+        tooltips = [
+            ("Estimator", "@estimator"),
+            ("Estimated policy value", "@value"),
+            ("Lower CI", "@lower"),
+            ("Upper CI", "@upper"),
+        ]
+        for group_name, estimated_interval_df in grouped_df:
+            source = ColumnDataSource(
+                data=dict(
+                    estimator=estimated_interval_df["estimator"],
+                    value=estimated_interval_df["value"],
+                    lower=estimated_interval_df["lower"],
+                    upper=estimated_interval_df["upper"],
+                )
+            )
+            fig = figure(
+                title=f"Policy value estimates for {group_name} objective",
+                x_axis_label="Estimator",
+                y_axis_label="Estimated policy value (\u00b1 CI)",
+                x_range=source.data["estimator"],
+                tools=tools,
+                tooltips=tooltips,
+            )
+            fig.vbar(x="estimator", top="value", width=0.9, source=source)
+
+            # Add error bars for confidence intervals
+            fig.segment(
+                x0="estimator", y0="lower", x1="estimator", y1="upper", source=source, line_width=2, color="black"
+            )  # error bar line
+            fig.vbar(
+                x="estimator", width=0.1, bottom="lower", top="upper", source=source, color="black"
+            )  # error bar cap
+
+            fig.xgrid.grid_line_color = None
+
+            tabs.append(TabPanel(child=fig, title=f"{group_name}"))
+
+        output_path = os.path.join(save_path, "multi_objective_estimated_policy.html") if save_path else None
+        visualize_via_bokeh(tabs=tabs, output_path=output_path)
+
+
+def _mab_predict(mab: BaseMab, mab_data: Union[np.ndarray, PositiveInt], mc_experiment: int = 0) -> List[ActionId]:
+    """
+    bandit action probabilities prediction in test set
+
+    Parameters
+    ----------
+    mab : BaseMab
+        Multi-armed bandit model
+    mab_data : Union[np.ndarray, PositiveInt]
+        test data used to update the bandit model; context or number of samples.
+    mc_experiment : int
+        placeholder for multiprocessing
+
+    Returns
+    -------
+    actions: List[ActionId] of shape (n_samples,)
+        The actions selected by the multi-armed bandit model.
+    """
+    mab_output = mab.predict(context=mab_data) if type(mab_data) is np.ndarray else mab.predict(n_samples=mab_data)
+    actions = mab_output[0]
+    return actions

--- a/pybandits/utils.py
+++ b/pybandits/utils.py
@@ -20,7 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import inspect
 import json
+from abc import ABC
+from types import ModuleType
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from bokeh.io import curdoc, output_file, output_notebook, save, show
@@ -68,6 +71,18 @@ def extract_argument_names_from_function(function_handle: Callable, is_class_met
     start_index = int(is_class_method)
     argument_names = function_handle.__code__.co_varnames[start_index : function_handle.__code__.co_argcount]
     return argument_names
+
+
+@validate_call(config=dict(arbitrary_types_allowed=True))
+def get_non_abstract_classes(module: ModuleType) -> List[type]:
+    non_abc_classes = []
+    for name, obj in inspect.getmembers(module, inspect.isclass):
+        # Ensure the class is defined in the module and not imported
+        if obj.__module__ == module.__name__:
+            # Check if the class is not an abstract class (i.e., doesn't inherit from abc.ABC)
+            if not inspect.isabstract(obj) and ABC not in obj.__bases__:
+                non_abc_classes.append(obj)
+    return non_abc_classes
 
 
 def in_jupyter_notebook() -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybandits"
-version = "3.0.0"
+version = "3.1.0"
 description = "Python Multi-Armed Bandit Library"
 authors = [
     "Dario d'Andrea <dariod@playtika.com>",
@@ -17,13 +17,15 @@ readme = "README.md"
 classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 homepage = "https://github.com/PlaytikaOSS/pybandits"
 repository = "https://github.com/PlaytikaOSS/pybandits"
 keywords = ["multi-armed bandit", "reinforcement-learning", "optimization"]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.12"
+python = ">=3.8.1,<3.13"
 loguru = "^0.6"
 numpy = [
     { version = ">=1.25", python = ">=3.9,<3.12" },
@@ -34,7 +36,10 @@ scipy = [
     { version = ">=1.9,<1.13", python = ">=3.8,<3.12" },
     { version = ">=1.11,<1.13", python = "3.12.*" },
 ]
-pymc = "^5.10"
+pymc = [
+    { version = "^5.3", python = "3.8.*" },
+    { version = "^5.10", python = ">=3.9" },
+]
 scikit-learn = "^1.1"
 optuna = "^3.6"
 bokeh = "^3.1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.fixture(scope="module")
+def monkeymodule():
+    with pytest.MonkeyPatch.context() as mp:
+        yield mp

--- a/tests/test_actions_manager.py
+++ b/tests/test_actions_manager.py
@@ -35,12 +35,6 @@ class DummyActionsManager(ActionsManager):
             self.actions[a].update(rewards=rewards_dict[a])
 
 
-@pytest.fixture(scope="module")
-def monkeymodule():
-    with pytest.MonkeyPatch.context() as mp:
-        yield mp
-
-
 @given(
     data_len=st.integers(min_value=1, max_value=100),
 )

--- a/tests/test_cmab.py
+++ b/tests/test_cmab.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 from copy import deepcopy
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union
 
 import numpy as np
 import pandas as pd
@@ -28,15 +28,18 @@ import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 from pydantic.dataclasses import dataclass
+from pytest import MonkeyPatch
 
 import pybandits
-from pybandits.base import ActionId, Float01, PositiveProbability
+from pybandits.base import ActionId, Float01, PositiveProbability, PyBanditsBaseModel
 from pybandits.cmab import BaseCmabBernoulli, CmabBernoulli, CmabBernoulliBAI, CmabBernoulliCC
 from pybandits.model import (
     BaseBayesianNeuralNetwork,
     BayesianLogisticRegression,
     BayesianNeuralNetwork,
     BayesianNeuralNetworkCC,
+    BnnLayerParams,
+    BnnParams,
     StudentTArray,
     UpdateMethods,
 )
@@ -58,29 +61,30 @@ def cost_strategy(draw, n_actions):
     return draw(st.lists(st.floats(min_value=0, max_value=2), min_size=n_actions, max_size=n_actions))
 
 
-@pytest.fixture(scope="module")
-def monkeymodule():
-    with pytest.MonkeyPatch.context() as mp:
-        yield mp
-
-
 def mock_student_t_array(
     field_value: StudentTArray,
     diff: Any,
-    monkeymodule: Any,
+    monkeymodule: MonkeyPatch,
     label: Union[int, str],
 ) -> int:
     """
     Update the mu and sigma fields of a StudentTArray object.
 
-    Args:
-        field_value: StudentTArray object to update
-        diff: Hypothesis diff object for drawing random values
-        monkeymodule: Module for monkey patching
-        label: Label for the diff draw
+    Parameters
+    ----------
+    field_value : StudentTArray
+        The object to update.
+    diff : Any
+        The diff object for drawing random values.
+    monkeymodule : MonkeyPatch
+        The monkey module for patching.
+    label : Union[int, str]
+        The label for the diff draw.
 
-    Returns:
-        Updated label value
+    Returns
+    -------
+    label: int
+        Updated label
     """
     for sub_field in ("mu", "sigma"):
         try:
@@ -104,31 +108,45 @@ def mock_student_t_array(
     return label
 
 
+def _is_of_relevant_types(member: Any):
+    """
+    Check if the member is of a relevant type for mocking.
+
+    Parameters
+    ----------
+    member : Any
+        The member to check.
+
+    Returns
+    -------
+    bool
+        True if the member is of a relevant type, False otherwise.
+    """
+    return isinstance(member, (PyBanditsBaseModel, BnnParams, BnnLayerParams, StudentTArray))
+
+
 def find_and_update_parameters(obj, diff, monkeymodule, label):
-    if isinstance(obj, StudentTArray):
-        label = mock_student_t_array(obj, diff, monkeymodule, label)
-        return label
+    stack = [obj]
 
-    for attr in dir(obj):
-        if attr.startswith("__"):
+    while stack:
+        current = stack.pop()
+        if isinstance(current, StudentTArray):
+            label = mock_student_t_array(current, diff, monkeymodule, label)
             continue
-        member = getattr(obj, attr)
 
-        if isinstance(member, list):
-            for item in member:
-                if hasattr(item, "__dict__"):
-                    label = find_and_update_parameters(item, diff, monkeymodule, label)
-
-        if hasattr(member, "__dict__"):
-            label = find_and_update_parameters(member, diff, monkeymodule, label)
+        for attr in dir(current):
+            if not attr.startswith("__"):
+                member = getattr(current, attr)
+                if _is_of_relevant_types(member):
+                    stack.append(member)
+                elif isinstance(member, Sequence):
+                    stack.extend(item for item in member if _is_of_relevant_types(item))
 
     return label
 
 
-def mock_update(
-    models: Union[List[BayesianLogisticRegression], BayesianLogisticRegression], diff, monkeymodule, label=0
-):
-    model_list = [models] if isinstance(models, BayesianLogisticRegression) else models
+def mock_update(models: Union[List[BaseBayesianNeuralNetwork], BaseBayesianNeuralNetwork], diff, monkeymodule, label=0):
+    model_list = [models] if isinstance(models, BaseBayesianNeuralNetwork) else models
     for model in model_list:
         label = find_and_update_parameters(model, diff, monkeymodule, label)
 
@@ -571,7 +589,6 @@ def test_predict(
     forbidden = set(sample_with_replacement(action_ids, len(action_ids) // 2)) if len(action_ids) > 2 else None
     if cmab.default_action is not None and forbidden is not None and cmab.default_action in forbidden:
         forbidden.remove(cmab.default_action)
-
     mock_update(list(cmab.actions.values()), diff, monkeymodule)
     best_actions, probs, weights = cmab.predict(context=context, forbidden_actions=forbidden)
     assert len(best_actions) == n_samples
@@ -579,29 +596,32 @@ def test_predict(
     assert len(weights) == n_samples
 
     if forbidden:
-        assert all(
-            len({action[0] if isinstance(action, tuple) else action for action in prob})
-            == len(action_ids) - len(forbidden)
-            for prob in probs
-        )
-        assert all(action[0] if isinstance(action, tuple) else action not in forbidden for action in best_actions)
-        assert all(
-            action[0] if isinstance(action, tuple) else action not in forbidden
-            for prob in probs
-            for action in prob.keys()
-        )
-        assert all(
-            action[0] if isinstance(action, tuple) else action not in forbidden
-            for weight in weights
-            for action in weight.keys()
-        )
+        # Check proper length of probabilities
+        for prob in probs:
+            action_keys = {action[0] if isinstance(action, tuple) else action for action in prob}
+            assert len(action_keys) == len(action_ids) - len(forbidden)
+
+        # Check best actions not in forbidden
+        for action in best_actions:
+            action_id = action[0] if isinstance(action, tuple) else action
+            assert action_id not in forbidden
+
+        # Check prob actions not in forbidden
+        for prob in probs:
+            for action in prob.keys():
+                action_id = action[0] if isinstance(action, tuple) else action
+                assert action_id not in forbidden
+
+        # Check weight actions not in forbidden
+        for weight in weights:
+            for action in weight.keys():
+                action_id = action[0] if isinstance(action, tuple) else action
+                assert action_id not in forbidden
+
     else:
-        assert all(
-            len({action[0] if isinstance(action, tuple) else action for action in prob}) == len(action_ids)
-            for prob in probs
-        )
-    if isinstance(cmab, CmabBernoulli) and not cmab.epsilon:
-        assert all(prob[best_action] == max(prob.values()) for best_action, prob in zip(best_actions, probs))
+        for prob in probs:
+            action_keys = {action[0] if isinstance(action, tuple) else action for action in prob}
+            assert len(action_keys) == len(action_ids)
 
 
 @settings(deadline=None)

--- a/tests/test_cmab_simulator.py
+++ b/tests/test_cmab_simulator.py
@@ -30,8 +30,10 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 from pytest_mock import MockerFixture
 
+import pybandits
 from pybandits.cmab import CmabBernoulli
 from pybandits.cmab_simulator import CmabSimulator
+from tests.test_utils import FakeApproximation
 
 
 def test_mismatched_probs_reward_columns(mocker: MockerFixture, groups=[0, 1]):
@@ -52,8 +54,18 @@ def test_mismatched_probs_reward_columns(mocker: MockerFixture, groups=[0, 1]):
 
 
 def test_cmab_e2e_simulation_with_default_arguments(
-    action_ids=["a1", "a2"], n_features=3, n_updates=2, batch_size=10, num_groups=2
+    monkeymodule, action_ids=["a1", "a2"], n_features=3, n_updates=2, batch_size=10, num_groups=2
 ):
+    monkeymodule.setattr(
+        pybandits.model,
+        "fit",
+        lambda *args, **kwargs: FakeApproximation(n_features=n_features),
+    )
+    monkeymodule.setattr(
+        pybandits.model,
+        "sample",
+        FakeApproximation(n_features=n_features).sample,
+    )
     mab = CmabBernoulli.cold_start(action_ids=action_ids, n_features=n_features)
     base_groups = list(range(num_groups))
     group = base_groups * (n_updates * batch_size // num_groups) + base_groups[: (n_updates * batch_size % num_groups)]
@@ -82,16 +94,16 @@ def test_cmab_e2e_simulation_with_default_arguments(
 
 @settings(deadline=None)
 @given(
-    st.just(["a1", "a2"]),
-    st.just(3),
-    st.integers(min_value=1, max_value=3),
-    st.integers(min_value=1, max_value=10),
-    st.booleans(),
-    st.sampled_from([None, 0, 42]),
-    st.booleans(),
-    st.booleans(),
-    st.sampled_from(["", "unit_test"]),
-    st.integers(min_value=1, max_value=3),
+    action_ids=st.just(["a1", "a2"]),
+    n_features=st.just(3),
+    n_updates=st.integers(min_value=1, max_value=3),
+    batch_size=st.integers(min_value=1, max_value=10),
+    save=st.booleans(),
+    random_seed=st.sampled_from([None, 0, 42]),
+    verbose=st.booleans(),
+    visualize=st.booleans(),
+    file_prefix=st.sampled_from(["", "unit_test"]),
+    num_groups=st.integers(min_value=1, max_value=3),
 )
 def test_cmab_e2e_simulation_with_non_default_args(
     action_ids,
@@ -104,7 +116,18 @@ def test_cmab_e2e_simulation_with_non_default_args(
     visualize,
     file_prefix,
     num_groups,
+    monkeymodule,
 ):
+    monkeymodule.setattr(
+        pybandits.model,
+        "fit",
+        lambda *args, **kwargs: FakeApproximation(n_features=n_features),
+    )
+    monkeymodule.setattr(
+        pybandits.model,
+        "sample",
+        FakeApproximation(n_features=n_features).sample,
+    )
     base_groups = list(range(num_groups))
     group = base_groups * (n_updates * batch_size // num_groups) + base_groups[: (n_updates * batch_size % num_groups)]
     effective_base_groups = sorted(set(group))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -306,11 +306,15 @@ def test_bnn_sample_proba(n_samples, n_features, hidden_dim_list):
 @settings(deadline=None)
 @given(
     n_features=st.integers(min_value=1, max_value=3),
-    hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=1),
+    hidden_dim_list=st.lists(st.integers(min_value=1, max_value=2), min_size=0, max_size=1),
+    n_samples=st.just(100),
+    update_method=st.just("VI"),
 )  # max_size=2 takes a lot of time (>10 min.)
-def test_bnn_update(n_features, hidden_dim_list):
+def test_bnn_vi_update(n_features, hidden_dim_list, n_samples, update_method):
     def update(context, rewards):
-        bnn = BayesianNeuralNetwork.cold_start(n_features=n_features, hidden_dim_list=hidden_dim_list)
+        bnn = BayesianNeuralNetwork.cold_start(
+            n_features=n_features, hidden_dim_list=hidden_dim_list, update_method=update_method
+        )
         init_params = dict(mu=0.0, sigma=10.0, nu=5.0)
         dim_list = [n_features] + hidden_dim_list
         for param in init_params.keys():
@@ -323,7 +327,7 @@ def test_bnn_update(n_features, hidden_dim_list):
 
         bnn.update(context=context, rewards=rewards)
 
-        for param in updated_params:
+        for param in ["mu", "sigma"]:  # nu is not updated:
             for layer_ind in range(len(dim_list)):
                 layer_w = bnn.model_params.bnn_layer_params[layer_ind].weight.params
                 layer_b = bnn.model_params.bnn_layer_params[layer_ind].bias.params
@@ -331,9 +335,6 @@ def test_bnn_update(n_features, hidden_dim_list):
                 assert all(w_val != init_params[param] for w_val in np.array(layer_w[param]).flatten())
                 assert all(b_val != init_params[param] for b_val in np.array(layer_b[param]).flatten())
 
-    n_samples = 100
-
-    updated_params = ["mu", "sigma"]  # nu is not updated
     rewards = np.random.choice([0, 1], size=n_samples).tolist()
 
     # context is numpy array
@@ -343,7 +344,52 @@ def test_bnn_update(n_features, hidden_dim_list):
 
     # raise an error if len(context) != len(rewards)
     with pytest.raises(AttributeError):
-        bnn = BayesianNeuralNetwork.cold_start(n_features=n_features, hidden_dim_list=hidden_dim_list)
+        bnn = BayesianNeuralNetwork.cold_start(
+            n_features=n_features, hidden_dim_list=hidden_dim_list, update_method=update_method
+        )
+        bnn.update(context=context, rewards=rewards[1:])
+
+
+@pytest.mark.parametrize("n_features", [1, 2])
+def test_bnn_mcmc_update(n_features, hidden_dim_list=(2,), n_samples=100, update_method="MCMC"):
+    hidden_dim_list = list(hidden_dim_list)
+
+    def update(context, rewards):
+        bnn = BayesianNeuralNetwork.cold_start(
+            n_features=n_features, hidden_dim_list=hidden_dim_list, update_method=update_method
+        )
+        init_params = dict(mu=0.0, sigma=10.0, nu=5.0)
+        dim_list = [n_features] + hidden_dim_list
+        for param in init_params.keys():
+            for layer_ind in range(len(dim_list)):
+                layer_w = bnn.model_params.bnn_layer_params[layer_ind].weight.params
+                layer_b = bnn.model_params.bnn_layer_params[layer_ind].bias.params
+
+                assert all(w_val == init_params[param] for w_val in np.array(layer_w[param]).flatten())
+                assert all(b_val == init_params[param] for b_val in np.array(layer_b[param]).flatten())
+
+        bnn.update(context=context, rewards=rewards)
+
+        for param in ["mu", "sigma"]:  # nu is not updated:
+            for layer_ind in range(len(dim_list)):
+                layer_w = bnn.model_params.bnn_layer_params[layer_ind].weight.params
+                layer_b = bnn.model_params.bnn_layer_params[layer_ind].bias.params
+
+                assert all(w_val != init_params[param] for w_val in np.array(layer_w[param]).flatten())
+                assert all(b_val != init_params[param] for b_val in np.array(layer_b[param]).flatten())
+
+    rewards = np.random.choice([0, 1], size=n_samples).tolist()
+
+    # context is numpy array
+    context = np.random.uniform(low=-100.0, high=100.0, size=(n_samples, n_features))
+    assert type(context) is np.ndarray
+    update(context=context, rewards=rewards)
+
+    # raise an error if len(context) != len(rewards)
+    with pytest.raises(AttributeError):
+        bnn = BayesianNeuralNetwork.cold_start(
+            n_features=n_features, hidden_dim_list=hidden_dim_list, update_method=update_method
+        )
         bnn.update(context=context, rewards=rewards[1:])
 
 

--- a/tests/test_offline_policy_estimator.py
+++ b/tests/test_offline_policy_estimator.py
@@ -1,0 +1,162 @@
+from typing import Tuple
+from unittest import mock
+
+import numpy as np
+import pytest
+from hypothesis import assume, given
+from hypothesis import strategies as st
+from hypothesis.extra.numpy import arrays
+
+from pybandits import offline_policy_estimator
+from pybandits.offline_policy_estimator import BaseOfflinePolicyEstimator
+from pybandits.utils import get_non_abstract_classes
+
+
+@st.composite
+def invalid_inputs(draw, n_samples: int = 10, n_actions: int = 2):
+    reward = None
+    propensity_score = None
+    estimated_policy = None
+    expected_reward = None
+    expected_importance_weight = None
+    bad_argument = draw(
+        st.sampled_from(
+            [
+                "action",
+                "reward",
+                "propensity_score",
+                "estimated_policy",
+                "expected_reward",
+                "expected_importance_weight",
+            ]
+        )
+    )
+    if bad_argument == "action":
+        action = draw(arrays(dtype=int, shape=(n_samples, 2), elements=st.integers(0, n_actions - 1)))
+    else:
+        action = draw(arrays(dtype=int, shape=(n_samples,), elements=st.integers(0, n_actions - 1)))
+        assume(np.unique(action).size == n_actions)
+        if bad_argument == "reward":
+            reward = draw(
+                st.one_of(
+                    arrays(dtype=int, shape=(n_samples, 2), elements=st.integers(0, 1)),
+                    arrays(dtype=float, shape=(n_samples,), elements=st.floats(0, 1)),
+                    arrays(
+                        dtype=int,
+                        shape=(n_samples - 1,),
+                        elements=st.integers(0, 1),
+                    ),
+                    arrays(
+                        dtype=int,
+                        shape=(n_samples + 1,),
+                        elements=st.integers(0, 1),
+                    ),
+                )
+            )
+        elif bad_argument in ("propensity_score", "expected_importance_weight"):
+            random_value = draw(
+                st.one_of(
+                    arrays(dtype=float, shape=(n_samples, 2), elements=st.floats(0, 1)),
+                    arrays(dtype=float, shape=(n_samples,), elements=st.floats(0, 0)),
+                    arrays(dtype=int, shape=(n_samples,), elements=st.integers(0, 1)),
+                    arrays(
+                        dtype=float,
+                        shape=(n_samples - 1,),
+                        elements=st.floats(0, 1),
+                    ),
+                    arrays(
+                        dtype=float,
+                        shape=(n_samples + 1,),
+                        elements=st.floats(0, 1),
+                    ),
+                )
+            )
+
+            if bad_argument == "propensity_score":
+                propensity_score = random_value
+            elif bad_argument == "expected_importance_weight":
+                expected_importance_weight = random_value
+        elif bad_argument == "estimated_policy":
+            estimated_policy = draw(
+                st.one_of(
+                    arrays(dtype=float, shape=(n_samples,), elements=st.floats(0, 1)),
+                    arrays(dtype=float, shape=(n_samples, 2), elements=st.floats(0, 0)),
+                    arrays(dtype=int, shape=(n_samples, 2), elements=st.integers(0, 1)),
+                    arrays(
+                        dtype=float,
+                        shape=(n_samples - 1, 1),
+                        elements=st.floats(0, 1),
+                    ),
+                    arrays(
+                        dtype=float,
+                        shape=(n_samples + 1, 1),
+                        elements=st.floats(0, 1),
+                    ),
+                )
+            )
+        elif bad_argument == "expected_reward":
+            expected_reward = draw(
+                st.one_of(
+                    arrays(dtype=float, shape=(n_samples,), elements=st.floats(0, 1)),
+                    arrays(dtype=int, shape=(n_samples, 2), elements=st.integers(0, 1)),
+                    arrays(
+                        dtype=float,
+                        shape=(n_samples - 1, 1),
+                        elements=st.floats(0, 1),
+                    ),
+                    arrays(
+                        dtype=float,
+                        shape=(n_samples + 1, 1),
+                        elements=st.floats(0, 1),
+                    ),
+                )
+            )
+        else:
+            raise ValueError(f"Invalid bad_argument: {bad_argument}")
+    return action, reward, propensity_score, estimated_policy, expected_reward, expected_importance_weight
+
+
+@mock.patch.multiple(BaseOfflinePolicyEstimator, __abstractmethods__=set())
+@given(invalid_inputs())
+def test_shape_mismatches(
+    inputs: Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+):
+    action, reward, propensity_score, estimated_policy, expected_reward, expected_importance_weight = inputs
+    estimator = BaseOfflinePolicyEstimator()
+    kwargs = {}
+    if reward is not None:
+        kwargs["reward"] = reward
+    if propensity_score is not None:
+        kwargs["propensity_score"] = propensity_score
+    if estimated_policy is not None:
+        kwargs["estimated_policy"] = estimated_policy
+    if expected_reward is not None:
+        kwargs["expected_reward"] = expected_reward
+    if expected_importance_weight is not None:
+        kwargs["expected_importance_weight"] = expected_importance_weight
+    with pytest.raises(ValueError):
+        estimator._check_inputs(action=action, **kwargs)
+
+
+@given(
+    arrays(dtype=int, shape=(10,), elements=st.integers(0, 1)),
+    arrays(dtype=int, shape=(10,), elements=st.integers(0, 1)),
+    arrays(dtype=float, shape=(10,), elements=st.floats(0.01, 1)),
+    arrays(dtype=float, shape=(10, 2), elements=st.floats(0.01, 1)),
+    arrays(dtype=float, shape=(10, 2), elements=st.floats(0, 1)),
+    arrays(dtype=float, shape=(10,), elements=st.floats(0.01, 1)),
+)
+def test_default_estimators(
+    action, reward, propensity_score, estimated_policy, expected_reward, expected_importance_weight
+):
+    if np.unique(action).size > 1:
+        estimators = [class_() for class_ in get_non_abstract_classes(offline_policy_estimator)]
+        for estimator in estimators:
+            estimator.estimate_policy_value_with_confidence_interval(
+                action=action,
+                reward=reward,
+                propensity_score=propensity_score,
+                estimated_policy=estimated_policy,
+                expected_reward=expected_reward,
+                expected_importance_weight=expected_importance_weight,
+            )

--- a/tests/test_offline_policy_evaluator.py
+++ b/tests/test_offline_policy_evaluator.py
@@ -1,0 +1,319 @@
+from tempfile import TemporaryDirectory
+from typing import Dict, List, Optional, Union, get_args, get_type_hints
+
+import numpy as np
+import pandas as pd
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from matplotlib.pyplot import close
+from pydantic import PositiveInt
+from pytest_mock import MockerFixture
+from sklearn.base import TransformerMixin
+from sklearn.preprocessing import MinMaxScaler
+
+import pybandits
+from pybandits.cmab import CmabBernoulli, CmabBernoulliCC
+from pybandits.offline_policy_estimator import BaseOfflinePolicyEstimator
+from pybandits.offline_policy_evaluator import OfflinePolicyEvaluator
+from pybandits.smab import (
+    SmabBernoulli,
+    SmabBernoulliCC,
+    SmabBernoulliMO,
+    SmabBernoulliMOCC,
+)
+from tests.test_utils import FakeApproximation
+
+
+@pytest.fixture(scope="module")
+def logged_data(n_samples=10, n_actions=2, n_batches=3, n_rewards=2, n_groups=2, n_features=3):
+    unique_actions = [f"a{i}" for i in range(n_actions)]
+    action_ids = np.random.choice(unique_actions, n_samples * n_batches)
+    batches = [i for i in range(n_batches) for _ in range(n_samples)]
+    rewards = [np.random.randint(2, size=(n_samples * n_batches)) for _ in range(n_rewards)]
+    action_true_rewards = {(a, r): np.random.rand() for a in unique_actions for r in range(n_rewards)}
+    true_rewards = [
+        np.array([action_true_rewards[(a, r)] for a in action_ids]).reshape(n_samples * n_batches)
+        for r in range(n_rewards)
+    ]
+    groups = np.random.randint(n_groups, size=n_samples * n_batches)
+    action_costs = {action: np.random.rand() for action in unique_actions}
+    costs = np.array([action_costs[a] for a in action_ids])
+    context = np.random.rand(n_samples * n_batches, n_features)
+    action_propensity_score = {action: np.random.rand() for action in unique_actions}
+    propensity_score = np.array([action_propensity_score[a] for a in action_ids])
+    return pd.DataFrame(
+        {
+            "batch": batches,
+            "action_id": action_ids,
+            "cost": costs,
+            "group": groups,
+            **{f"reward_{r}": rewards[r] for r in range(n_rewards)},
+            **{f"true_reward_{r}": true_rewards[r] for r in range(n_rewards)},
+            **{f"context_{i}": context[:, i] for i in range(n_features)},
+            "propensity_score": propensity_score,
+        }
+    )
+
+
+# validate failure for empty logged_data
+def test_empty_logged_data(
+    split_prop=0.5,
+    n_trials=10,
+    verbose=False,
+    batch_feature="batch",
+    action_feature="action_id",
+    reward_feature="reward",
+    propensity_score_model_type="empirical",
+    expected_reward_model_type="logreg",
+    importance_weights_model_type="logreg",
+):
+    with pytest.raises(AttributeError):
+        OfflinePolicyEvaluator(
+            logged_data=pd.DataFrame(),
+            split_prop=split_prop,
+            propensity_score_model_type=propensity_score_model_type,
+            expected_reward_model_type=expected_reward_model_type,
+            importance_weights_model_type=importance_weights_model_type,
+            n_trials=n_trials,
+            ope_metrics=None,
+            batch_feature=batch_feature,
+            action_feature=action_feature,
+            reward_feature=reward_feature,
+            verbose=verbose,
+        )
+
+
+@pytest.mark.usefixtures("logged_data")
+@given(
+    split_prop=st.sampled_from([0.0, 1.0]),
+    n_trials=st.just(10),
+    ope_metrics=st.just(None),
+    verbose=st.just(False),
+    batch_feature=st.just("batch"),
+    action_feature=st.just("action_id"),
+    reward_feature=st.just("reward_0"),
+    propensity_score_model_type=st.just("empirical"),
+    expected_reward_model_type=st.just("logreg"),
+    importance_weights_model_type=st.just("logreg"),
+)
+# validate failure for extreme split_prop values
+def test_initialization_extreme_split_prop(
+    logged_data: MockerFixture,
+    split_prop: float,
+    n_trials: PositiveInt,
+    ope_metrics: Optional[List[BaseOfflinePolicyEstimator]],
+    verbose: bool,
+    batch_feature: str,
+    action_feature: str,
+    reward_feature: str,
+    propensity_score_model_type: str,
+    expected_reward_model_type: str,
+    importance_weights_model_type: str,
+):
+    with pytest.raises(ValueError):
+        OfflinePolicyEvaluator(
+            logged_data=logged_data,
+            split_prop=split_prop,
+            propensity_score_model_type=propensity_score_model_type,
+            expected_reward_model_type=expected_reward_model_type,
+            importance_weights_model_type=importance_weights_model_type,
+            n_trials=n_trials,
+            ope_metrics=ope_metrics,
+            batch_feature=batch_feature,
+            action_feature=action_feature,
+            reward_feature=reward_feature,
+            true_reward_feature=reward_feature,
+            verbose=verbose,
+        )
+
+
+# validate failure for invalid initialization parameters
+def test_initialization_mismatches(
+    logged_data: MockerFixture,
+    split_prop=0.5,
+    n_trials=10,
+    ope_metrics=None,
+    verbose=False,
+    batch_feature="batch",
+    action_feature="action_id",
+    reward_feature="reward_0",
+    propensity_score_model_type="empirical",
+    expected_reward_model_type="logreg",
+    importance_weights_model_type="logreg",
+):
+    # more true_reward_features than rewards
+    with pytest.raises(ValueError):
+        OfflinePolicyEvaluator(
+            logged_data=logged_data,
+            split_prop=split_prop,
+            propensity_score_model_type=propensity_score_model_type,
+            expected_reward_model_type=expected_reward_model_type,
+            importance_weights_model_type=importance_weights_model_type,
+            n_trials=n_trials,
+            ope_metrics=ope_metrics,
+            batch_feature=batch_feature,
+            action_feature=action_feature,
+            reward_feature=reward_feature,
+            true_reward_feature=[reward_feature, reward_feature],
+            verbose=verbose,
+        )
+    # missing propensity_score_feature
+    with pytest.raises(ValueError):
+        OfflinePolicyEvaluator(
+            logged_data=logged_data,
+            split_prop=split_prop,
+            propensity_score_model_type="propensity_score",
+            expected_reward_model_type=expected_reward_model_type,
+            importance_weights_model_type=importance_weights_model_type,
+            n_trials=n_trials,
+            ope_metrics=ope_metrics,
+            batch_feature=batch_feature,
+            action_feature=action_feature,
+            reward_feature=reward_feature,
+            visualize=False,
+        )
+    # missing context
+    with pytest.raises(AttributeError):
+        OfflinePolicyEvaluator(
+            logged_data=logged_data,
+            split_prop=split_prop,
+            propensity_score_model_type=propensity_score_model_type,
+            expected_reward_model_type=expected_reward_model_type,
+            importance_weights_model_type=importance_weights_model_type,
+            n_trials=n_trials,
+            ope_metrics=ope_metrics,
+            batch_feature=batch_feature,
+            action_feature=action_feature,
+            reward_feature=reward_feature,
+            verbose=False,
+            contextual_features=["non_existent"],
+        )
+
+
+@pytest.mark.usefixtures("logged_data")
+@settings(deadline=None)
+@given(
+    split_prop=st.just(0.5),
+    n_trials=st.just(10),
+    fast_fit=st.booleans(),
+    scaler=st.sampled_from([None, MinMaxScaler()]),
+    verbose=st.booleans(),
+    visualize=st.booleans(),
+    propensity_score_model_type=st.sampled_from(
+        get_args(get_type_hints(OfflinePolicyEvaluator)["propensity_score_model_type"])
+    ),
+    expected_reward_model_type=st.sampled_from(
+        get_args(get_type_hints(OfflinePolicyEvaluator)["expected_reward_model_type"])
+    ),
+    importance_weights_model_type=st.sampled_from(
+        get_args(get_type_hints(OfflinePolicyEvaluator)["importance_weights_model_type"])
+    ),
+    batch_feature=st.just("batch"),
+    action_feature=st.just("action_id"),
+    reward_feature=st.sampled_from(["reward_0", ["reward_0", "reward_1"]]),
+    context=st.booleans(),
+    group_feature=st.sampled_from(["group", None]),
+    cost_feature=st.sampled_from(["cost", None]),
+    propensity_score_feature=st.just("propensity_score"),
+    n_mc_experiments=st.just(2),
+    update=st.booleans(),
+    shuffle=st.booleans(),
+)
+# test various OfflinePolicyEvaluator configurations to validate that everything works
+def test_running_configuration(
+    logged_data: MockerFixture,
+    split_prop: float,
+    n_trials: PositiveInt,
+    fast_fit: bool,
+    scaler: Optional[Union[TransformerMixin, Dict[str, TransformerMixin]]],
+    verbose: bool,
+    visualize: bool,
+    propensity_score_model_type: str,
+    expected_reward_model_type: str,
+    importance_weights_model_type: str,
+    batch_feature: str,
+    action_feature: str,
+    reward_feature: Union[str, List[int]],
+    context: bool,
+    group_feature: Optional[str],
+    cost_feature: Optional[str],
+    propensity_score_feature: Optional[str],
+    n_mc_experiments: int,
+    shuffle: bool,
+    update: bool,
+    monkeymodule,
+):
+    if context and type(reward_feature) is List:
+        pass  # CmabMO and CmabMOCC are not supported yet
+    true_reward_feature = (
+        f"true_{reward_feature}" if isinstance(reward_feature, str) else [f"true_{r}" for r in reward_feature]
+    )
+    if context:
+        contextual_features = [col for col in logged_data.columns if col.startswith("context")]
+        monkeymodule.setattr(
+            pybandits.model,
+            "fit",
+            lambda *args, **kwargs: FakeApproximation(n_features=len(contextual_features)),
+        )
+        monkeymodule.setattr(
+            pybandits.model,
+            "sample",
+            FakeApproximation(n_features=len(contextual_features)).sample,
+        )
+    else:
+        contextual_features = None
+    unique_actions = logged_data["action_id"].unique()
+    if cost_feature:
+        action_ids_cost = {
+            action_id: logged_data["cost"][logged_data["action_id"] == action_id].iloc[0]
+            for action_id in unique_actions
+        }
+    if context:
+        if cost_feature:
+            if type(reward_feature) is list:
+                return  # CmabMOCC is not supported yet
+            else:
+                mab = CmabBernoulliCC.cold_start(action_ids_cost=action_ids_cost, n_features=len(contextual_features))
+        else:
+            if type(reward_feature) is list:
+                return  # CmabMO is not supported yet
+            else:
+                mab = CmabBernoulli.cold_start(action_ids=set(unique_actions), n_features=len(contextual_features))
+    else:
+        if cost_feature:
+            if type(reward_feature) is list:
+                mab = SmabBernoulliMOCC.cold_start(action_ids_cost=action_ids_cost, n_objectives=len(reward_feature))
+            else:
+                mab = SmabBernoulliCC.cold_start(action_ids_cost=action_ids_cost)
+        else:
+            if type(reward_feature) is list:
+                mab = SmabBernoulliMO.cold_start(action_ids=set(unique_actions), n_objectives=len(reward_feature))
+            else:
+                mab = SmabBernoulli.cold_start(action_ids=set(unique_actions))
+    evaluator = OfflinePolicyEvaluator(
+        logged_data=logged_data,
+        split_prop=split_prop,
+        n_trials=n_trials,
+        fast_fit=fast_fit,
+        scaler=scaler,
+        ope_estimators=None,
+        verbose=verbose,
+        shuffle=shuffle,
+        propensity_score_model_type=propensity_score_model_type,
+        expected_reward_model_type=expected_reward_model_type,
+        importance_weights_model_type=importance_weights_model_type,
+        batch_feature=batch_feature,
+        action_feature=action_feature,
+        reward_feature=reward_feature,
+        true_reward_feature=true_reward_feature,
+        contextual_features=contextual_features,
+        group_feature=group_feature,
+        cost_feature=cost_feature,
+        propensity_score_feature=propensity_score_feature,
+    )
+    execution_func = evaluator.update_and_evaluate if update else evaluator.evaluate
+    with TemporaryDirectory() as tmp_dir:
+        execution_func(mab=mab, visualize=visualize, n_mc_experiments=n_mc_experiments, save_path=tmp_dir)
+    if visualize:
+        close("all")  # close all figures to avoid memory leak

--- a/tests/test_smab.py
+++ b/tests/test_smab.py
@@ -60,12 +60,6 @@ def cost_strategy(draw, n_actions):
     return draw(st.lists(st.floats(min_value=0, max_value=2), min_size=n_actions, max_size=n_actions))
 
 
-@pytest.fixture(scope="module")
-def monkeymodule():
-    with pytest.MonkeyPatch.context() as mp:
-        yield mp
-
-
 def mock_update(models: List[BaseBeta], diff, monkeymodule, label=0):
     for model in models:
         for field in model.model_fields:


### PR DESCRIPTION
### Changes
* Introduced `offline_policy_evaluator.py` with classes for propensity score estimation and offline policy evaluation.
* Introduced `offline_policy_estimator.py` with classes for offline policy estimation.
* Updated `pyproject.toml` to include new dependencies: `bokeh` and `optuna`. Further adjusted existing dependencies to compatible versions and added python 3.12 support.
* Changed .pre-commit-config.yaml to utilize nbstripout instead of nbdev_clean.
* Added class method to PyBanditsBaseModel on base.py to allow seeing default values for arguments that were not passed to the model.
* Added test_offline_policy_evaluator.py and test_offline_policy_estimator.py as a test suite for the OfflinePolicyEvaluator.
* Added `get_non_abstract_classes`, `visualize_via_bokeh` and `in_jupyter_notebook` utility functions.