### PR TITLE
Enhance Bayesian Neural Network with Layerwise Scaling Support and Early Stopping

### DIFF
--- a/pybandits/model.py
+++ b/pybandits/model.py
@@ -33,6 +33,7 @@ from pymc import Bernoulli, Data, Deterministic, Minibatch, fit, math, sample
 from pymc import Model as PymcModel
 from pymc import Normal as PymcNormal
 from pymc import StudentT as PymcStudentT
+from pymc.variational.callbacks import CheckParametersConvergence
 from scipy.special import erf
 from scipy.stats import norm, t
 from typing_extensions import Self
@@ -539,6 +540,90 @@ class BaseLocationScaleArray(PyBanditsBaseModel, ABC):
             and type(self) is type(other)
         )
 
+    @classmethod
+    def cold_start(
+        cls,
+        shape: Union[PositiveInt, Tuple[PositiveInt, ...]],
+        mu: float = 0.0,
+        sigma: NonNegativeFloat = 10.0,
+        use_layerwise_scaling: bool = False,
+        **kwargs,
+    ) -> "BaseLocationScaleArray":
+        """
+        Template method for cold start initialization.
+
+        Common logic for shape normalization, validation, and parameter array creation
+        is handled here. Subclasses override `_get_distribution_specific_params` to
+        provide distribution-specific parameters.
+
+        Parameters
+        ----------
+        shape : Union[PositiveInt, Tuple[PositiveInt, ...]]
+            Dimensions of the distribution array.
+        mu : float
+            Mean of the distribution, by default 0.0.
+        sigma : NonNegativeFloat
+            Standard deviation of the distribution, by default 10.0.
+        use_layerwise_scaling : bool
+            Whether to use layerwise scaling in the network (default is False).
+            When applied, the sigma is scaled by the square root of the input dimension.
+            This is useful to enable smoother convergence with Gaussian Process-like behavior.
+        **kwargs
+            Additional keyword arguments for distribution-specific parameters
+            (e.g., `nu` for StudentTArray).
+
+        Returns
+        -------
+        BaseLocationScaleArray
+            An instance of the distribution array with the specified parameters.
+
+        Raises
+        ------
+        ValueError
+            If shape has empty dimensions.
+        """
+        if isinstance(shape, int):
+            shape = (shape,)
+
+        if any(dim_len == 0 for dim_len in shape):
+            raise ValueError("shape must have at least one element in every dimension.")
+
+        mu_array = np.full(shape, mu)
+        sigma_array = np.full(shape, sigma / np.sqrt(shape[0]) if use_layerwise_scaling else sigma)
+
+        # Get distribution-specific parameters from subclass
+        dist_params = cls._get_distribution_specific_params(shape, **kwargs)
+
+        return cls(mu=mu_array, sigma=sigma_array, **dist_params)
+
+    @classmethod
+    @abstractmethod
+    def _get_distribution_specific_params(cls, shape: Tuple[PositiveInt, ...], **kwargs) -> Dict[str, np.ndarray]:
+        """
+        Get distribution-specific parameters for cold start initialization.
+
+        Subclasses must implement this method to provide distribution-specific
+        parameters (e.g., `nu` for StudentTArray).
+
+        Note: Subclasses can omit `**kwargs` from their signature if they don't
+        need to accept additional parameters. This provides stricter validation
+        by raising TypeError for unexpected arguments.
+
+        Parameters
+        ----------
+        shape : Tuple[PositiveInt, ...]
+            Shape of the distribution array.
+        **kwargs
+            Additional keyword arguments containing distribution-specific parameters.
+            May be omitted in subclass implementations if not needed.
+
+        Returns
+        -------
+        Dict[str, np.ndarray]
+            Dictionary mapping parameter names to numpy arrays of the specified shape.
+        """
+        pass
+
 
 class StudentTArray(BaseLocationScaleArray):
     """
@@ -577,23 +662,25 @@ class StudentTArray(BaseLocationScaleArray):
         return super().__eq__(other) and np.all(self._nu_array == other._nu_array)
 
     @classmethod
-    def cold_start(
-        cls,
-        shape: Union[PositiveInt, Tuple[PositiveInt, ...]],
-        mu: float = 0.0,
-        sigma: NonNegativeFloat = 10.0,
-        nu: PositiveFloat = 5.0,
-    ) -> "StudentTArray":
-        if isinstance(shape, int):
-            shape = (shape,)
+    def _get_distribution_specific_params(
+        cls, shape: Tuple[PositiveInt, ...], nu: PositiveFloat = 5.0
+    ) -> Dict[str, np.ndarray]:
+        """
+        Get distribution-specific parameters for Student's t-distribution.
 
-        if any(dim_len == 0 for dim_len in shape):
-            raise ValueError("shape of mu, sigma, and nu must have at least one element in every dimension.")
+        Parameters
+        ----------
+        shape : Tuple[PositiveInt, ...]
+            Shape of the distribution array.
+        nu : PositiveFloat
+            Degrees of freedom of the Student's t-distribution, by default 5.0.
 
-        mu = np.full(shape, mu)
-        sigma = np.full(shape, sigma)
-        nu = np.full(shape, nu)
-        return cls(mu=mu, sigma=sigma, nu=nu)
+        Returns
+        -------
+        Dict[str, np.ndarray]
+            Dictionary containing 'nu' parameter as a numpy array.
+        """
+        return {"nu": np.full(shape, nu)}
 
     def model_post_init(self, __context: Any) -> None:
         """
@@ -674,38 +761,24 @@ class NormalArray(BaseLocationScaleArray):
     _pymc_class: ClassVar[type] = PymcNormal
 
     @classmethod
-    def cold_start(
-        cls,
-        shape: Union[PositiveInt, Tuple[PositiveInt, ...]],
-        mu: float = 0.0,
-        sigma: NonNegativeFloat = 10.0,
-    ) -> "NormalArray":
+    def _get_distribution_specific_params(cls, shape: Tuple[PositiveInt, ...]) -> Dict[str, np.ndarray]:
         """
-        Create a NormalArray with the specified parameters.
+        Get distribution-specific parameters for Normal distribution.
+
+        Normal distributions only require mu and sigma, which are handled
+        by the base class, so this method returns an empty dictionary.
 
         Parameters
         ----------
-        shape : Union[PositiveInt, Tuple[PositiveInt, ...]]
-            Shape of the array.
-        mu : float, optional
-            Mean value, by default 0.0.
-        sigma : NonNegativeFloat, optional
-            Standard deviation value, by default 10.0.
+        shape : Tuple[PositiveInt, ...]
+            Shape of the distribution array.
 
         Returns
         -------
-        NormalArray
-            A NormalArray instance with the specified parameters.
+        Dict[str, np.ndarray]
+            Empty dictionary (no additional parameters needed for Normal distribution).
         """
-        if isinstance(shape, int):
-            shape = (shape,)
-
-        if any(dim_len == 0 for dim_len in shape):
-            raise ValueError("shape of mu and sigma must have at least one element in every dimension.")
-
-        mu = np.full(shape, mu)
-        sigma = np.full(shape, sigma)
-        return cls(mu=mu, sigma=sigma)
+        return {}
 
     def sample_rvs(self, size: Tuple[int, ...]) -> np.ndarray:
         """
@@ -796,6 +869,9 @@ class BaseBayesianNeuralNetwork(Model, ABC):
     use_residual_connections : bool, optional
         Whether to use residual connections in the network. Residual connections are only added when
         the layer output dimension is greater than or equal to the input dimension (default is False).
+    early_stopping_config : Optional[EarlyStoppingConfig], optional
+        Configuration for early stopping during VI training. If None, no early stopping is used (default is None).
+        Only applicable when update_method is "VI".
 
     Examples
     --------
@@ -829,7 +905,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
     _prob_var_name: ClassVar[str] = "prob"
     _weight_var_name: ClassVar[str] = "weight"
     _bias_var_name: ClassVar[str] = "bias"
-    _vi_update_params: ClassVar[list] = ["optimizer_type", "optimizer_kwargs", "batch_size"]
+    _vi_update_params: ClassVar[list] = ["optimizer_type", "optimizer_kwargs", "batch_size", "early_stopping_kwargs"]
     _distribution_mapping: ClassVar[Dict[str, type]] = {"normal": NormalArray, "studentt": StudentTArray}
     _supported_optimizers: ClassVar[list] = [
         "sgd",
@@ -854,7 +930,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         "gelu": _numpy_gelu,
     }
 
-    update_method: str = "VI"
+    update_method: UpdateMethods = "VI"
     update_kwargs: Optional[dict] = None
     activation: ActivationFunctions = "tanh"
     use_residual_connections: bool = False
@@ -875,79 +951,12 @@ class BaseBayesianNeuralNetwork(Model, ABC):
     _approx_history: np.ndarray = PrivateAttr(None)
     _numpy_activation_fn: Callable = PrivateAttr(None)
     _pymc_activation_fn: Callable = PrivateAttr(None)
+    _obj_optimizer: Optional[Callable] = PrivateAttr(None)
+    _early_stopping_callback: Optional[CheckParametersConvergence] = PrivateAttr(None)
+    _update_kwargs: Dict[str, Any] = PrivateAttr(default_factory=dict)
 
     class Config:
         arbitrary_types_allowed = True
-
-    if pydantic_version == PYDANTIC_VERSION_1:
-
-        @model_validator(mode="before")
-        @classmethod
-        def arrange_update_kwargs(cls, values):
-            update_kwargs = cls._get_value_with_default("update_kwargs", values)
-            update_method = cls._get_value_with_default("update_method", values)
-
-            if update_kwargs is None:
-                update_kwargs = dict()
-
-            if update_method == "VI":
-                update_kwargs["fit"] = {**cls._default_variational_inference_fit_kwargs, **update_kwargs.get("fit", {})}
-                optimizer_type = update_kwargs.get("optimizer_type", None)
-
-                if optimizer_type is not None:
-                    if optimizer_type not in cls._supported_optimizers:
-                        raise ValueError(
-                            f"Invalid optimizer type: {optimizer_type}. Supported optimizers are: {cls._supported_optimizers}"
-                        )
-
-            elif update_method == "MCMC":
-                for param in cls._vi_update_params:
-                    if param in update_kwargs:
-                        raise ValueError(
-                            f"Invalid update MCMC parameter: {param}. {cls._vi_update_params} are VI parameters."
-                        )
-
-                update_kwargs["trace"] = {**cls._default_mcmc_trace_kwargs, **update_kwargs.get("trace", {})}
-            else:
-                raise ValueError("Invalid update method.")
-
-            values["update_kwargs"] = update_kwargs
-            values["update_method"] = update_method
-            return values
-
-    elif pydantic_version == PYDANTIC_VERSION_2:
-
-        @model_validator(mode="after")
-        def arrange_update_kwargs(self):
-            if self.update_kwargs is None:
-                self.update_kwargs = dict()
-
-            if self.update_method == "VI":
-                self.update_kwargs["fit"] = {
-                    **self._default_variational_inference_fit_kwargs,
-                    **self.update_kwargs.get("fit", {}),
-                }
-                optimizer_type = self.update_kwargs.get("optimizer_type", None)
-                if optimizer_type is not None:
-                    if optimizer_type not in self._supported_optimizers:
-                        raise ValueError(
-                            f"Invalid optimizer type: {optimizer_type}. Supported optimizers are: {self._supported_optimizers}"
-                        )
-
-            elif self.update_method == "MCMC":
-                for param in self._vi_update_params:
-                    if param in self.update_kwargs:
-                        raise ValueError(
-                            f"Invalid update MCMC parameter: {param}. {self._vi_update_params} are VI parameters."
-                        )
-
-                self.update_kwargs["trace"] = {**self._default_mcmc_trace_kwargs, **self.update_kwargs.get("trace", {})}
-            else:
-                raise ValueError("Invalid update method.")
-            return self
-
-    else:
-        raise ValueError(f"Unsupported pydantic version: {pydantic_version}")
 
     @field_validator("activation")
     @classmethod
@@ -962,17 +971,38 @@ class BaseBayesianNeuralNetwork(Model, ABC):
     def approx_history(self) -> Optional[np.ndarray]:
         return self._approx_history
 
-    @property
-    def optimizer(self) -> Callable:
+    def _get_obj_optimizer(self) -> Optional[Callable]:
+        if self.update_kwargs is None:
+            return None
         optimizer_type = self.update_kwargs.get("optimizer_type", None)
         if optimizer_type is not None:
+            if optimizer_type not in self._supported_optimizers:
+                raise ValueError(
+                    f"Invalid optimizer type: {optimizer_type}. Supported optimizers are: {self._supported_optimizers}"
+                )
             optimizer = getattr(pymc, optimizer_type)
             optimizer_kwargs = self.update_kwargs.get("optimizer_kwargs", {})
-            _optimizer = optimizer(**optimizer_kwargs)
+            try:
+                _optimizer = optimizer(**optimizer_kwargs)
+            except (TypeError, ValueError, KeyError) as e:
+                raise e.__class__(f"Invalid optimizer kwargs: {optimizer_kwargs}.\n{e}")
         else:
             _optimizer = None
 
         return _optimizer
+
+    def _get_early_stopping_callback(self) -> Optional[CheckParametersConvergence]:
+        if self.update_kwargs is None:
+            return None
+        early_stopping_kwargs = self.update_kwargs.get("early_stopping_kwargs", None)
+        if early_stopping_kwargs is not None:
+            try:
+                early_stopping_callback = CheckParametersConvergence(**early_stopping_kwargs)
+            except (TypeError, ValueError, KeyError) as e:
+                raise e.__class__(f"Invalid early stopping kwargs: {early_stopping_kwargs}.\n{e}")
+        else:
+            early_stopping_callback = None
+        return early_stopping_callback
 
     @classmethod
     def get_layer_params_name(cls, layer_ind: PositiveInt) -> Tuple[str, str]:
@@ -984,7 +1014,8 @@ class BaseBayesianNeuralNetwork(Model, ABC):
     def create_model_params(
         cls,
         n_features: PositiveInt,
-        hidden_dim_list: List[PositiveInt],
+        hidden_dim_list: Optional[List[PositiveInt]],
+        use_layerwise_scaling: bool = False,
         dist_class: type[BaseLocationScaleArray] = StudentTArray,
         **dist_params_init,
     ) -> BnnParams:
@@ -998,13 +1029,16 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         ----------
         n_features : PositiveInt
             The number of input features for the BNN.
-        hidden_dim_list : List[PositiveInt]
+        hidden_dim_list : Optional[List[PositiveInt]]
             A list of integers specifying the number of hidden units in each hidden layer.
             If None, no hidden layers are added.
+        use_layerwise_scaling : bool
+            Whether to use layerwise scaling in the network (default is False).
         dist_class : type[BaseLocationScaleArray], optional
             The distribution class to use (StudentTArray or NormalArray), by default StudentTArray.
         **dist_params_init : dict, optional
             Additional parameters for initializing the distribution of weights and biases.
+
         Returns
         -------
         BnnParams
@@ -1022,7 +1056,9 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         for layer_ind in range(len(_dim_list) - 1):
             input_dim = _dim_list[layer_ind]
             output_dim = _dim_list[layer_ind + 1]
-            w_param = dist_class.cold_start(shape=(input_dim, output_dim), **dist_params_init)
+            w_param = dist_class.cold_start(
+                shape=(input_dim, output_dim), use_layerwise_scaling=use_layerwise_scaling, **dist_params_init
+            )
             b_param = dist_class.cold_start(shape=output_dim, **dist_params_init)
             layer_params_init.append(BnnLayerParams(weight=w_param, bias=b_param))
 
@@ -1067,6 +1103,27 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         """
         return self.model_params.bnn_layer_params[0].weight.shape[0]
 
+    def _arrange_update_kwargs(self):
+        if self.update_kwargs is None:
+            self.update_kwargs = dict()
+
+        if self.update_method == "VI":
+            self.update_kwargs["fit"] = {
+                **self._default_variational_inference_fit_kwargs,
+                **self.update_kwargs.get("fit", {}),
+            }
+
+        elif self.update_method == "MCMC":
+            for param in self._vi_update_params:
+                if param in self.update_kwargs:
+                    raise ValueError(
+                        f"Invalid update MCMC parameter: {param}. {self._vi_update_params} are VI parameters."
+                    )
+
+            self.update_kwargs["trace"] = {**self._default_mcmc_trace_kwargs, **self.update_kwargs.get("trace", {})}
+        else:
+            raise ValueError("Invalid update method.")
+
     def model_post_init(self, __context: Any) -> None:
         """
         Initialize activation function PrivateAttr based on the activation setting.
@@ -1074,6 +1131,14 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         # Initialize activation functions (always set to ensure they're available after model_copy)
         self._numpy_activation_fn = self._numpy_activations[self.activation]
         self._pymc_activation_fn = self._pymc_activations[self.activation]
+        self._arrange_update_kwargs()
+        self._obj_optimizer = self._get_obj_optimizer()
+        self._early_stopping_callback = self._get_early_stopping_callback()
+        self._update_kwargs = deepcopy(self.update_kwargs)
+        if self._obj_optimizer is not None:
+            self._update_kwargs["fit"]["obj_optimizer"] = self._obj_optimizer
+        if self._early_stopping_callback is not None:
+            self._update_kwargs["fit"]["callbacks"] = [self._early_stopping_callback]
 
     def create_update_model(
         self, x: ArrayLike, y: Union[List[BinaryReward], np.ndarray], batch_size: Optional[PositiveInt] = None
@@ -1110,8 +1175,11 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             if batch_size is None:
                 bnn_output = Data("bnn_output", y)
                 bnn_input = Data("bnn_input", x)
+                likelihood_kwargs = {}
             else:
                 bnn_input, bnn_output = Minibatch(x, y, batch_size=batch_size)
+                # total_size is the total number of samples in the dataset
+                likelihood_kwargs = dict(total_size=x.shape[0])
 
             next_layer_input = bnn_input
 
@@ -1150,7 +1218,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             # Final output processing
             logit = Deterministic(self._logit_var_name, linear_transform.squeeze())
 
-            Bernoulli("out", logit_p=logit, observed=bnn_output)
+            Bernoulli("out", logit_p=logit, observed=bnn_output, **likelihood_kwargs)
 
         return _model
 
@@ -1271,17 +1339,14 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         if len(context) != len(rewards):
             raise AttributeError("Shape mismatch: context and rewards must have the same length.")
 
-        batch_size = self.update_kwargs.get("batch_size", None)
+        batch_size = self._update_kwargs.get("batch_size", None)
         _context = np.atleast_2d(context)
         _model = self.create_update_model(x=_context, y=rewards, batch_size=batch_size)
         with _model:
+            # update traces object by sampling from posterior distribution
             if self.update_method == "VI":
-                update_kwargs = self.update_kwargs.copy()
-
-                if self.optimizer is not None:
-                    approx = fit(obj_optimizer=self.optimizer, **update_kwargs["fit"])
-                else:
-                    approx = fit(**update_kwargs["fit"])
+                # variational inference
+                approx = fit(**self._update_kwargs["fit"])
 
                 self._approx_history = approx.hist
                 approx_mean_eval = approx.mean.eval()
@@ -1341,6 +1406,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         dist_params_init: Optional[Dict[str, float]] = None,
         activation: ActivationFunctions = "tanh",
         use_residual_connections: bool = False,
+        use_layerwise_scaling: bool = False,
         **kwargs,
     ) -> Self:
         """
@@ -1366,6 +1432,10 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             The activation function to use for hidden layers. Supported values are: "tanh", "relu", "sigmoid", "gelu" (default is "tanh").
         use_residual_connections : bool
             Whether to use residual connections in the network (default is False).
+        use_layerwise_scaling : bool
+            Whether to use layerwise scaling in the network (default is False).
+            When applied, the sigma is scaled by the square root of the input dimension.
+            This is useful to enable smoother convergence with Gaussian Process-like behavior.
         **kwargs
             Additional keyword arguments for the BayesianNeuralNetwork constructor.
 
@@ -1387,7 +1457,11 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         dist_class = cls._distribution_mapping[dist_type]
 
         model_params = cls.create_model_params(
-            n_features=n_features, hidden_dim_list=hidden_dim_list, dist_class=dist_class, **dist_params_init
+            n_features=n_features,
+            hidden_dim_list=hidden_dim_list,
+            use_layerwise_scaling=use_layerwise_scaling,
+            dist_class=dist_class,
+            **dist_params_init,
         )
         return cls(
             model_params=model_params,
@@ -1420,11 +1494,6 @@ class BayesianNeuralNetworkCC(BaseBayesianNeuralNetwork, ModelCC):
     This class implements a Bayesian Neural Network with an arbitrary number of fully connected layers
     using PyMC for binary classification tasks. It supports both Markov Chain Monte Carlo (MCMC)
     and Variational Inference (VI) methods for posterior inference.
-
-    References
-    ----------
-    Bayesian Learning for Neural Networks (Radford M. Neal, 1995)
-    https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=db869fa192a3222ae4f2d766674a378e47013b1b
 
     Parameters
     ----------
@@ -1484,6 +1553,7 @@ class BaseBayesianNeuralNetworkMO(ModelMO, ABC):
         dist_params: Optional[Dict[str, float]] = None,
         activation: ActivationFunctions = "tanh",
         use_residual_connections: bool = False,
+        use_layerwise_scaling: bool = False,
         **kwargs,
     ) -> Self:
         """
@@ -1509,6 +1579,8 @@ class BaseBayesianNeuralNetworkMO(ModelMO, ABC):
             The activation function to use for hidden layers. Supported values are: "tanh", "relu", "sigmoid", "gelu" (default is "tanh").
         use_residual_connections : bool
             Whether to use residual connections in the network (default is False).
+        use_layerwise_scaling : bool
+            Whether to use layerwise scaling in the network (default is False).
         **kwargs
             Additional keyword arguments.
 
@@ -1528,6 +1600,7 @@ class BaseBayesianNeuralNetworkMO(ModelMO, ABC):
                 dist_params_init=dist_params,
                 activation=activation,
                 use_residual_connections=use_residual_connections,
+                use_layerwise_scaling=use_layerwise_scaling,
             )
             for _ in range(n_objectives)
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybandits"
-version = "4.1.1"
+version = "4.1.2"
 description = "Python Multi-Armed Bandit Library"
 authors = [
     "Dario d'Andrea <dariod@playtika.com>",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -20,6 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from typing import Literal, Optional
+
 import numpy as np
 import pandas as pd
 import pymc
@@ -42,6 +44,7 @@ from pybandits.model import (
     BetaMOCC,
     NormalArray,
     StudentTArray,
+    UpdateMethods,
 )
 from pybandits.pydantic_version_compatibility import ValidationError
 
@@ -383,15 +386,18 @@ def test_check_context_matrix_error_handling(n_features: int, n_rows: int, inval
 
 
 @settings(deadline=20000)
-@pytest.mark.parametrize("activation", ["tanh", "relu", "sigmoid", "gelu"])
-@pytest.mark.parametrize("use_residual_connections", [True, False])
-@pytest.mark.parametrize("dist_type", ["studentt", "normal"])
 @given(
-    n_samples=st.integers(min_value=1, max_value=1000),
+    activation=st.sampled_from(["tanh", "relu", "sigmoid", "gelu"]),
+    use_residual_connections=st.booleans(),
+    use_layerwise_scaling=st.booleans(),
+    dist_type=st.sampled_from(["studentt", "normal"]),
+    n_samples=st.integers(min_value=1, max_value=100),
     n_features=st.integers(min_value=1, max_value=3),
     hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
 )
-def test_bnn_sample_proba(activation, use_residual_connections, dist_type, n_samples, n_features, hidden_dim_list):
+def test_bnn_sample_proba(
+    activation, use_residual_connections, use_layerwise_scaling, dist_type, n_samples, n_features, hidden_dim_list
+):
     def sample_proba(context):
         prob_and_weighted_sum = bnn.sample_proba(context=np.array(context))
         prob, weighted_sum = zip(*prob_and_weighted_sum)
@@ -403,6 +409,7 @@ def test_bnn_sample_proba(activation, use_residual_connections, dist_type, n_sam
         hidden_dim_list,
         activation=activation,
         use_residual_connections=use_residual_connections,
+        use_layerwise_scaling=use_layerwise_scaling,
         dist_type=dist_type,
     )
 
@@ -413,7 +420,7 @@ def test_bnn_sample_proba(activation, use_residual_connections, dist_type, n_sam
         assert isinstance(layer_params.bias, expected_array)
 
     # context is numpy array
-    context = np.random.uniform(low=-100.0, high=100.0, size=(n_samples, n_features))
+    context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
     assert type(context) is np.ndarray
     sample_proba(context=context)
 
@@ -436,24 +443,29 @@ def test_bnn_sample_proba(activation, use_residual_connections, dist_type, n_sam
     assert is_all_different
 
 
-@settings(deadline=None)
-@pytest.mark.parametrize("activation", ["tanh", "relu", "sigmoid", "gelu"])
-@pytest.mark.parametrize("use_residual_connections", [True, False])
-@pytest.mark.parametrize("dist_type", ["studentt", "normal"])
+@settings(deadline=None, max_examples=25)
 @given(
+    activation=st.sampled_from(["tanh", "relu", "sigmoid", "gelu"]),
+    use_residual_connections=st.booleans(),
+    use_layerwise_scaling=st.booleans(),
+    dist_type=st.sampled_from(["studentt", "normal"]),
     n_features=st.integers(min_value=1, max_value=2),
     hidden_dim_list=st.lists(st.integers(min_value=1, max_value=2), min_size=0, max_size=1),
-    n_samples=st.just(5),
+    n_samples=st.just(3),
     update_method=st.just("VI"),
+    n=st.just(2),
 )
 def test_bnn_vi_update(
-    activation, use_residual_connections, dist_type, n_features, hidden_dim_list, n_samples, update_method
+    activation,
+    use_residual_connections,
+    use_layerwise_scaling,
+    dist_type,
+    n_features,
+    hidden_dim_list,
+    n_samples,
+    update_method,
+    n,
 ):
-    init_params = dict(mu=0.0, sigma=10.0)
-    if dist_type == "studentt":
-        init_params["nu"] = 5.0
-    dist_params = init_params.copy()
-
     def update(context: np.ndarray, rewards: list):
         bnn = BayesianNeuralNetwork.cold_start(
             n_features=n_features,
@@ -461,20 +473,23 @@ def test_bnn_vi_update(
             update_method=update_method,
             activation=activation,
             use_residual_connections=use_residual_connections,
+            use_layerwise_scaling=use_layerwise_scaling,
             dist_type=dist_type,
-            dist_params_init=dist_params,
+            update_kwargs={"fit": {"n": n}},  # Use minimal iterations for faster tests
         )
+
+        expected_array = NormalArray if dist_type == "normal" else StudentTArray
         dim_list = [n_features] + hidden_dim_list
 
         for layer_ind in range(len(dim_list)):
             layer_w = bnn.model_params.bnn_layer_params[layer_ind].weight.params
+            layer_w_init = bnn.model_params.bnn_layer_params_init[layer_ind].weight.params
             layer_b = bnn.model_params.bnn_layer_params[layer_ind].bias.params
-            for param in init_params.keys():
-                assert np.all(np.array(layer_w[param]) == init_params[param])
-                assert np.all(np.array(layer_b[param]) == init_params[param])
+            layer_b_init = bnn.model_params.bnn_layer_params_init[layer_ind].bias.params
+            for param in expected_array.model_fields.keys():
+                assert np.all(layer_w[param] == layer_w_init[param])
+                assert np.all(layer_b[param] == layer_b_init[param])
 
-            # Verify distribution type
-            expected_array = NormalArray if dist_type == "normal" else StudentTArray
             assert isinstance(bnn.model_params.bnn_layer_params[layer_ind].weight, expected_array)
             assert isinstance(bnn.model_params.bnn_layer_params[layer_ind].bias, expected_array)
 
@@ -483,13 +498,14 @@ def test_bnn_vi_update(
         # mu and sigma are updated:
         for layer_ind in range(len(dim_list)):
             layer_w = bnn.model_params.bnn_layer_params[layer_ind].weight.params
+            layer_w_init = bnn.model_params.bnn_layer_params_init[layer_ind].weight.params
             layer_b = bnn.model_params.bnn_layer_params[layer_ind].bias.params
+            layer_b_init = bnn.model_params.bnn_layer_params_init[layer_ind].bias.params
             for param in ["mu", "sigma"]:
-                assert np.all(np.array(layer_w[param]) != init_params[param])
-                assert np.all(np.array(layer_b[param]) != init_params[param])
+                assert np.all(layer_w[param] != layer_w_init[param])
+                assert np.all(layer_b[param] != layer_b_init[param])
 
         # Verify distribution type is preserved after update
-        expected_array = NormalArray if dist_type == "normal" else StudentTArray
         for layer_ind in range(len(dim_list)):
             assert isinstance(bnn.model_params.bnn_layer_params[layer_ind].weight, expected_array)
             assert isinstance(bnn.model_params.bnn_layer_params[layer_ind].bias, expected_array)
@@ -503,127 +519,302 @@ def test_bnn_vi_update(
     # raise an error if len(context) != len(rewards)
     with pytest.raises(AttributeError):
         bnn = BayesianNeuralNetwork.cold_start(
-            n_features=n_features, hidden_dim_list=hidden_dim_list, update_method=update_method
+            n_features=n_features,
+            hidden_dim_list=hidden_dim_list,
+            update_method=update_method,
+            use_residual_connections=use_residual_connections,
+            use_layerwise_scaling=use_layerwise_scaling,
+            dist_type=dist_type,
+            update_kwargs={"fit": {"n": n}},  # Use minimal iterations for faster tests
         )
         bnn.update(context=context, rewards=rewards[1:])
+
+
+def _create_update_kwargs(
+    batch_size: Optional[int] = None,
+    optimizer_type: Optional[str] = None,
+    lr: Optional[float] = None,
+    early_stopping_diff: Optional[Literal["absolute", "relative"]] = None,
+    early_stopping_tol: Optional[float] = None,
+    early_stopping_every: Optional[int] = None,
+) -> dict:
+    """Create update_kwargs dictionary from individual parameters."""
+    update_kwargs: dict = {}
+    if batch_size is not None:
+        update_kwargs["batch_size"] = batch_size
+    if optimizer_type is not None:
+        update_kwargs["optimizer_type"] = optimizer_type
+        update_kwargs["optimizer_kwargs"] = {}
+        if lr is not None:
+            update_kwargs["optimizer_kwargs"]["learning_rate"] = lr
+        if len(update_kwargs["optimizer_kwargs"]) == 0:
+            update_kwargs.pop("optimizer_kwargs")
+
+    if early_stopping_diff is not None or early_stopping_tol is not None or early_stopping_every is not None:
+        early_stopping_kwargs: dict = {}
+        if early_stopping_diff is not None:
+            early_stopping_kwargs["diff"] = early_stopping_diff
+        if early_stopping_tol is not None:
+            early_stopping_kwargs["tolerance"] = early_stopping_tol
+        if early_stopping_every is not None:
+            early_stopping_kwargs["every"] = early_stopping_every
+        if len(early_stopping_kwargs):
+            update_kwargs["early_stopping_kwargs"] = early_stopping_kwargs
+
+    return update_kwargs
 
 
 @given(
     n_features=st.just(2),
     hidden_dim_list=st.just([1]),
     n_samples=st.just(5),
-    update_method=st.sampled_from(("VI", "MCMC")),
     batch_size=st.sampled_from((None, 2, 4)),
-    optimizer_type=st.sampled_from((None, "adam", "dummy_optimizer")),
+    optimizer_type=st.sampled_from((None, "adam")),
     lr=st.floats(min_value=0.0, max_value=1.0, exclude_min=True, exclude_max=True),
-    beta1=st.floats(min_value=0.0, max_value=1.0, exclude_min=True, exclude_max=True),
-    beta2=st.floats(min_value=0.0, max_value=1.0, exclude_min=True, exclude_max=True),
-    epsilon=st.floats(min_value=0.0, max_value=1.0, exclude_min=True, exclude_max=True),
+    early_stopping_diff=st.sampled_from((None, "absolute", "relative")),
+    early_stopping_tol=st.one_of(st.none(), st.floats(min_value=1e-6, max_value=1e-1)),
+    early_stopping_every=st.one_of(st.none(), st.integers(min_value=1, max_value=10)),
+    update_method=st.just("VI"),
 )
 def test_bnn_vi_update_parameters(
-    n_features, hidden_dim_list, n_samples, update_method, batch_size, optimizer_type, lr, beta1, beta2, epsilon
-):
-    def create_update_kwargs(batch_size, optimizer_type, lr, beta1, beta2, epsilon):
-        update_kwargs = {}
-        if batch_size is not None:
-            update_kwargs["batch_size"] = batch_size
-        if optimizer_type is not None:
-            update_kwargs["optimizer_type"] = optimizer_type
-            update_kwargs["optimizer_kwargs"] = {}
-            if lr is not None:
-                update_kwargs["optimizer_kwargs"]["learning_rate"] = lr
-            if beta1 is not None:
-                update_kwargs["optimizer_kwargs"]["beta1"] = beta1
-            if beta2 is not None:
-                update_kwargs["optimizer_kwargs"]["beta2"] = beta2
-            if epsilon is not None:
-                update_kwargs["optimizer_kwargs"]["epsilon"] = epsilon
-            if len(update_kwargs["optimizer_kwargs"]) == 0:
-                update_kwargs.pop("optimizer_kwargs")
-
-        return update_kwargs
-
-    update_kwargs = create_update_kwargs(batch_size, optimizer_type, lr, beta1, beta2, epsilon)
+    n_features: int,
+    hidden_dim_list: list[int],
+    n_samples: int,
+    batch_size: Optional[int],
+    optimizer_type: Optional[str],
+    lr: Optional[float],
+    early_stopping_diff: Optional[Literal["absolute", "relative"]],
+    early_stopping_tol: Optional[float],
+    early_stopping_every: Optional[int],
+    update_method: UpdateMethods,
+) -> None:
+    """Test BNN VI update with various valid parameters."""
+    update_kwargs = _create_update_kwargs(
+        batch_size, optimizer_type, lr, early_stopping_diff, early_stopping_tol, early_stopping_every
+    )
     rewards = np.random.choice([0, 1], size=n_samples).tolist()
     context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
 
-    if update_method == "MCMC":
-        if (
-            ("batch_size" in update_kwargs)
-            or ("optimizer_kwargs" in update_kwargs)
-            or ("optimizer_type" in update_kwargs)
-        ):
-            with pytest.raises(ValueError):
-                BayesianNeuralNetwork.cold_start(
-                    n_features=n_features,
-                    hidden_dim_list=hidden_dim_list,
-                    update_method=update_method,
-                    update_kwargs=update_kwargs,
-                )
+    bnn = BayesianNeuralNetwork.cold_start(
+        n_features=n_features,
+        hidden_dim_list=hidden_dim_list,
+        update_method=update_method,
+        update_kwargs=update_kwargs,
+    )
 
-    elif optimizer_type == "dummy_optimizer":
+    pymc_model = bnn.create_update_model(x=context, y=rewards, batch_size=batch_size)
+
+    if batch_size is None:
+        assert pymc_model["out"].eval().shape[0] == n_samples
+    else:
+        assert pymc_model["out"].eval().shape[0] == batch_size
+
+    if optimizer_type is not None:
+        optimizer = getattr(pymc, optimizer_type)
+        optimizer_kwargs = update_kwargs.get("optimizer_kwargs", {})
+        optimizer = optimizer(**optimizer_kwargs)
+        assert (
+            (optimizer.func == bnn._obj_optimizer.func)
+            and (optimizer.args == bnn._obj_optimizer.args)
+            and (optimizer.keywords == bnn._obj_optimizer.keywords)
+        )
+    else:
+        assert bnn._obj_optimizer is None
+
+    if "early_stopping_kwargs" in update_kwargs:
+        from pymc.variational.callbacks import CheckParametersConvergence
+
+        assert bnn._get_early_stopping_callback() is not None
+        assert isinstance(bnn._get_early_stopping_callback(), CheckParametersConvergence)
+    else:
+        assert bnn._get_early_stopping_callback() is None
+
+
+@given(
+    n_features=st.just(2),
+    hidden_dim_list=st.just([1]),
+    n_samples=st.just(5),
+    update_method=st.just("MCMC"),
+)
+def test_bnn_mcmc_update_parameters(
+    n_features: int,
+    hidden_dim_list: list[int],
+    n_samples: int,
+    update_method: UpdateMethods,
+) -> None:
+    """Test BNN MCMC update with valid parameters (no batch_size, optimizer, or early_stopping)."""
+    rewards = np.random.choice([0, 1], size=n_samples).tolist()
+    context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
+
+    bnn = BayesianNeuralNetwork.cold_start(
+        n_features=n_features,
+        hidden_dim_list=hidden_dim_list,
+        update_method=update_method,
+        update_kwargs={},
+    )
+
+    pymc_model = bnn.create_update_model(x=context, y=rewards, batch_size=None)
+    assert pymc_model["out"].eval().shape[0] == n_samples
+
+
+@given(
+    n_features=st.just(2),
+    hidden_dim_list=st.just([1]),
+    batch_size=st.sampled_from((2, 4)),
+    optimizer_type=st.sampled_from((None, "adam")),
+    lr=st.floats(min_value=0.0, max_value=1.0, exclude_min=True, exclude_max=True),
+    early_stopping_diff=st.sampled_from(("absolute", "relative")),
+    early_stopping_tol=st.floats(min_value=1e-6, max_value=1e-1),
+    early_stopping_every=st.integers(min_value=1, max_value=10),
+    update_method=st.just("MCMC"),
+)
+def test_bnn_mcmc_update_parameters_failures(
+    n_features: int,
+    hidden_dim_list: list[int],
+    batch_size: int,
+    optimizer_type: Optional[str],
+    lr: Optional[float],
+    early_stopping_diff: str,
+    early_stopping_tol: float,
+    early_stopping_every: int,
+    update_method: UpdateMethods,
+) -> None:
+    """Test that MCMC update raises ValueError when invalid parameters are provided."""
+    # Test with batch_size
+    update_kwargs_with_batch = _create_update_kwargs(batch_size)
+    with pytest.raises(ValueError):
+        BayesianNeuralNetwork.cold_start(
+            n_features=n_features,
+            hidden_dim_list=hidden_dim_list,
+            update_method=update_method,
+            update_kwargs=update_kwargs_with_batch,
+        )
+
+    # Test with optimizer_type
+    if optimizer_type is not None:
+        update_kwargs_with_optimizer = _create_update_kwargs(None, optimizer_type, lr, None, None, None)
         with pytest.raises(ValueError):
             BayesianNeuralNetwork.cold_start(
                 n_features=n_features,
                 hidden_dim_list=hidden_dim_list,
-                update_method=update_method,
-                update_kwargs=update_kwargs,
+                update_method="MCMC",
+                update_kwargs=update_kwargs_with_optimizer,
             )
-    else:
-        bnn = BayesianNeuralNetwork.cold_start(
+
+    # Test with early_stopping_kwargs
+    update_kwargs_with_early_stopping = _create_update_kwargs(
+        None, None, early_stopping_diff, early_stopping_tol, early_stopping_every
+    )
+    with pytest.raises(ValueError):
+        BayesianNeuralNetwork.cold_start(
+            n_features=n_features,
+            hidden_dim_list=hidden_dim_list,
+            update_method=update_method,
+            update_kwargs=update_kwargs_with_early_stopping,
+        )
+
+
+@given(
+    n_features=st.just(2),
+    hidden_dim_list=st.just([1]),
+    batch_size=st.sampled_from((None, 2, 4)),
+    optimizer_type=st.just("dummy_optimizer"),
+    update_method=st.just("VI"),
+)
+def test_bnn_vi_update_parameters_dummy_optimizer_failure(
+    n_features: int,
+    hidden_dim_list: list[int],
+    batch_size: Optional[int],
+    optimizer_type: Optional[str],
+    update_method: UpdateMethods,
+) -> None:
+    """Test that dummy_optimizer raises ValueError for BNN VI update."""
+    update_kwargs = _create_update_kwargs(batch_size, optimizer_type)
+
+    with pytest.raises(ValueError):
+        BayesianNeuralNetwork.cold_start(
             n_features=n_features,
             hidden_dim_list=hidden_dim_list,
             update_method=update_method,
             update_kwargs=update_kwargs,
         )
 
-        pymc_model = bnn.create_update_model(x=context, y=rewards, batch_size=batch_size)
 
-        if batch_size is None:
-            assert pymc_model["out"].eval().shape[0] == n_samples
-        else:
-            assert pymc_model["out"].eval().shape[0] == batch_size
+@pytest.mark.parametrize(
+    "optimizer_type,optimizer_kwargs",
+    [
+        ("adam", {"invalid_param": 123, "learning_rate": 0.01}),
+        ("sgd", {"invalid_param": 123}),
+    ],
+)
+def test_invalid_optimizer_kwargs(
+    optimizer_type: str, optimizer_kwargs: dict, n_features: int = 2, update_method: UpdateMethods = "VI"
+) -> None:
+    """Test that invalid optimizer kwargs raise TypeError or ValueError."""
 
-        if optimizer_type is not None:
-            optimizer = getattr(pymc, optimizer_type)
-            optimizer_kwargs = update_kwargs.get("optimizer_kwargs", {})
-            optimizer = optimizer(**optimizer_kwargs)
-            assert (
-                (optimizer.func == bnn.optimizer.func)
-                and (optimizer.args == bnn.optimizer.args)
-                and (optimizer.keywords == bnn.optimizer.keywords)
-            )
+    with pytest.raises((TypeError, ValueError), match="Invalid optimizer kwargs"):
+        BayesianNeuralNetwork.cold_start(
+            n_features=n_features,
+            update_method=update_method,
+            update_kwargs={
+                "optimizer_type": optimizer_type,
+                "optimizer_kwargs": optimizer_kwargs,
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    "early_stopping_kwargs",
+    [
+        {"invalid_param": 123, "tolerance": 1e-3},
+        {"diff": "invalid", "tolerance": 1e-3},
+    ],
+)
+def test_invalid_early_stopping_kwargs(
+    early_stopping_kwargs: dict, n_features: int = 2, update_method: UpdateMethods = "VI"
+) -> None:
+    """Test that invalid early stopping kwargs raise TypeError or ValueError."""
+
+    with pytest.raises((TypeError, ValueError, KeyError), match="Invalid early stopping kwargs"):
+        BayesianNeuralNetwork.cold_start(
+            n_features=n_features,
+            update_method=update_method,
+            update_kwargs={
+                "early_stopping_kwargs": early_stopping_kwargs,
+            },
+        )
 
 
 @pytest.mark.parametrize("n_features", [1, 2])
 def test_bnn_mcmc_update(n_features, hidden_dim_list=(1,), n_samples=5, update_method="MCMC"):
     hidden_dim_list = list(hidden_dim_list)
-    init_params = dict(mu=0.0, sigma=10.0, nu=5.0)
-    dist_params = init_params.copy()
 
     def update(context: np.ndarray, rewards: list):
         bnn = BayesianNeuralNetwork.cold_start(
             n_features=n_features,
             hidden_dim_list=hidden_dim_list,
             update_method=update_method,
-            dist_params_init=dist_params,
         )
         dim_list = [n_features] + hidden_dim_list
         for layer_ind in range(len(dim_list)):
             layer_w = bnn.model_params.bnn_layer_params[layer_ind].weight.params
+            layer_w_init = bnn.model_params.bnn_layer_params_init[layer_ind].weight.params
             layer_b = bnn.model_params.bnn_layer_params[layer_ind].bias.params
-            for param in init_params.keys():
-                assert np.all(np.array(layer_w[param]) == init_params[param])
-                assert np.all(np.array(layer_b[param]) == init_params[param])
+            layer_b_init = bnn.model_params.bnn_layer_params_init[layer_ind].bias.params
+            for param in ["mu", "sigma", "nu"]:
+                assert np.all(layer_w[param] == layer_w_init[param])
+                assert np.all(layer_b[param] == layer_b_init[param])
 
         bnn.update(context=context, rewards=rewards)
 
         for layer_ind in range(len(dim_list)):
             layer_w = bnn.model_params.bnn_layer_params[layer_ind].weight.params
+            layer_w_init = bnn.model_params.bnn_layer_params_init[layer_ind].weight.params
             layer_b = bnn.model_params.bnn_layer_params[layer_ind].bias.params
+            layer_b_init = bnn.model_params.bnn_layer_params_init[layer_ind].bias.params
             for param in ["mu", "sigma"]:
-                assert np.all(np.array(layer_w[param]) != init_params[param])
-                assert np.all(np.array(layer_b[param]) != init_params[param])
+                assert np.all(layer_w[param] != layer_w_init[param])
+                assert np.all(layer_b[param] != layer_b_init[param])
 
     rewards = np.random.choice([0, 1], size=n_samples).tolist()
     context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
@@ -692,41 +883,101 @@ def test_bayesian_logistic_regression_with_residual_connections():
     assert all([0 <= p <= 1 for p in prob])
 
 
+@settings(deadline=500)
+@pytest.mark.parametrize("use_layerwise_scaling", [True, False])
+@given(
+    n_features=st.integers(min_value=1, max_value=3),
+    hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
+    sigma=st.floats(min_value=0.1, max_value=20.0, allow_nan=False, allow_infinity=False),
+)
+def test_bnn_layerwise_scaling(use_layerwise_scaling, n_features, hidden_dim_list, sigma):
+    """Test that use_layerwise_scaling correctly scales weight sigma by sqrt(input_dim)."""
+    bnn = BayesianNeuralNetwork.cold_start(
+        n_features=n_features,
+        hidden_dim_list=hidden_dim_list,
+        use_layerwise_scaling=use_layerwise_scaling,
+        dist_params_init={"sigma": sigma},
+    )
+
+    dim_list = [n_features] + hidden_dim_list
+    dim_list.append(1)
+
+    for layer_ind, layer_params in enumerate(bnn.model_params.bnn_layer_params):
+        input_dim = dim_list[layer_ind]
+        weight_sigma = np.array(layer_params.weight.sigma)
+        bias_sigma = np.array(layer_params.bias.sigma)
+
+        if use_layerwise_scaling:
+            expected_weight_sigma = sigma / np.sqrt(input_dim)
+        else:
+            expected_weight_sigma = sigma
+
+        # Check that weight sigma is scaled correctly
+        assert np.allclose(weight_sigma, expected_weight_sigma), (
+            f"Layer {layer_ind}: weight sigma should be {expected_weight_sigma} but got {weight_sigma.mean()}"
+        )
+
+        # Check that bias sigma is not scaled
+        assert np.allclose(bias_sigma, sigma), (
+            f"Layer {layer_ind}: bias sigma should be {sigma} but got {bias_sigma.mean()}"
+        )
+
+
 ########################################################################################################################
 
 
 # BayesianNeuralNetworkCC
 @settings(deadline=500)
-@pytest.mark.parametrize("activation", ["tanh", "relu", "sigmoid", "gelu"])
 @given(
+    activation=st.sampled_from(["tanh", "relu", "sigmoid", "gelu"]),
+    use_residual_connections=st.booleans(),
+    use_layerwise_scaling=st.booleans(),
     n_features=st.integers(min_value=1, max_value=3),
     hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
     cost=st.floats(allow_nan=False, allow_infinity=False),
 )
-def test_can_init_bayesian_neural_network_cc(activation, n_features, hidden_dim_list, cost):
+def test_can_init_bayesian_neural_network_cc(
+    activation, use_residual_connections, use_layerwise_scaling, n_features, hidden_dim_list, cost
+):
     # at least one beta must be specified
     dim_list = [n_features] + hidden_dim_list
     if any(layer_dim <= 0 for layer_dim in dim_list) or (cost < 0):
         with pytest.raises((ValidationError, ValueError)):
-            model_params = BayesianNeuralNetwork.create_model_params(n_features, hidden_dim_list)
-            bnn = BayesianNeuralNetworkCC(model_params=model_params, cost=cost, activation=activation)
+            model_params = BayesianNeuralNetwork.create_model_params(
+                n_features, hidden_dim_list, use_layerwise_scaling=use_layerwise_scaling
+            )
+            bnn = BayesianNeuralNetworkCC(
+                model_params=model_params,
+                cost=cost,
+                activation=activation,
+                use_residual_connections=use_residual_connections,
+            )
     else:
-        model_params = BayesianNeuralNetwork.create_model_params(n_features, hidden_dim_list)
-        bnn = BayesianNeuralNetworkCC(model_params=model_params, cost=cost, activation=activation)
+        model_params = BayesianNeuralNetwork.create_model_params(
+            n_features, hidden_dim_list, use_layerwise_scaling=use_layerwise_scaling
+        )
+        bnn = BayesianNeuralNetworkCC(
+            model_params=model_params,
+            cost=cost,
+            activation=activation,
+            use_residual_connections=use_residual_connections,
+        )
         assert bnn.model_params == model_params
         assert bnn.activation == activation
+        assert bnn.use_residual_connections == use_residual_connections
 
 
 @settings(deadline=500)
-@pytest.mark.parametrize("activation", ["tanh", "relu", "sigmoid", "gelu"])
-@pytest.mark.parametrize("use_residual_connections", [True, False])
 @given(
+    activation=st.sampled_from(["tanh", "relu", "sigmoid", "gelu"]),
+    use_residual_connections=st.booleans(),
+    use_layerwise_scaling=st.booleans(),
     n_features=st.integers(min_value=1, max_value=3),
     hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
     cost=st.floats(allow_nan=False, allow_infinity=False),
 )
 def test_create_default_instance_bayesian_neural_network_cc(
-    activation, use_residual_connections, n_features, hidden_dim_list, cost
+    activation, use_residual_connections, use_layerwise_scaling, n_features, hidden_dim_list, cost
 ):
     dim_list = [n_features] + hidden_dim_list
     if any(layer_dim <= 0 for layer_dim in dim_list) or (cost < 0):
@@ -737,6 +988,7 @@ def test_create_default_instance_bayesian_neural_network_cc(
                 cost=cost,
                 activation=activation,
                 use_residual_connections=use_residual_connections,
+                use_layerwise_scaling=use_layerwise_scaling,
             )
     else:
         bnn_cold_start = BayesianNeuralNetworkCC.cold_start(
@@ -745,8 +997,11 @@ def test_create_default_instance_bayesian_neural_network_cc(
             cost=cost,
             activation=activation,
             use_residual_connections=use_residual_connections,
+            use_layerwise_scaling=use_layerwise_scaling,
         )
-        model_params = BayesianNeuralNetwork.create_model_params(n_features=n_features, hidden_dim_list=hidden_dim_list)
+        model_params = BayesianNeuralNetwork.create_model_params(
+            n_features=n_features, hidden_dim_list=hidden_dim_list, use_layerwise_scaling=use_layerwise_scaling
+        )
         bnn_init = BayesianNeuralNetworkCC(
             model_params=model_params,
             cost=cost,
@@ -858,20 +1113,25 @@ def test_can_init_bayesian_neural_network_mo(n_features, hidden_dim_list, n_obje
 
 
 @settings(deadline=500)
-@pytest.mark.parametrize("activation", ["tanh", "relu", "sigmoid", "gelu"])
-@pytest.mark.parametrize("use_residual_connections", [True, False])
 @given(
+    activation=st.sampled_from(["tanh", "relu", "sigmoid", "gelu"]),
+    use_residual_connections=st.booleans(),
+    use_layerwise_scaling=st.booleans(),
     n_samples=st.integers(min_value=1, max_value=1000),
     n_features=st.integers(min_value=1, max_value=3),
     hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
     n_objectives=st.integers(min_value=1, max_value=3),
 )
 def test_bayesian_neural_network_mo_sample_proba(
-    activation, use_residual_connections, n_samples, n_features, hidden_dim_list, n_objectives
+    activation, use_residual_connections, use_layerwise_scaling, n_samples, n_features, hidden_dim_list, n_objectives
 ):
     models = [
         BayesianNeuralNetwork.cold_start(
-            n_features, hidden_dim_list, activation=activation, use_residual_connections=use_residual_connections
+            n_features,
+            hidden_dim_list,
+            activation=activation,
+            use_residual_connections=use_residual_connections,
+            use_layerwise_scaling=use_layerwise_scaling,
         )
         for _ in range(n_objectives)
     ]
@@ -893,21 +1153,26 @@ def test_bayesian_neural_network_mo_sample_proba(
             assert 0 <= prob <= 1
 
 
-@pytest.mark.parametrize("activation", ["tanh", "relu", "sigmoid", "gelu"])
-@settings(deadline=None)
+@settings(deadline=None, max_examples=25)
 @given(
+    activation=st.sampled_from(["tanh", "relu", "sigmoid", "gelu"]),
     n_features=st.integers(min_value=1, max_value=2),
     hidden_dim_list=st.lists(st.integers(min_value=1, max_value=2), min_size=0, max_size=1),
-    n_samples=st.just(5),
+    n_samples=st.just(3),
     update_method=st.just("VI"),
     n_objectives=st.integers(min_value=1, max_value=2),
+    n=st.just(2),
 )
 def test_bayesian_neural_network_mo_update(
-    activation, n_features, hidden_dim_list, n_samples, update_method, n_objectives
+    activation, n_features, hidden_dim_list, n_samples, update_method, n_objectives, n
 ):
     models = [
         BayesianNeuralNetwork.cold_start(
-            n_features, hidden_dim_list, update_method=update_method, activation=activation
+            n_features,
+            hidden_dim_list,
+            update_method=update_method,
+            activation=activation,
+            update_kwargs={"fit": {"n": n}},  # Use minimal iterations for faster tests
         )
         for _ in range(n_objectives)
     ]
@@ -935,16 +1200,17 @@ def test_bayesian_neural_network_mo_update(
 
 
 @settings(deadline=500)
-@pytest.mark.parametrize("activation", ["tanh", "relu", "sigmoid", "gelu"])
-@pytest.mark.parametrize("use_residual_connections", [True, False])
 @given(
+    activation=st.sampled_from(["tanh", "relu", "sigmoid", "gelu"]),
+    use_residual_connections=st.booleans(),
+    use_layerwise_scaling=st.booleans(),
     n_features=st.integers(min_value=1, max_value=3),
     hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
     n_objectives=st.integers(min_value=1, max_value=3),
     cost=st.floats(allow_nan=False, allow_infinity=False),
 )
 def test_can_init_bayesian_neural_network_mo_cc(
-    activation, use_residual_connections, n_features, hidden_dim_list, n_objectives, cost
+    activation, use_residual_connections, use_layerwise_scaling, n_features, hidden_dim_list, n_objectives, cost
 ):
     dim_list = [n_features] + hidden_dim_list
     if any(layer_dim <= 0 for layer_dim in dim_list) or n_objectives <= 0 or cost < 0:
@@ -955,6 +1221,7 @@ def test_can_init_bayesian_neural_network_mo_cc(
                     hidden_dim_list,
                     activation=activation,
                     use_residual_connections=use_residual_connections,
+                    use_layerwise_scaling=use_layerwise_scaling,
                 )
                 for _ in range(n_objectives)
             ]
@@ -962,7 +1229,11 @@ def test_can_init_bayesian_neural_network_mo_cc(
     else:
         models = [
             BayesianNeuralNetwork.cold_start(
-                n_features, hidden_dim_list, activation=activation, use_residual_connections=use_residual_connections
+                n_features,
+                hidden_dim_list,
+                activation=activation,
+                use_residual_connections=use_residual_connections,
+                use_layerwise_scaling=use_layerwise_scaling,
             )
             for _ in range(n_objectives)
         ]

--- a/tests/test_offline_policy_evaluator.py
+++ b/tests/test_offline_policy_evaluator.py
@@ -19,12 +19,16 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import importlib
 import random
+import sys
 from tempfile import TemporaryDirectory
 from typing import List, Optional, Union, get_args, get_type_hints
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
+import pydantic
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
@@ -38,6 +42,12 @@ from pybandits import offline_policy_estimator
 from pybandits.cmab import CmabBernoulli, CmabBernoulliCC, CmabBernoulliMO, CmabBernoulliMOCC
 from pybandits.offline_policy_estimator import BaseOfflinePolicyEstimator
 from pybandits.offline_policy_evaluator import OfflinePolicyEvaluator
+from pybandits.pydantic_version_compatibility import (
+    PYDANTIC_VERSION_1,
+    PYDANTIC_VERSION_2,
+    ValidationError,
+    pydantic_version,
+)
 from pybandits.smab import (
     SmabBernoulli,
     SmabBernoulliCC,
@@ -349,3 +359,130 @@ def test_running_configuration(
         execution_func(mab=mab, visualize=visualize, n_mc_experiments=n_mc_experiments, save_path=tmp_dir)
     if visualize:
         close("all")  # close all figures to avoid memory leak
+
+
+@pytest.mark.usefixtures("logged_data")
+@settings(deadline=None)
+@given(
+    split_prop=st.just(0.5),
+    n_trials=st.just(2),
+    propensity_score_model_type=st.sampled_from(
+        get_args(get_type_hints(OfflinePolicyEvaluator)["propensity_score_model_type"])
+    ),
+    expected_reward_model_type=st.sampled_from(
+        get_args(get_type_hints(OfflinePolicyEvaluator)["expected_reward_model_type"])
+    ),
+    importance_weights_model_type=st.sampled_from(
+        get_args(get_type_hints(OfflinePolicyEvaluator)["importance_weights_model_type"])
+    ),
+    batch_feature=st.just("batch"),
+    action_feature=st.just("action_id"),
+    reward_feature=st.sampled_from(["reward_0", ["reward_0", "reward_1"]]),
+    context=st.booleans(),
+    group_feature=st.sampled_from(["group", None]),
+    cost_feature=st.sampled_from(["cost", None]),
+    propensity_score_feature=st.just("propensity_score"),
+    ope_estimators=st.just(None),
+)
+def test_initialization_when_xgboost_not_available(
+    logged_data: pd.DataFrame,
+    split_prop: float,
+    n_trials: PositiveInt,
+    propensity_score_model_type: str,
+    expected_reward_model_type: str,
+    importance_weights_model_type: str,
+    batch_feature: str,
+    action_feature: str,
+    reward_feature: Union[str, List[str]],
+    context: bool,
+    group_feature: Optional[str],
+    cost_feature: Optional[str],
+    propensity_score_feature: Optional[str],
+    ope_estimators: Optional[List[BaseOfflinePolicyEstimator]],
+    monkeymodule,
+) -> None:
+    """Test that other model types still work when XGBoost is not available."""
+    with patch.dict(sys.modules, {"xgboost": None}):
+        if pydantic_version == PYDANTIC_VERSION_1:
+            pydantic.class_validators._FUNCS.clear()
+            importlib.reload(pybandits.offline_policy_evaluator)
+        elif pydantic_version == PYDANTIC_VERSION_2:
+            importlib.reload(pybandits.offline_policy_evaluator)
+        else:
+            raise ValueError(f"Unsupported pydantic version: {pydantic_version}")
+
+        assert pybandits.offline_policy_evaluator._XGBOOST_AVAILABLE is False
+        assert pybandits.offline_policy_evaluator.XGBClassifier is None
+        OfflinePolicyEvaluator = importlib.import_module("pybandits.offline_policy_evaluator").OfflinePolicyEvaluator
+
+        scaler = random.choice([None, MinMaxScaler()])
+        shuffle = generate_random_bool()
+        verbose = generate_random_bool()
+        fast_fit = generate_random_bool()
+
+        true_reward_feature = (
+            f"true_{reward_feature}" if isinstance(reward_feature, str) else [f"true_{r}" for r in reward_feature]
+        )
+        if context:
+            contextual_features = [col for col in logged_data.columns if col.startswith("context")]
+            monkeymodule.setattr(
+                pybandits.model,
+                "fit",
+                lambda *args, **kwargs: FakeApproximation(n_features=len(contextual_features)),
+            )
+            monkeymodule.setattr(
+                pybandits.model,
+                "sample",
+                FakeApproximation(n_features=len(contextual_features)).sample,
+            )
+        else:
+            contextual_features = None
+
+        if "xgb" in (propensity_score_model_type, expected_reward_model_type, importance_weights_model_type):
+            # When XGBoost is not available, using "xgb" should fail at runtime
+            with pytest.raises(ValidationError):
+                OfflinePolicyEvaluator(
+                    logged_data=logged_data,
+                    split_prop=split_prop,
+                    propensity_score_model_type=propensity_score_model_type,
+                    expected_reward_model_type=expected_reward_model_type,
+                    importance_weights_model_type=importance_weights_model_type,
+                    n_trials=n_trials,
+                    fast_fit=fast_fit,
+                    scaler=scaler,
+                    ope_estimators=ope_estimators,
+                    verbose=verbose,
+                    shuffle=shuffle,
+                    batch_feature=batch_feature,
+                    action_feature=action_feature,
+                    reward_feature=reward_feature,
+                    contextual_features=[col for col in logged_data.columns if col.startswith("context")]
+                    if context
+                    else None,
+                    group_feature=group_feature,
+                    cost_feature=cost_feature,
+                    propensity_score_feature=propensity_score_feature,
+                )
+        else:
+            evaluator = OfflinePolicyEvaluator(
+                logged_data=logged_data,
+                split_prop=split_prop,
+                propensity_score_model_type=propensity_score_model_type,
+                expected_reward_model_type=expected_reward_model_type,
+                importance_weights_model_type=importance_weights_model_type,
+                n_trials=n_trials,
+                fast_fit=fast_fit,
+                scaler=scaler,
+                ope_estimators=ope_estimators,
+                verbose=verbose,
+                shuffle=shuffle,
+                batch_feature=batch_feature,
+                action_feature=action_feature,
+                reward_feature=reward_feature,
+                true_reward_feature=true_reward_feature,
+                contextual_features=contextual_features,
+                group_feature=group_feature,
+                cost_feature=cost_feature,
+                propensity_score_feature=propensity_score_feature,
+            )
+            assert evaluator is not None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,7 @@
 """Tests for pybandits.utils module."""
 
+import importlib
+import sys
 from abc import ABC, abstractmethod
 from types import ModuleType
 from unittest.mock import MagicMock, patch
@@ -7,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from bokeh.models import Div, InlineStyleSheet, TabPanel, Tabs
 
+import pybandits
 from pybandits.utils import (
     classproperty,
     extract_argument_names_from_function,
@@ -192,6 +195,21 @@ class TestInJupyterNotebook:
 
         result = in_jupyter_notebook()
         assert result is False
+
+    def test_in_jupyter_notebook_false_import_error(self) -> None:
+        """Test that function returns False when IPython import fails at module level."""
+        # The import error is handled at module import time in utils.py
+        # When IPython import fails, _IPYTHON_AVAILABLE is set to False
+        # and get_ipython is set to None
+        with patch.dict(sys.modules, {"IPython": None}):
+            # 2. Force a reload of the utils module so the try/except runs again
+            importlib.reload(pybandits.utils)
+
+            # Verify that the module has the flag (it's set during import)
+            assert hasattr(pybandits.utils, "_IPYTHON_AVAILABLE")
+            assert pybandits.utils._IPYTHON_AVAILABLE is False
+            result = in_jupyter_notebook()
+            assert result is False
 
 
 class TestVisualizeViaBokeh:


### PR DESCRIPTION
### Changes:
* Added `use_layerwise_scaling` parameter to `StudentTArray` and `BaseBayesianNeuralNetwork` for improved weight initialization.
* Added support for early stopping via update kwargs.
* Updated relevant methods to incorporate layerwise scaling logic.
* Enhanced tests to validate layerwise scaling functionality in Bayesian Neural Networks.