### PR TITLE
Add compatibility for multiple Pydantic versions

### DIFF
--- a/.github/workflows/continuous_delivery.yml
+++ b/.github/workflows/continuous_delivery.yml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ "3.8", "3.9", "3.10" ]
+        pydantic-version: [ "1.10.*", "2.*" ]
 
     steps:
       - name: Checkout repository
@@ -28,6 +29,7 @@ jobs:
           export PATH="$HOME/.poetry/bin:$PATH"
       - name: Install project dependencies with Poetry
         run: |
+          poetry add pydantic@${{ matrix.pydantic-version }}
           poetry install
       - name: Style check
         run: |
@@ -51,14 +53,14 @@ jobs:
             echo "VERSION_CHANGED=true" >> $GITHUB_ENV
           fi
       - name: Create a Git tag
-        if: ${{ env.VERSION_CHANGED == 'true' && matrix.python-version == '3.8' }}
+        if: ${{ env.VERSION_CHANGED == 'true' && matrix.python-version == '3.8' && matrix.pydantic-version == '2.*' }}
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "GitHub Actions"
           git tag "${{ env.PACKAGE_VERSION }}"
           git push origin "${{ env.PACKAGE_VERSION }}"
       - name: Publish Draft Release
-        if: ${{ env.VERSION_CHANGED == 'true' && matrix.python-version == '3.8' }}
+        if: ${{ env.VERSION_CHANGED == 'true' && matrix.python-version == '3.8' && matrix.pydantic-version == '2.*' }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -83,7 +85,7 @@ jobs:
               core.setFailed(`Draft release named "Draft" not found.`);
             };
       - name: Build and publish to pypi
-        if: ${{ env.VERSION_CHANGED == 'true' && matrix.python-version == '3.8' }}
+        if: ${{ env.VERSION_CHANGED == 'true' && matrix.python-version == '3.8' && matrix.pydantic-version == '2.*' }}
         run: |
           poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
           poetry publish --build

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -21,6 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ "3.8", "3.9", "3.10" ]
+        pydantic-version: [ "1.10.*", "2.*" ]
 
     steps:
       - name: Checkout repository
@@ -36,6 +37,7 @@ jobs:
           export PATH="$HOME/.poetry/bin:$PATH"
       - name: Install project dependencies with Poetry
         run: |
+          poetry add pydantic@${{ matrix.pydantic-version }}
           poetry install
       - name: Style check
         run: |

--- a/pybandits/cmab.py
+++ b/pybandits/cmab.py
@@ -25,11 +25,11 @@ from typing import Dict, List, Optional, Set, Union
 from numpy import array
 from numpy.random import choice
 from numpy.typing import ArrayLike
-from pydantic import field_validator, validate_call
 
 from pybandits.base import ActionId, BinaryReward, CmabPredictions
 from pybandits.mab import BaseMab
 from pybandits.model import BayesianLogisticRegression, BayesianLogisticRegressionCC
+from pybandits.pydantic_version_compatibility import field_validator, validate_call
 from pybandits.strategy import (
     BestActionIdentificationBandit,
     ClassicBandit,

--- a/pybandits/pydantic_version_compatibility.py
+++ b/pybandits/pydantic_version_compatibility.py
@@ -1,0 +1,268 @@
+# MIT License
+#
+# Copyright (c) 2023 Playtika Ltd.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+This snippet is a compatibility layer for pydantic v1 and v2.
+"""
+
+from typing import Any, Callable, Dict, Literal, Optional, Union
+from warnings import warn
+
+from pydantic import BaseModel, Field, NonNegativeFloat, PositiveInt, ValidationError, confloat, conint, constr
+from pydantic.version import VERSION as _VERSION
+
+# Define the pydantic versions
+PYDANTIC_VERSION_1 = "1"
+PYDANTIC_VERSION_2 = "2"
+
+
+def _get_major_pydantic_version():
+    """
+    Get the major version of pydantic.
+
+    Returns
+    -------
+    major_version : str
+        The major version of pydantic.
+    """
+    try:
+        major_version = _VERSION.split(".")[0]
+        return major_version
+    except Exception as e:
+        raise ValueError(f"Error getting Pydantic version: {e}")
+
+
+pydantic_version = _get_major_pydantic_version()
+
+if pydantic_version == PYDANTIC_VERSION_1:
+    from pydantic import root_validator, validate_arguments, validator
+    from pydantic.typing import AnyCallable as _AnyCallable
+
+    # In pydantic v1, the field, model, and call validators are defined differently
+    def field_validator(
+        field: str,
+        /,
+        *fields: str,
+        mode: Literal["after", "before"] = "after",
+        check_fields: bool = True,
+    ):
+        """
+        Decorate methods on the class indicating that they should be used to validate fields.
+
+        Example usage:
+        ```py
+        from typing import Any
+
+        from pybandits.pydantic_version_compatibility import (
+            BaseModel,
+            ValidationError,
+            field_validator,
+        )
+
+        class Model(BaseModel):
+            a: str
+
+            @field_validator('a')
+            @classmethod
+            def ensure_foobar(cls, v: Any):
+                if 'foobar' not in v:
+                    raise ValueError('"foobar" not found in a')
+                return v
+
+        print(repr(Model(a='this is foobar good')))
+        #> Model(a='this is foobar good')
+
+        try:
+            Model(a='snap')
+        except ValidationError as exc_info:
+            print(exc_info)
+            '''
+            1 validation error for Model
+            a
+              Value error, "foobar" not found in a [type=value_error, input_value='snap', input_type=str]
+            '''
+        ```
+
+        For more in depth examples, see [Field Validators](../concepts/validators.md#field-validators).
+
+        Args:
+            field: The first field the `field_validator` should be called on; this is separate
+                from `fields` to ensure an error is raised if you don't pass at least one.
+            *fields: Additional field(s) the `field_validator` should be called on.
+            mode: Specifies whether to validate the fields before or after validation.
+            check_fields: Whether to check that the fields actually exist on the model.
+
+        Returns:
+            A decorator that can be used to decorate a function to be used as a field_validator.
+
+        Raises:
+            PydanticUserError:
+                - If `@field_validator` is used bare (with no fields).
+                - If the args passed to `@field_validator` as fields are not strings.
+                - If `@field_validator` applied to instance methods.
+        """
+        pre = mode == "before"
+        fields = field, *fields
+        return validator(*fields, pre=pre, check_fields=check_fields)
+
+    def model_validator(
+        *,
+        mode: Literal["before", "after"],
+    ) -> Any:
+        """
+        Decorate model methods for validation purposes.
+
+        Example usage:
+        ```py
+        from typing_extensions import Self
+
+        from pybandits.pydantic_version_compatibility import BaseModel, ValidationError, model_validator
+
+        class Square(BaseModel):
+            width: float
+            height: float
+
+            @model_validator(mode='after')
+            def verify_square(self) -> Self:
+                if self.width != self.height:
+                    raise ValueError('width and height do not match')
+                return self
+
+        s = Square(width=1, height=1)
+        print(repr(s))
+        #> Square(width=1.0, height=1.0)
+
+        try:
+            Square(width=1, height=2)
+        except ValidationError as e:
+            print(e)
+            '''
+            1 validation error for Square
+              Value error, width and height do not match [type=value_error, input_value={'width': 1, 'height': 2}, input_type=dict]
+            '''
+        ```
+
+        For more in depth examples, see [Model Validators](../concepts/validators.md#model-validators).
+
+        Parameters
+        ----------
+        mode: Literal["before", "after"]
+            A required string literal that specifies the validation mode.
+            It can be one of the following: 'before', or 'after'.
+
+        Returns
+        -------
+        A decorator that can be used to decorate a function to be used as a model validator.
+        """
+        pre = mode == "before"
+        return root_validator(pre=pre)
+
+    def validate_call(
+        func: Optional[_AnyCallable] = None,
+        /,
+        *,
+        config: Optional[Dict] = None,
+        validate_return: bool = False,
+    ) -> Union[_AnyCallable, Callable[[_AnyCallable], _AnyCallable]]:
+        """
+        Returns a decorated wrapper around the function that validates the arguments and, optionally, the return value.
+        Usage may be either as a plain decorator `@validate_call` or with arguments `@validate_call(...)`.
+
+        Parameters
+        ----------
+        func : Optional[_AnyCallable], defaults to None
+            The function to be decorated.
+        config: Optional[Dict], defaults to None
+            The configuration dictionary.
+        validate_return: bool
+            Whether to validate the return value.
+            Placeholder for pydantic v2 compatibility, as this functionality is absent in v1.
+
+        Returns
+        -------
+        Union[_AnyCallable, Callable[[_AnyCallable], _AnyCallable]]
+            The decorated function.
+        """
+        if not hasattr(validate_call, "warning_raised") and validate_return:
+            warn("validate_return is not supported in pydantic v1", UserWarning)
+            validate_call.warning_raised = True
+
+        for v1_name, v2_name in [
+            ("allow_population_by_field_name", "populate_by_name"),
+            ("anystr_lower", "str_to_lower"),
+            ("anystr_strip_whitespace", "str_strip_whitespace"),
+            ("anystr_upper", "str_to_upper"),
+            ("keep_untouched", "ignored_types"),
+            ("max_anystr_length", "str_max_length"),
+            ("min_anystr_length", "str_min_length"),
+            ("orm_mode", "from_attributes"),
+            ("schema_extra", "json_schema_extra"),
+            ("validate_all", "validate_default"),
+        ]:
+            config = _convert_config_param(config, v2_name, v1_name)
+
+        return validate_arguments(func=func, config=config)
+
+    def _convert_config_param(config: Dict[str, Any], v2_name: str, v1_name: str) -> Dict[str, Any]:
+        """
+        Convert a config parameter from v2 to v1.
+
+        Parameters
+        ----------
+        config : Dict[str, Any]
+            The dictionary of configuration parameters.
+        v2_name : str
+            The v2 name of the configuration parameter.
+        v1_name : str
+            The v1 name of the configuration parameter.
+
+        Returns
+        -------
+        config : Dict[str, Any]
+            The converted dictionary of configuration parameters.
+        """
+        if config is not None and v2_name in config:
+            config[v1_name] = config.pop(v2_name)
+        return config
+
+elif pydantic_version == PYDANTIC_VERSION_2:
+    from pydantic import (
+        field_validator,
+        model_validator,
+        validate_call,
+    )
+else:
+    raise ImportError(f"Unsupported pydantic version: {pydantic_version}")
+
+__all__ = [
+    "field_validator",
+    "model_validator",
+    "validate_call",
+    "NonNegativeFloat",
+    "PositiveInt",
+    "BaseModel",
+    "ValidationError",
+    "confloat",
+    "conint",
+    "constr",
+    "Field",
+]

--- a/pybandits/smab.py
+++ b/pybandits/smab.py
@@ -24,8 +24,6 @@
 from collections import defaultdict
 from typing import Dict, List, Optional, Set, Union
 
-from pydantic import PositiveInt, field_validator, validate_call
-
 from pybandits.base import (
     ActionId,
     BinaryReward,
@@ -34,6 +32,7 @@ from pybandits.base import (
 )
 from pybandits.mab import BaseMab
 from pybandits.model import BaseBeta, Beta, BetaCC, BetaMO, BetaMOCC
+from pybandits.pydantic_version_compatibility import PositiveInt, field_validator, validate_call
 from pybandits.strategy import (
     BestActionIdentificationBandit,
     ClassicBandit,

--- a/pybandits/strategy.py
+++ b/pybandits/strategy.py
@@ -25,12 +25,12 @@ from random import random
 from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
-from pydantic import field_validator, validate_call
 from scipy.stats import ttest_ind_from_stats
 from typing_extensions import Self
 
 from pybandits.base import ActionId, Float01, Probability, PyBanditsBaseModel
 from pybandits.model import Beta, BetaMOCC, Model
+from pybandits.pydantic_version_compatibility import field_validator, validate_call
 
 
 class Strategy(PyBanditsBaseModel, ABC):
@@ -54,7 +54,9 @@ class Strategy(PyBanditsBaseModel, ABC):
         mutated_strategy: Strategy
             The mutated strategy.
         """
-        mutated_strategy = self.model_copy(update={argument_name: argument_value}, deep=True)
+        mutated_strategy = self._apply_version_adjusted_method(
+            "model_copy", "copy", update={argument_name: argument_value}
+        )
         return mutated_strategy
 
     @abstractmethod

--- a/pybandits/utils.py
+++ b/pybandits/utils.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Callable, Dict, List, Union
 
-from pydantic import validate_call
+from pybandits.pydantic_version_compatibility import validate_call
 
 JSONSerializable = Union[str, int, float, bool, None, List["JSONSerializable"], Dict[str, "JSONSerializable"]]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybandits"
-version = "1.0.0"
+version = "1.0.1"
 description = "Python Multi-Armed Bandit Library"
 authors = [
     "Dario d'Andrea <dariod@playtika.com>",
@@ -16,7 +16,7 @@ readme = "README.md"
 python = ">=3.8.1,<3.12"
 loguru = "^0.6"
 numpy = "^1.23"
-pydantic = "^2.0"
+pydantic = "1.10.0"
 scipy = "^1.9"
 pymc = "^5.3"
 scikit-learn = "^1.1"

--- a/tests/test_mab.py
+++ b/tests/test_mab.py
@@ -26,12 +26,12 @@ import hypothesis.strategies as st
 import numpy as np
 import pytest
 from hypothesis import given
-from pydantic import ValidationError
 from pytest_mock import MockerFixture
 
 from pybandits.base import ACTION_IDS_PREFIX, ActionId, BinaryReward, Float01, Probability
 from pybandits.mab import BaseMab
 from pybandits.model import Beta, BetaCC
+from pybandits.pydantic_version_compatibility import ValidationError
 from pybandits.strategy import ClassicBandit
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -25,7 +25,6 @@ import pandas as pd
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
-from pydantic import ValidationError
 
 from pybandits.model import (
     BayesianLogisticRegression,
@@ -36,6 +35,7 @@ from pybandits.model import (
     BetaMOCC,
     StudentT,
 )
+from pybandits.pydantic_version_compatibility import ValidationError
 
 ########################################################################################################################
 

--- a/tests/test_python_version_compatability.py
+++ b/tests/test_python_version_compatability.py
@@ -1,0 +1,52 @@
+from typing import List
+
+import pytest
+
+from pybandits.base import PyBanditsBaseModel
+from pybandits.pydantic_version_compatibility import (
+    PYDANTIC_VERSION_1,
+    PYDANTIC_VERSION_2,
+    field_validator,
+    model_validator,
+    pydantic_version,
+    validate_call,
+)
+
+
+def test_pydantic_version_compatibility():
+    assert pydantic_version in [PYDANTIC_VERSION_1, PYDANTIC_VERSION_2]
+
+
+def test_dummy_pybandits_model():
+    class DummyPyBanditsModel(PyBanditsBaseModel):
+        a: int
+        b: float
+
+        @field_validator("a")
+        @classmethod
+        def check_even_a(cls, value):
+            if value % 2 != 0:
+                raise ValueError("a must be even")
+            return value
+
+        @model_validator(mode="before")
+        @classmethod
+        def check_a_ge_b(cls, values):
+            if values["b"] > values["a"]:
+                raise ValueError("a must be greater than or equal to b")
+            return values
+
+        @validate_call
+        def add(self, addends: List[float]):
+            return self.a + sum(addends)
+
+    with pytest.raises(ValueError):
+        DummyPyBanditsModel(a=1, b=0.0)
+    with pytest.raises(ValueError):
+        DummyPyBanditsModel(a=0, b=1.0)
+
+    dummy_model = DummyPyBanditsModel(a=0, b=0.0)
+    with pytest.raises(ValueError):
+        dummy_model.add(addends=0.5)
+
+    dummy_model.add(addends=[1.0])

--- a/tests/test_smab.py
+++ b/tests/test_smab.py
@@ -27,10 +27,10 @@ from typing import List
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
-from pydantic import NonNegativeFloat, ValidationError
 
 from pybandits.base import BinaryReward, Float01
 from pybandits.model import Beta, BetaCC, BetaMO, BetaMOCC
+from pybandits.pydantic_version_compatibility import NonNegativeFloat, ValidationError
 from pybandits.smab import SmabBernoulli, SmabBernoulliBAI, SmabBernoulliCC, SmabBernoulliMO, SmabBernoulliMOCC
 from pybandits.strategy import (
     ClassicBandit,

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -26,10 +26,10 @@ import numpy as np
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
-from pydantic import ValidationError
 
 from pybandits.base import ActionId, Probability
 from pybandits.model import Beta, BetaCC, BetaMOCC
+from pybandits.pydantic_version_compatibility import ValidationError
 from pybandits.strategy import (
     BestActionIdentificationBandit,
     ClassicBandit,


### PR DESCRIPTION
 ### Changes:
 * Add pydantic_version_compact.py with `get_major_pydantic_version` function to handle version-specific logic.
 * Updated test cases to use `pydantic_version_compact` for version compatibility.
 * Adjusted error handling in tests to accommodate different Pydantic versions.
 * Refactored imports and added necessary logic to support both Pydantic v1 and v2.
 * Updated continuous integration and delivery workflows to test for both version of pydantic.