### PR TITLE
Add private numpy array attributes and initialize them in StudentTArray

### DIFF
--- a/pybandits/model.py
+++ b/pybandits/model.py
@@ -273,6 +273,20 @@ class StudentTArray(PyBanditsBaseModel):
     sigma: Union[List[NonNegativeFloat], List[List[NonNegativeFloat]]]
     nu: Union[List[PositiveFloat], List[List[PositiveFloat]]]
 
+    _mu_array: np.ndarray = PrivateAttr()
+    _sigma_array: np.ndarray = PrivateAttr()
+    _nu_array: np.ndarray = PrivateAttr()
+    _params: Dict[str, np.ndarray] = PrivateAttr()
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, StudentTArray):
+            return False
+        return (
+            np.all(self._mu_array == other._mu_array)
+            and np.all(self._sigma_array == other._sigma_array)
+            and np.all(self._nu_array == other._nu_array)
+        )
+
     @staticmethod
     def maybe_convert_list_to_array(input_list: Union[List[float], List[List[float]]]) -> bool:
         if len(input_list) == 0:
@@ -336,13 +350,43 @@ class StudentTArray(PyBanditsBaseModel):
         nu = np.full(shape, nu)
         return cls(mu=mu, sigma=sigma, nu=nu)
 
-    @property
-    def shape(self) -> Tuple[PositiveInt, ...]:
-        return np.array(self.mu).shape
+    def model_post_init(self, __context: Any) -> None:
+        """
+        Initialize private numpy array attributes by converting lists to arrays once at initialization.
+
+        Parameters
+        ----------
+        __context : Any
+            Pydantic context (unused).
+        """
+        self._mu_array = np.array(self.mu)
+        self._sigma_array = np.array(self.sigma)
+        self._nu_array = np.array(self.nu)
+        self._params = dict(mu=self._mu_array, sigma=self._sigma_array, nu=self._nu_array)
 
     @property
-    def params(self):
-        return dict(mu=np.array(self.mu), sigma=np.array(self.sigma), nu=np.array(self.nu))
+    def shape(self) -> Tuple[PositiveInt, ...]:
+        """
+        Get the shape of the mu array.
+
+        Returns
+        -------
+        Tuple[PositiveInt, ...]
+            The shape of the mu array.
+        """
+        return self._mu_array.shape
+
+    @property
+    def params(self) -> Dict[str, np.ndarray]:
+        """
+        Get the parameters as a dictionary of numpy arrays.
+
+        Returns
+        -------
+        Dict[str, np.ndarray]
+            Dictionary containing 'mu', 'sigma', and 'nu' as numpy arrays.
+        """
+        return self._params
 
 
 class BnnLayerParams(PyBanditsBaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybandits"
-version = "4.0.15"
+version = "4.0.16"
 description = "Python Multi-Armed Bandit Library"
 authors = [
     "Dario d'Andrea <dariod@playtika.com>",


### PR DESCRIPTION
### Changes:
* Introduced private attributes `_mu_array`, `_sigma_array`, and `_nu_array` to store numpy arrays.
* Added `model_post_init` method to convert lists to numpy arrays during initialization.
* Updated `shape` and `params` properties to utilize the new private attributes for improved performance and clarity.
