### PR TITLE
Add loss factor to CostControlBandit and update logic for dynamic subsidy factor

### DIFF
--- a/.github/workflows/continuous_delivery.yml
+++ b/.github/workflows/continuous_delivery.yml
@@ -35,7 +35,7 @@ jobs:
           poetry run pre-commit run --all-files
       - name: Run tests
         run: |
-          poetry run pytest -vv -k 'not time and not update_parallel'
+          poetry run pytest -vv -k 'not time and not update_parallel' --cov=pybandits
       - name: Extract version from pyproject.toml
         id: extract_version
         run: |

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -43,4 +43,4 @@ jobs:
           poetry run pre-commit run --all-files
       - name: Run tests
         run: |
-          poetry run pytest -vv -k 'not time and not update_parallel'
+          poetry run pytest -vv -k 'not time and not update_parallel' --cov=pybandits

--- a/pybandits/cmab.py
+++ b/pybandits/cmab.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Dict, List, Optional, Set, Union
+from typing import Dict, List, Set, Union
 
 from numpy import array
 from numpy.random import choice
@@ -76,22 +76,20 @@ class BaseCmabBernoulli(BaseMab):
         return v
 
     @validate_call(config=dict(arbitrary_types_allowed=True))
-    def predict(
+    def _predict(
         self,
         context: ArrayLike,
-        forbidden_actions: Optional[Set[ActionId]] = None,
+        valid_actions: Set[ActionId],
     ) -> CmabPredictions:
         """
         Predict actions.
 
         Parameters
         ----------
-        context: ArrayLike of shape (n_samples, n_features)
+        context : ArrayLike of shape (n_samples, n_features)
             Matrix of contextual features.
-        forbidden_actions : Optional[Set[ActionId]], default=None
-            Set of forbidden actions. If specified, the model will discard the forbidden_actions and it will only
-            consider the remaining allowed_actions. By default, the model considers all actions as allowed_actions.
-            Note that: actions = allowed_actions U forbidden_actions.
+        valid_actions : Set[ActionId]
+            The set of valid actions to consider.
 
         Returns
         -------
@@ -102,7 +100,6 @@ class BaseCmabBernoulli(BaseMab):
         ws : List[Dict[ActionId, float]]
             The weighted sum of logistic regression logits.
         """
-        valid_actions = self._get_valid_actions(forbidden_actions)
 
         # cast inputs to numpy arrays to facilitate their manipulation
         context = array(context)
@@ -149,7 +146,7 @@ class BaseCmabBernoulli(BaseMab):
         return selected_actions, probs, weighted_sums
 
     @validate_call(config=dict(arbitrary_types_allowed=True))
-    def update(
+    def _update(
         self, context: ArrayLike, actions: List[ActionId], rewards: List[Union[BinaryReward, List[BinaryReward]]]
     ):
         """

--- a/pybandits/strategy.py
+++ b/pybandits/strategy.py
@@ -22,15 +22,15 @@
 
 from abc import ABC, abstractmethod
 from random import random
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
-from pydantic import field_validator, validate_call
+from pydantic import PrivateAttr, field_validator, validate_call
 from scipy.stats import ttest_ind_from_stats
 from typing_extensions import Self
 
-from pybandits.base import ActionId, Float01, Probability, PyBanditsBaseModel
-from pybandits.model import Beta, BetaMOCC, Model
+from pybandits.base import ActionId, BinaryReward, Float01, Probability, PyBanditsBaseModel
+from pybandits.model import Beta, Model
 
 
 class Strategy(PyBanditsBaseModel, ABC):
@@ -231,76 +231,25 @@ class CostControlStrategy(Strategy, ABC):
     Cost Control (CC) strategy for multi-armed bandits.
 
     Bandits are extended to include a control of the action cost. Each action is associated with a predefined "cost".
-    """
-
-    @classmethod
-    @validate_call
-    def _average(cls, p_of_action: Union[Probability, List[Probability]]):
-        return np.mean(p_of_action)
-
-    @classmethod
-    @validate_call
-    def _evaluate_and_select(
-        cls,
-        p: Union[Dict[ActionId, Probability], Dict[ActionId, List[Probability]]],
-        actions: Dict[ActionId, Model],
-        feasible_actions: List[ActionId],
-    ) -> ActionId:
-        """
-        Evaluate the feasible actions and select the one with the minimum cost.
-
-        Parameters
-        ----------
-        p: Union[Dict[ActionId, Probability], Dict[ActionId, List[Probability]]]
-            The dictionary of actions and their sampled probability of getting a positive reward.
-        actions: Dict[ActionId, Model]
-            The dictionary of actions and their associated model.
-        feasible_actions: List[ActionId]
-            The list of feasible actions.
-
-        Returns
-        -------
-        selected_action: ActionId
-            The selected action.
-        """
-        # feasible actions enriched with their characteristics (cost, np.mean(probabilities), action_id)
-        # the negative probability ensures that if we order the actions based on their minimum values the one with
-        # higher probability will be selected
-        sortable_actions = [(actions[a].cost, -cls._average(p[a]), a) for a in feasible_actions]
-
-        # select the action with the min cost (and the highest mean of probabilities in case of cost equality)
-        _, _, selected_action = sorted(sortable_actions)[0]
-
-        # return cheapest action from the set of feasible actions
-        return selected_action
-
-
-class CostControlBandit(CostControlStrategy):
-    """
-    Cost Control (CC) strategy for multi-armed bandits.
-
-    Bandits are extended to include a control of the action cost. Each action is associated with a predefined "cost".
-    At prediction time, the model considers the actions whose expected rewards are above a pre-defined lower bound.
-    Among these actions, the one with the lowest associated cost is recommended. The expected reward interval for
-    feasible actions is defined as [(1-subsidy_factor)*max_p, max_p], where max_p is the highest expected reward sampled
-    value.
-
-    Reference: Thompson Sampling for Contextual Bandit Problems with Auxiliary Safety Constraints (Daulton et al., 2019)
-               https://arxiv.org/abs/1911.00638
-
-               Multi-Armed Bandits with Cost Subsidy (Sinha et al., 2021)
-               https://arxiv.org/abs/2011.01488
 
     Parameters
     ----------
-    subsidy_factor: Optional[Float01], 0.5 if not specified
+    subsidy_factor: Optional[Union[Float01, Beta, List[Beta]]], 0.5 if not specified
         Number in [0, 1] to define smallest tolerated probability reward, hence the set of feasible actions.
         If subsidy_factor is 1, the bandits always selects the action with the minimum cost.
         If subsidy_factor is 0, the bandits always selects the action with highest probability of getting a positive
             reward (it behaves as a classic Bernoulli bandit).
+    loss_factor : Float01, defaults to 0
+        Number in [0, 1] that controls the tradeoff between the cost and the expected reward.
+        The tradeoff is characterized via the convex combination of the normalized cost
+        and the negated normalized expected reward.
+        If loss_factor is 0 or 1, the criterion for choosing the optimal action from the feasible set is based only
+        on the cost or expected reward, respectively.
     """
 
-    subsidy_factor: Optional[Float01] = 0.5
+    subsidy_factor: Optional[Union[Float01, Beta, List[Beta]]] = 0.5
+    loss_factor: Float01 = 0.0
+    _buffer = []
 
     @field_validator("subsidy_factor", mode="before")
     @classmethod
@@ -328,11 +277,160 @@ class CostControlBandit(CostControlStrategy):
         mutated_cost_control_bandit = self._with_argument("subsidy_factor", subsidy_factor)
         return mutated_cost_control_bandit
 
+    def reset(self):
+        if isinstance(self.subsidy_factor, Beta) or isinstance(self.subsidy_factor, list):
+            self._buffer = []
+
+    def _realize_subsidy_factor(self, subsidy_factor: Union[Float01, Beta]) -> Float01:
+        """
+        Realize the subsidy factor.
+        If the subsidy factor is a model, sample from it. Otherwise, return the subsidy factor.
+
+        Returns
+        -------
+        subsidy_factor: Float01
+            The realized subsidy factor.
+        """
+        if isinstance(subsidy_factor, Beta):
+            subsidy_factor = subsidy_factor.sample_proba()
+        elif isinstance(subsidy_factor, float):
+            subsidy_factor = subsidy_factor
+        else:
+            raise ValueError(f"Invalid subsidy factor type: {type(subsidy_factor)}")
+        return subsidy_factor
+
+    @validate_call
+    def _evaluate_feasible_actions(
+        self, p: Dict[ActionId, Probability], actions: Dict[ActionId, Model], subsidy_factor: Union[Float01, Beta]
+    ) -> Tuple[Dict[ActionId, Probability], ActionId]:
+        """
+        Select the action with the minimum cost among the set of feasible actions.
+        Feasible actions are the ones whose expected rewards are above (1-subsidy_factor)*max_p.
+
+        Parameters
+        ----------
+        p : Dict[ActionId, Probability]
+            The dictionary or actions and their sampled probability of getting a positive reward.
+        actions : Dict[ActionId, Model]
+            The dictionary of actions and their characteristics.
+        subsidy_factor : Union[Float01, Beta]
+            The subsidy factor.
+
+
+        Returns
+        -------
+        feasible_actions_loss : Dict[ActionId, Probability]
+            The dictionary of feasible actions and their loss.
+        max_p_action : ActionId
+            The highest expected reward action identifier.
+        """
+        realized_subsidy_factor = self._realize_subsidy_factor(subsidy_factor)
+        # get the highest expected reward sampled value
+        max_p = max(p.values())
+        # find action whose value is max_p and has the lowest cost
+        max_p_actions = [a for a in p.keys() if p[a] == max_p]
+        max_p_action = min(max_p_actions, key=lambda action_id: (actions[action_id].cost, action_id))
+        max_p_action_cost = actions[max_p_action].cost
+        if max_p_action_cost == 0 or max_p == 0:
+            feasible_actions_loss = {max_p_action: 0.0}
+        else:
+            feasible_actions_loss = {
+                a: self.loss_factor * (1 - p[a] / max_p) + (1 - self.loss_factor) * actions[a].cost / max_p_action_cost
+                for a in p.keys()
+                if p[a] >= (1 - realized_subsidy_factor) * max_p and actions[a].cost <= max_p_action_cost
+            }
+
+        return feasible_actions_loss, max_p_action
+
+    @validate_call
+    def update(self, rewards: Union[List[BinaryReward], List[List[BinaryReward]]]):
+        """
+        Update the subsidy factor based on the rewards and the buffered relative costs.
+
+        Parameters
+        ----------
+        rewards : Union[List[BinaryReward], List[List[BinaryReward]]]
+            The binary reward for each sample.
+            If strategy is not MultiObjectiveBandit, rewards should be a list, e.g.
+                rewards = [1, 0, 1, 1, 1, ...]
+            If strategy is MultiObjectiveBandit, rewards should be a list of list, e.g. (with n_objectives=2):
+                rewards = [[1, 1], [1, 0], [1, 1], [1, 0], [1, 1], ...]
+
+        """
+        if type(self.subsidy_factor) is Beta:
+            self._update_subsidy_factor(subsidy_factor=self.subsidy_factor, rewards=rewards, buffer=self._buffer)
+        elif isinstance(self.subsidy_factor, list) and all(
+            isinstance(subsidy_factor, Beta) for subsidy_factor in self.subsidy_factor
+        ):
+            for subsidy_factor, single_objective_rewards, single_objective_buffer in zip(
+                self.subsidy_factor, zip(*rewards), zip(*self._buffer)
+            ):
+                self._update_subsidy_factor(
+                    subsidy_factor=subsidy_factor, rewards=single_objective_rewards, buffer=single_objective_buffer
+                )
+
+    def _update_subsidy_factor(self, subsidy_factor: Beta, rewards: List[BinaryReward], buffer: List[Probability]):
+        """
+        Update the subsidy factor based on the rewards and the relative cost.
+
+        Parameters
+        ----------
+        subsidy_factor : Beta
+            The subsidy factor model.
+        rewards : List[BinaryReward]
+            The binary reward for each sample.
+        buffer : List[Probability]
+            The buffer of relative costs.
+
+        """
+
+        rewards = [
+            (1 - r) * self.loss_factor + relative_cost > 0.5
+            for relative_cost, r in zip(buffer, rewards)
+            if relative_cost is not None
+        ]
+        subsidy_factor.update(rewards=rewards)
+
+
+class CostControlBandit(CostControlStrategy):
+    """
+    Cost Control (CC) strategy for multi-armed bandits.
+
+    Bandits are extended to include a control of the action cost. Each action is associated with a predefined "cost".
+    At prediction time, the model considers the actions whose expected rewards are above a pre-defined lower bound.
+    Among these actions, the one with the lowest associated cost is recommended. The expected reward interval for
+    feasible actions is defined as [(1-subsidy_factor)*max_p, max_p], where max_p is the highest expected reward sampled
+    value.
+
+    Reference: Thompson Sampling for Contextual Bandit Problems with Auxiliary Safety Constraints (Daulton et al., 2019)
+               https://arxiv.org/abs/1911.00638
+
+               Multi-Armed Bandits with Cost Subsidy (Sinha et al., 2021)
+               https://arxiv.org/abs/2011.01488
+
+    Parameters
+    ----------
+    subsidy_factor: Optional[Union[Float01, Beta]], 0.5 if not specified
+        Number in [0, 1] to define smallest tolerated probability reward, hence the set of feasible actions.
+        If subsidy_factor is 1, the bandits always selects the action with the minimum cost.
+        If subsidy_factor is 0, the bandits always selects the action with highest probability of getting a positive
+            reward (it behaves as a classic Bernoulli bandit).
+    loss_factor : Float01, defaults to 0
+        Number in [0, 1] that controls the tradeoff between the cost and the expected reward.
+        The tradeoff is characterized via the convex combination of the normalized cost
+        and the negated normalized expected reward.
+        If loss_factor is 0 or 1, the criterion for choosing the optimal action from the feasible set is based only
+        on the cost or expected reward, respectively.
+
+    """
+
+    subsidy_factor: Optional[Union[Float01, Beta]] = 0.5
+
     @validate_call
     def select_action(self, p: Dict[ActionId, Probability], actions: Dict[ActionId, Model]) -> ActionId:
         """
         Select the action with the minimum cost among the set of feasible actions (the actions whose expected rewards
-        are above a certain lower bound defined as [(1-subsidy_factor)*max_p, max_p], where max_p is the highest
+        are above a certain lower bound. defined as [(1-subsidy_factor)*max_p, max_p], where max_p is the highest
         expected reward sampled value.
 
         Parameters
@@ -347,13 +445,24 @@ class CostControlBandit(CostControlStrategy):
         selected_action: ActionId
             The selected action.
         """
-        # get the highest expected reward sampled value
-        max_p = max(p.values())
-
-        # define the set of feasible actions
-        feasible_actions = [a for a in p.keys() if p[a] >= (1 - self.subsidy_factor) * max_p]
-
-        selected_action = self._evaluate_and_select(p, actions, feasible_actions)
+        feasible_actions_loss, max_p_action = self._evaluate_feasible_actions(
+            p=p, actions=actions, subsidy_factor=self.subsidy_factor
+        )
+        selected_action = min(
+            feasible_actions_loss,
+            key=lambda action_id: (
+                feasible_actions_loss[action_id],
+                -p[action_id] if self.loss_factor > 0.5 else actions[action_id].cost,
+                actions[action_id].cost if self.loss_factor > 0.5 else -p[action_id],
+                action_id,
+            ),
+        )
+        max_p_action_cost = actions[max_p_action].cost
+        self._buffer.append(
+            (1 - self.loss_factor) * actions[selected_action].cost / max_p_action_cost
+            if max_p_action_cost > 0
+            else None
+        )
         return selected_action
 
 
@@ -364,7 +473,7 @@ class MultiObjectiveStrategy(Strategy, ABC):
 
     @classmethod
     @validate_call
-    def get_pareto_front(cls, p: Dict[ActionId, List[Probability]]) -> List[ActionId]:
+    def _get_pareto_front(cls, p: Dict[ActionId, List[Probability]]) -> List[ActionId]:
         """
         Create Pareto optimal set of actions (Pareto front) A* identified as actions that are not dominated by
         any action out of the set A*.
@@ -376,7 +485,7 @@ class MultiObjectiveStrategy(Strategy, ABC):
 
         Return
         ------
-        pareto_front: set
+        pareto_front: List[ActionId]
             The list of Pareto optimal actions
         """
         # store non dominated actions
@@ -408,20 +517,6 @@ class MultiObjectiveStrategy(Strategy, ABC):
 
         return pareto_front
 
-
-class MultiObjectiveBandit(MultiObjectiveStrategy):
-    """
-    Multi-Objective (MO) strategy for multi-armed bandits.
-
-    The reward pertaining to an action is a multidimensional vector instead of a scalar value. In this setting,
-    different actions are compared according to Pareto order between their expected reward vectors, and those actions
-    whose expected rewards are not inferior to that of any other actions are called Pareto optimal actions, all of which
-    constitute the Pareto front.
-
-    Reference: Thompson Sampling for Multi-Objective Multi-Armed Bandits Problem (Yahyaa and Manderick, 2015)
-               https://www.researchgate.net/publication/272823659_Thompson_Sampling_for_Multi-Objective_Multi-Armed_Bandits_Problem
-    """
-
     @validate_call
     def select_action(self, p: Dict[ActionId, List[Probability]], **kwargs) -> ActionId:
         """
@@ -439,7 +534,55 @@ class MultiObjectiveBandit(MultiObjectiveStrategy):
         selected_action: ActionId
             The selected action.
         """
-        return np.random.choice(self.get_pareto_front(p=p))
+        return np.random.choice(self._get_pareto_front(self._alter_p(p, **kwargs)))
+
+    @abstractmethod
+    def _alter_p(self, p: Dict[ActionId, List[Probability]], **kwargs) -> Dict[ActionId, List[Probability]]:
+        """
+        Alter the probability of getting a positive reward for each objective.
+
+        Parameters
+        ----------
+        p : Dict[ActionId, List[Probability]]
+            The dictionary of actions and their sampled probability of getting a positive reward for each objective.
+
+        Returns
+        -------
+        altered_p : Dict[ActionId, List[Probability]]
+            The altered probability of getting a positive reward for each objective.
+        """
+        pass
+
+
+class MultiObjectiveBandit(MultiObjectiveStrategy):
+    """
+    Multi-Objective (MO) strategy for multi-armed bandits.
+
+    The reward pertaining to an action is a multidimensional vector instead of a scalar value. In this setting,
+    different actions are compared according to Pareto order between their expected reward vectors, and those actions
+    whose expected rewards are not inferior to that of any other actions are called Pareto optimal actions, all of which
+    constitute the Pareto front.
+
+    Reference: Thompson Sampling for Multi-Objective Multi-Armed Bandits Problem (Yahyaa and Manderick, 2015)
+               https://www.researchgate.net/publication/272823659_Thompson_Sampling_for_Multi-Objective_Multi-Armed_Bandits_Problem
+    """
+
+    def _alter_p(self, p: Dict[ActionId, List[Probability]], **kwargs) -> Dict[ActionId, List[Probability]]:
+        """
+        Return the probability of getting a positive reward for each objective.
+
+        Parameters
+        ----------
+        p : Dict[ActionId, List[Probability]]
+            The dictionary of actions and their sampled probability of getting a positive reward for each objective.
+
+        Returns
+        -------
+        altered_p : Dict[ActionId, List[Probability]]
+            The dictionary of actions and their sampled probability of getting a positive reward for each objective.
+        """
+        altered_p = p
+        return altered_p
 
 
 class MultiObjectiveCostControlBandit(MultiObjectiveStrategy, CostControlStrategy):
@@ -450,24 +593,76 @@ class MultiObjectiveCostControlBandit(MultiObjectiveStrategy, CostControlStrateg
     the Multi-Objective and Cost Control strategies.
     """
 
+    subsidy_factor: Optional[Union[Float01, List[Beta]]] = 0.5
+    _feasible_actions_losses = PrivateAttr([])
+
     @validate_call
-    def select_action(self, p: Dict[ActionId, List[Probability]], actions: Dict[ActionId, BetaMOCC]) -> ActionId:
+    def select_action(self, p: Dict[ActionId, List[Probability]], actions: Dict[ActionId, Model]) -> ActionId:
         """
-        Select the action with the minimum cost among the Pareto optimal set of action. The Pareto optimal
-        action set (Pareto front) A* is the set of actions not dominated by any other actions not in A*. Dominance
-        relation is established based on the objective reward probabilities vectors.
+        Select an action at random from the Pareto optimal set of action. The Pareto optimal action set (Pareto front)
+        A* is the set of actions not dominated by any other actions not in A*. Dominance relation is established based
+        on the objective reward probabilities vectors.
 
         Parameters
         ----------
-        p: Dict[ActionId, List[Probability]]
+        p : Dict[ActionId, List[Probability]]
              The dictionary of actions and their sampled probability of getting a positive reward for each objective.
+        actions : Dict[ActionId, Model]
+            The dictionary of actions and their associated model.
 
         Returns
         -------
         selected_action: ActionId
             The selected action.
         """
-        pareto_set = self.get_pareto_front(p=p)
+        self._buffer.append([])
 
-        selected_action = self._evaluate_and_select(p, actions, pareto_set)
+        selected_action = super().select_action(p=p, actions=actions)
+
+        for feasible_actions_loss, max_p_action in self._feasible_actions_losses:
+            max_p_action_cost = actions[max_p_action].cost
+            if selected_action in feasible_actions_loss and max_p_action_cost > 0:
+                max_p_action_cost = actions[max_p_action].cost
+                self._buffer[-1].append((1 - self.loss_factor) * actions[selected_action].cost / max_p_action_cost)
+            else:
+                self._buffer[-1].append(None)
         return selected_action
+
+    def _alter_p(
+        self, p: Dict[ActionId, List[Probability]], actions: Dict[ActionId, Model]
+    ) -> Dict[ActionId, List[Probability]]:
+        """
+        Alter the probability of getting a positive reward for each objective. The probability is replaced with the
+        convex combination of the relative cost and the negated normalized expected reward.
+
+        Parameters
+        ----------
+        p : Dict[ActionId, List[Probability]]
+            The dictionary of actions and their sampled probability of getting a positive reward for each objective.
+        actions : Dict[ActionId, Model]
+            The dictionary of actions and their associated model.
+
+        Returns
+        -------
+        altered_p : Dict[ActionId, List[Probability]]
+            The altered probability of getting a positive reward for each objective
+        """
+        self._feasible_actions_losses = []
+        action_ids = p.keys()
+        altered_p = {action_id: [] for action_id in action_ids}
+        for objective_id, single_objective_rewards in enumerate(zip(*p.values())):
+            single_objective_p = dict(zip(action_ids, single_objective_rewards))
+            feasible_actions_loss, max_p_action = self._evaluate_feasible_actions(
+                p=single_objective_p,
+                actions=actions,
+                subsidy_factor=self.subsidy_factor[objective_id]
+                if isinstance(self.subsidy_factor, list)
+                else self.subsidy_factor,
+            )
+            {
+                action_id: altered_p[action_id].append(feasible_actions_loss.get(action_id, float("inf")))
+                for action_id in action_ids
+            }
+
+            self._feasible_actions_losses.append((feasible_actions_loss, max_p_action))
+        return altered_p

--- a/tests/test_mab.py
+++ b/tests/test_mab.py
@@ -39,14 +39,13 @@ class DummyMab(BaseMab):
     epsilon: Optional[Float01] = None
     default_action: Optional[ActionId] = None
 
-    def update(self, actions: List[ActionId], rewards: Union[List[BinaryReward], List[List[BinaryReward]]]):
-        self._validate_update_params(actions=actions, rewards=rewards)
+    def _update(self, actions: List[ActionId], rewards: Union[List[BinaryReward], List[List[BinaryReward]]]):
+        pass
 
-    def predict(
+    def _predict(
         self,
-        forbidden_actions: Optional[Set[ActionId]] = None,
+        valid_actions: Set[ActionId],
     ):
-        valid_actions = self._get_valid_actions(forbidden_actions)
         return np.random.choice(valid_actions)
 
     def get_state(self) -> (str, dict):

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -54,13 +54,11 @@ def test_can_init_classic_bandit():
 )
 def test_select_action_classic_bandit(a_list_str, a_list_float):
     p = dict(zip(a_list_str, a_list_float))
-
     c = ClassicBandit()
     assert max(p, key=p.get) == c.select_action(p=p)
 
 
 ########################################################################################################################
-
 
 # BestActionIdentificationBandit
 
@@ -123,16 +121,19 @@ def test_select_action_logic(a_float1, a_float2, a_float3):
     assert sorted(p.items(), key=lambda x: x[1], reverse=True)[1][0] == mutated_b.select_action(p=p)
 
 
-def test_select_action_logic_all_probs_equal():
-    p = {"a1": 0.5, "a2": 0.5, "a3": 0.5}
-
+@given(
+    st.lists(st.text(min_size=1, alphabet=st.characters(blacklist_categories=("Cc", "Cs"))), min_size=2, unique=True),
+    st.floats(min_value=0, max_value=1, allow_infinity=False, allow_nan=False),
+)
+def test_select_action_logic_all_probs_equal(action_ids, equal_reward):
+    p = {action_id: equal_reward for action_id in action_ids}
     b = BestActionIdentificationBandit(exploit_p=1)
     # if exploit_p is 1 and all probs are equal => return the action with 1st highest prob (max)
-    assert "a1" == b.select_action(p=p)
+    assert action_ids[0] == b.select_action(p=p)
 
     # if exploit_p is 0 => return the action with 2nd highest prob (not 1st highest prob)
     mutated_b = b.with_exploit_p(exploit_p=0)
-    assert "a2" == mutated_b.select_action(p=p)
+    assert action_ids[1] == mutated_b.select_action(p=p)
 
 
 @given(st.builds(Beta), st.builds(Beta), st.builds(Beta))
@@ -141,12 +142,10 @@ def test_compare_best_action(b1, b2, b3):
     actions = {"a1": b1, "a2": b2, "a3": b3}
 
     pval = b.compare_best_actions(actions=actions)
-
     assert pval > 0
 
 
 ########################################################################################################################
-
 
 # CostControlBandit
 
@@ -195,51 +194,68 @@ def test_select_action_cc(a_list_str, a_list_float):
     c.select_action(p=p, actions=a)
 
 
-def test_select_action_logic_cc():
-    actions_cost = {"a1": 10, "a2": 30, "a3": 20, "a4": 10, "a5": 20}
-    p = {"a1": 0.1, "a2": 0.8, "a3": 0.6, "a4": 0.2, "a5": 0.65}
+def test_select_action_logic_cc(
+    actions_cost={"a1": 10, "a2": 30, "a3": 20, "a4": 10, "a5": 20},
+    p={"a1": 0.1, "a2": 0.8, "a3": 0.6, "a4": 0.2, "a5": 0.65},
+):
+    actions = {action_id: BetaCC(cost=cost) for action_id, cost in actions_cost.items()}
 
-    actions = {
-        "a1": BetaCC(cost=actions_cost["a1"]),
-        "a2": BetaCC(cost=actions_cost["a2"]),
-        "a3": BetaCC(cost=actions_cost["a3"]),
-        "a4": BetaCC(cost=actions_cost["a4"]),
-        "a5": BetaCC(cost=actions_cost["a5"]),
-    }
-
+    # if subsidy_factor is 1 => return the action with cheapest cost
     c = CostControlBandit(subsidy_factor=1)
-    # if subsidy_factor is 1 => return the action with min cost and the highest sampled probability
     assert "a4" == c.select_action(p=p, actions=actions)
 
     # if subsidy_factor is 0 => return the action with highest p (classic bandit)
     mutated_c = c.with_subsidy_factor(subsidy_factor=0)
     assert "a2" == mutated_c.select_action(p=p, actions=actions)
 
-    # otherwise, return the cheapest feasible action with the highest sampled probability
+    # # otherwise, return the cheapest feasible action with the highest sampled probability
     mutated_c = c.with_subsidy_factor(subsidy_factor=0.5)
     assert "a5" == mutated_c.select_action(p=p, actions=actions)
 
 
 @given(
-    st.lists(st.floats(min_value=0, max_value=1, allow_infinity=False, allow_nan=False), min_size=3, max_size=3),
-    st.lists(
-        st.floats(min_value=0, allow_infinity=False, allow_nan=False),
+    st.just({"a1": 10, "a2": 30, "a3": 20, "a4": 10, "a5": 20}),
+    st.just({"a1": 0.1, "a2": 0.8, "a3": 0.6, "a4": 0.2, "a5": 0.65}),
+    st.integers(min_value=0, max_value=1),
+    st.floats(min_value=0, max_value=1, allow_infinity=False, allow_nan=False),
+)
+def test_select_action_logic_dynamic_cc(actions_cost, p, rewards, loss_factor):
+    actions = {action_id: BetaCC(cost=cost) for action_id, cost in actions_cost.items()}
+
+    c = CostControlBandit(subsidy_factor=Beta(), loss_factor=loss_factor)
+    # if subsidy_factor is 1 => return the action with min cost and the highest sampled probability
+    c.select_action(p=p, actions=actions)
+    c.update(rewards=[rewards])
+
+    # if subsidy_factor is 0 => return the action with highest p (classic bandit)
+    mutated_c = c.with_subsidy_factor(subsidy_factor=0)
+    mutated_c.select_action(p=p, actions=actions)
+    mutated_c.update(rewards=[rewards])
+
+    # otherwise, return the cheapest feasible action with the highest sampled probability
+    mutated_c = c.with_subsidy_factor(subsidy_factor=0.5)
+    mutated_c.select_action(p=p, actions=actions)
+    mutated_c.update(rewards=[rewards])
+
+
+@given(
+    st.dictionaries(
+        st.text(min_size=1, alphabet=st.characters(blacklist_categories=("Cc", "Cs"))),
+        st.floats(min_value=0, max_value=1),
         min_size=3,
         max_size=3,
     ),
+    st.lists(st.floats(min_value=0, max_value=10, allow_infinity=False, allow_nan=False), min_size=3, max_size=3),
 )
-def test_select_action_logic_corner_cases(a_list_p, a_list_cost):
-    action_ids = ["a1", "a2", "a3"]
+def test_select_action_logic_corner_cases(p, a_list_cost):
+    action_ids = p.keys()
 
-    p = dict(zip(action_ids, a_list_p))
     actions_cost = dict(zip(action_ids, a_list_cost))
-    actions_cost_proba = [(a_cost, -a_proba, a_id) for a_id, a_cost, a_proba in zip(action_ids, a_list_cost, a_list_p)]
+    actions_cost_proba = [
+        (a_cost, -a_proba, a_id) for a_cost, a_proba, a_id in zip(a_list_cost, p.values(), action_ids)
+    ]
 
-    actions = {
-        "a1": BetaCC(cost=actions_cost["a1"]),
-        "a2": BetaCC(cost=actions_cost["a2"]),
-        "a3": BetaCC(cost=actions_cost["a3"]),
-    }
+    actions = {a_id: BetaCC(cost=actions_cost[a_id]) for a_id in action_ids}
 
     c = CostControlBandit(subsidy_factor=1)
     # if cost factor is 1 return:
@@ -262,11 +278,12 @@ def test_select_action_logic_corner_cases(a_list_p, a_list_cost):
     # e.g. p={"a1": 0.5, "a2": 0.5} and cost={"a1": 20, "a2": 10} => return always "a2"
     else:
         actions_cost_max = {k: actions_cost[k] for k in max_p_values}
-        assert min(actions_cost_max, key=actions_cost_max.get) == mutated_c.select_action(p=p, actions=actions)
+        assert min(
+            actions_cost_max, key=lambda action_id: (actions_cost_max[action_id], action_id)
+        ) == mutated_c.select_action(p=p, actions=actions)
 
 
 ########################################################################################################################
-
 
 # MultiObjectiveBandit
 
@@ -284,7 +301,7 @@ def test_can_init_multiobjective():
 )
 def test_select_action_mo(p: Dict[ActionId, List[Probability]]):
     m = MultiObjectiveBandit()
-    assert m.select_action(p=p) in m.get_pareto_front(p=p)
+    assert m.select_action(p=p) in m._get_pareto_front(p=p)
 
 
 def test_pareto_front():
@@ -311,18 +328,15 @@ def test_pareto_front():
         "a6": [0.3, 0.0],
         "a7": [0.1, 0.1],
     }
-
-    assert MultiObjectiveStrategy.get_pareto_front(p2d) == ["a0", "a1", "a4", "a5"]
+    assert MultiObjectiveStrategy._get_pareto_front(p=p2d) == ["a0", "a1", "a4", "a5"]
 
     p2d = {
         "a0": [0.1, 0.1],
         "a1": [0.3, 0.3],
         "a2": [0.3, 0.3],
     }
+    assert MultiObjectiveStrategy._get_pareto_front(p=p2d) == ["a1", "a2"]
 
-    assert MultiObjectiveStrategy.get_pareto_front(p2d) == ["a1", "a2"]
-
-    # works in 3D
     p3d = {
         "a0": [0.1, 0.3, 0.1],
         "a1": [0.1, 0.3, 0.1],
@@ -333,51 +347,64 @@ def test_pareto_front():
         "a6": [0.3, 0.0, 0.1],
         "a7": [0.1, 0.1, 0.3],
     }
-
-    assert MultiObjectiveStrategy.get_pareto_front(p3d) == ["a0", "a1", "a4", "a5", "a7"]
+    assert MultiObjectiveStrategy._get_pareto_front(p=p3d) == ["a0", "a1", "a4", "a5", "a7"]
 
 
 ########################################################################################################################
 
-
 # MultiObjectiveCostControlBandit
 
 
-def test_can_init_multiobjective_mo_cc():
+def test_can_init_mo_cc():
     MultiObjectiveCostControlBandit()
 
 
-def test_select_action_mo_cc():
+@given(
+    st.dictionaries(
+        st.text(min_size=1, alphabet=st.characters(blacklist_categories=("Cc", "Cs"))),
+        st.lists(st.floats(min_value=0, max_value=1), min_size=3, max_size=3),
+        min_size=3,
+        max_size=3,
+    ),
+    st.lists(st.floats(min_value=0, allow_infinity=False, allow_nan=False), min_size=3, max_size=3),
+)
+def test_select_action_mo_cc(p, costs):
     m = MultiObjectiveCostControlBandit()
-
     actions = {
-        "a1": BetaMOCC(counters=[Beta(), Beta(), Beta()], cost=8),
-        "a2": BetaMOCC(counters=[Beta(), Beta(), Beta()], cost=2),
-        "a3": BetaMOCC(counters=[Beta(), Beta(), Beta()], cost=5),
-        "a4": BetaMOCC(counters=[Beta(), Beta(), Beta()], cost=1),
-        "a5": BetaMOCC(counters=[Beta(), Beta(), Beta()], cost=7),
+        action_id: BetaMOCC(counters=[Beta(), Beta(), Beta()], cost=cost) for action_id, cost in zip(p.keys(), costs)
     }
-    p = {
-        "a1": [0.1, 0.3, 0.5],
-        "a2": [0.1, 0.3, 0.5],
-        "a3": [0.0, 0.4, 0.4],
-        "a4": [0.5, 0.3, 0.7],
-        "a5": [0.6, 0.1, 0.5],
-    }
-    # within the pareto front ("a3", "a4", "a5") select the action with min cost ("a4")
-    assert m.get_pareto_front(p) == ["a3", "a4", "a5"]
-    assert m.select_action(p=p, actions=actions) == "a4"
+    assert m._get_pareto_front(p) == m._get_pareto_front(p)
+    m.select_action(p=p, actions=actions)
 
+
+@given(
+    st.dictionaries(
+        st.text(min_size=1, alphabet=st.characters(blacklist_categories=("Cc", "Cs"))),
+        st.lists(st.floats(min_value=0, max_value=1), min_size=3, max_size=3),
+        min_size=3,
+        max_size=3,
+    ),
+    st.lists(
+        st.floats(min_value=0, allow_infinity=False, allow_nan=False),
+        min_size=3,
+        max_size=3,
+    ),
+    st.lists(
+        st.integers(min_value=0, max_value=1),
+        min_size=3,
+        max_size=3,
+    ),
+    st.floats(min_value=0, max_value=1, allow_infinity=False, allow_nan=False),
+)
+def test_select_action_mo_dynamic_cc(p, costs, rewards, loss_factor):
+    m = MultiObjectiveCostControlBandit(subsidy_factor=[Beta() for _ in range(3)], loss_factor=loss_factor)
     actions = {
-        "a1": BetaMOCC(counters=[Beta(), Beta(), Beta()], cost=2),
-        "a2": BetaMOCC(counters=[Beta(), Beta(), Beta()], cost=2),
-        "a3": BetaMOCC(counters=[Beta(), Beta(), Beta()], cost=5),
+        action_id: BetaMOCC(counters=[Beta(), Beta(), Beta()], cost=cost) for action_id, cost in zip(p.keys(), costs)
     }
-    p = {
-        "a1": [0.6, 0.1, 0.1],
-        "a2": [0.5, 0.8, 0.8],
-        "a3": [0.0, 0.1, 0.9],
-    }
-    # within the actions with the min cost ("a1" or "a2") select the action the highest mean of probabilities ("a2")
-    assert m.get_pareto_front(p) == ["a1", "a2", "a3"]
-    assert m.select_action(p=p, actions=actions) == "a2"
+    assert m._get_pareto_front(p) == m._get_pareto_front(p)
+    m.select_action(p=p, actions=actions)
+    m.update(rewards=[rewards])
+
+    assert m._get_pareto_front(p) == m._get_pareto_front(p)
+    m.select_action(p=p, actions=actions)
+    m.update(rewards=[rewards])


### PR DESCRIPTION
### Changes:
* Added update of subsidy factor on MAB update step.
* Added option to allow Beta regime for subsidy factor and added convex combination loss function for determining best action over feasible set.
* Edited MultiObjectiveCostControlBandit on strategy.py to generalize CostControlBandit.
* Edited Base MAB, sMAB, and cMAB classes in mab.py, smab.py, and cmab.py, respectively to reduce duplicated code.
* Added test suite to support the new dynamic CC functionality.