### PR TITLE
Add Epochs Logic to Bayesian Neural Network Updates

### DIFF
--- a/.github/workflows/continuous_delivery.yml
+++ b/.github/workflows/continuous_delivery.yml
@@ -25,7 +25,11 @@ jobs:
 
       - name: Install Poetry
         run: |
-          curl -sSL https://install.python-poetry.org | python3 -
+          if [ "${{ matrix.python-version }}" == "3.9" ]; then
+            curl -sSL https://install.python-poetry.org | python3 - --version 2.2.1
+          else
+            curl -sSL https://install.python-poetry.org | python3 -
+          fi
           export PATH="$HOME/.poetry/bin:$PATH"
       - name: Backup pyproject.toml
         run: cp pyproject.toml pyproject.toml.bak

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -33,8 +33,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry
         run: |
+          if [ "${{ matrix.python-version }}" == "3.9" ]; then
+            curl -sSL https://install.python-poetry.org | python3 - --version 2.2.1
+          else
             curl -sSL https://install.python-poetry.org | python3 -
-            export PATH="$HOME/.poetry/bin:$PATH"
+          fi
+          export PATH="$HOME/.poetry/bin:$PATH"
       - name: Install project dependencies with Poetry
         run: |
           poetry add pydantic@${{ matrix.pydantic-version }}

--- a/pybandits/model.py
+++ b/pybandits/model.py
@@ -301,9 +301,7 @@ class BaseLocationScaleArray(PyBanditsBaseModel, ABC):
     _params: Dict[str, np.ndarray] = PrivateAttr()
     _pymc_class: ClassVar[type]
 
-    def to_pymc_distribution(
-        self, name: str, shape: Tuple[PositiveInt, ...], initval: Literal["prior"] = "prior"
-    ) -> Union[PymcStudentT, PymcNormal]:
+    def to_pymc_distribution(self, name: str, shape: Tuple[PositiveInt, ...]) -> Union[PymcStudentT, PymcNormal]:
         """
         Create a PyMC distribution from this prior distribution array.
 
@@ -313,8 +311,6 @@ class BaseLocationScaleArray(PyBanditsBaseModel, ABC):
             Name for the PyMC random variable.
         shape : Tuple[PositiveInt, ...]
             Shape of the distribution array.
-        initval : Literal["prior"], optional
-            Initialization value strategy, by default "prior".
 
         Returns
         -------
@@ -325,7 +321,7 @@ class BaseLocationScaleArray(PyBanditsBaseModel, ABC):
             raise NotImplementedError(
                 f"{self.__class__.__name__} must define _pymc_class ClassVar to specify the PyMC distribution class."
             )
-        return self._pymc_class(name=name, shape=shape, **self.params, initval=initval)
+        return self._pymc_class(name=name, shape=shape, **self.params)
 
     def with_dist_parameters(self, **kwargs) -> "BaseLocationScaleArray":
         """
@@ -863,7 +859,9 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         The method used for posterior inference, either "MCMC" or "VI" (default is "MCMC").
     update_kwargs : Optional[dict], optional
         A dictionary of keyword arguments for the update method. For MCMC, it contains 'trace' settings.
-        For VI, it contains both 'trace' and 'fit' settings.
+        For VI, it contains 'fit' settings and additional parameters like 'epochs', 'optimizer_type',
+        'optimizer_kwargs', 'batch_size', and 'early_stopping_kwargs'. The 'epochs' parameter specifies
+        the number of iterations for VI (maps to 'n' in PyMC's fit function).
     activation : str, optional
         The activation function to use for hidden layers. Supported values are: "tanh", "relu", "sigmoid", "gelu" (default is "tanh").
     use_residual_connections : bool, optional
@@ -905,7 +903,13 @@ class BaseBayesianNeuralNetwork(Model, ABC):
     _prob_var_name: ClassVar[str] = "prob"
     _weight_var_name: ClassVar[str] = "weight"
     _bias_var_name: ClassVar[str] = "bias"
-    _vi_update_params: ClassVar[list] = ["optimizer_type", "optimizer_kwargs", "batch_size", "early_stopping_kwargs"]
+    _vi_update_params: ClassVar[list] = [
+        "optimizer_type",
+        "optimizer_kwargs",
+        "batch_size",
+        "early_stopping_kwargs",
+        "epochs",
+    ]
     _distribution_mapping: ClassVar[Dict[str, type]] = {"normal": NormalArray, "studentt": StudentTArray}
     _supported_optimizers: ClassVar[list] = [
         "sgd",
@@ -1108,6 +1112,15 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             self.update_kwargs = dict()
 
         if self.update_method == "VI":
+            # Validate that epochs and n are mutually exclusive
+            has_epochs = "epochs" in self.update_kwargs
+            has_n = "n" in self.update_kwargs.get("fit", {})
+            if has_epochs and has_n:
+                raise ValueError(
+                    "Cannot specify both 'epochs' and 'n' in update_kwargs. "
+                    "Use 'epochs' for epoch-based training or 'fit': {'n': ...} for iteration-based training."
+                )
+
             self.update_kwargs["fit"] = {
                 **self._default_variational_inference_fit_kwargs,
                 **self.update_kwargs.get("fit", {}),
@@ -1192,10 +1205,8 @@ class BaseBayesianNeuralNetwork(Model, ABC):
 
                 # For training, use shared weights and biases
                 # Use polymorphism to create the appropriate PyMC distribution
-                w = layer_params.weight.to_pymc_distribution(
-                    name=weight_layer_params_name, shape=w_shape, initval="prior"
-                )
-                b = layer_params.bias.to_pymc_distribution(name=bias_layer_params_name, shape=b_shape, initval="prior")
+                w = layer_params.weight.to_pymc_distribution(name=weight_layer_params_name, shape=w_shape)
+                b = layer_params.bias.to_pymc_distribution(name=bias_layer_params_name, shape=b_shape)
 
                 linear_transform = math.dot(next_layer_input, w) + b
 
@@ -1346,7 +1357,14 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             # update traces object by sampling from posterior distribution
             if self.update_method == "VI":
                 # variational inference
-                approx = fit(**self._update_kwargs["fit"])
+                fit_kwargs = self._update_kwargs["fit"].copy()
+                # Handle epochs parameter - convert to 'n' based on effective batch size
+                if "epochs" in self._update_kwargs:
+                    num_samples = _context.shape[0]
+                    effective_batch_size = batch_size if batch_size is not None else num_samples
+                    fit_kwargs["n"] = int(self._update_kwargs["epochs"] * num_samples / effective_batch_size)
+
+                approx = fit(**fit_kwargs)
 
                 self._approx_history = approx.hist
                 approx_mean_eval = approx.mean.eval()

--- a/pybandits/offline_policy_evaluator.py
+++ b/pybandits/offline_policy_evaluator.py
@@ -1207,7 +1207,7 @@ class OfflinePolicyEvaluator(PyBanditsBaseModel, arbitrary_types_allowed=True):
                 title=f"Policy value estimates for {group_name} objective",
                 x_axis_label="Estimator",
                 y_axis_label="Estimated policy value (\u00b1 CI)",
-                x_range=source.data["estimator"],
+                x_range=source.data["estimator"].tolist(),
                 tools=tools,
                 tooltips=tooltips,
             )

--- a/pybandits/simulator.py
+++ b/pybandits/simulator.py
@@ -644,7 +644,9 @@ class Simulator(PyBanditsBaseModel, ABC):
                 group_name = (group_name,)
             elif len(groupby_cols) == 0:
                 group_name = tuple()
-            overall_actions_rate = selected_actions_rate.loc[group_name + ("total",)].to_frame("total").reset_index()
+            overall_actions_rate = (
+                selected_actions_rate.loc[group_name + ("total",), :].squeeze().to_frame("total").reset_index()
+            )
             overall_actions_rate = overall_actions_rate[overall_actions_rate["action"].isin(action_ids)]
 
             # rate vs step line plot
@@ -667,7 +669,7 @@ class Simulator(PyBanditsBaseModel, ABC):
                 title="Overall selected actions rate",
                 x_axis_label="Action",
                 y_axis_label="Rate [%]",
-                x_range=overall_actions_rate["action"],
+                x_range=overall_actions_rate["action"].tolist(),
             )
             fig_overall.vbar(x="action", top="total", width=0.9, source=ColumnDataSource(overall_actions_rate))
             fig_overall.xgrid.grid_line_color = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybandits"
-version = "4.1.2"
+version = "4.1.3"
 description = "Python Multi-Armed Bandit Library"
 authors = [
     "Dario d'Andrea <dariod@playtika.com>",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -284,7 +284,7 @@ def test_location_scale_array_to_pymc_distribution(array_class, expected_pymc_cl
         a = array_class.cold_start(shape=shape, mu=mu, sigma=sigma, nu=nu)
 
     with pymc.Model():
-        pymc_dist = a.to_pymc_distribution(name="test", shape=shape, initval="prior")
+        pymc_dist = a.to_pymc_distribution(name="test", shape=shape)
         assert pymc_dist.owner is not None
         assert isinstance(pymc_dist.owner.op, expected_pymc_class)
 
@@ -453,7 +453,7 @@ def test_bnn_sample_proba(
     hidden_dim_list=st.lists(st.integers(min_value=1, max_value=2), min_size=0, max_size=1),
     n_samples=st.just(3),
     update_method=st.just("VI"),
-    n=st.just(2),
+    epochs=st.just(1),
 )
 def test_bnn_vi_update(
     activation,
@@ -464,7 +464,7 @@ def test_bnn_vi_update(
     hidden_dim_list,
     n_samples,
     update_method,
-    n,
+    epochs,
 ):
     def update(context: np.ndarray, rewards: list):
         bnn = BayesianNeuralNetwork.cold_start(
@@ -475,7 +475,7 @@ def test_bnn_vi_update(
             use_residual_connections=use_residual_connections,
             use_layerwise_scaling=use_layerwise_scaling,
             dist_type=dist_type,
-            update_kwargs={"fit": {"n": n}},  # Use minimal iterations for faster tests
+            update_kwargs={"epochs": epochs},  # Use minimal iterations for faster tests
         )
 
         expected_array = NormalArray if dist_type == "normal" else StudentTArray
@@ -525,7 +525,7 @@ def test_bnn_vi_update(
             use_residual_connections=use_residual_connections,
             use_layerwise_scaling=use_layerwise_scaling,
             dist_type=dist_type,
-            update_kwargs={"fit": {"n": n}},  # Use minimal iterations for faster tests
+            update_kwargs={"epochs": epochs},  # Use minimal iterations for faster tests
         )
         bnn.update(context=context, rewards=rewards[1:])
 
@@ -782,6 +782,22 @@ def test_invalid_early_stopping_kwargs(
             update_kwargs={
                 "early_stopping_kwargs": early_stopping_kwargs,
             },
+        )
+
+
+@given(
+    n_features=st.just(2),
+    update_method=st.just("VI"),
+    epochs=st.integers(min_value=1, max_value=100),
+    n=st.integers(min_value=1, max_value=100),
+)
+def test_epochs_and_n_mutually_exclusive(n_features: int, update_method: UpdateMethods, epochs: int, n: int) -> None:
+    """Test that specifying both 'epochs' and 'n' raises ValueError."""
+    with pytest.raises(ValueError, match="Cannot specify both 'epochs' and 'n'"):
+        BayesianNeuralNetwork.cold_start(
+            n_features=n_features,
+            update_method=update_method,
+            update_kwargs={"epochs": epochs, "fit": {"n": n}},
         )
 
 
@@ -1161,10 +1177,10 @@ def test_bayesian_neural_network_mo_sample_proba(
     n_samples=st.just(3),
     update_method=st.just("VI"),
     n_objectives=st.integers(min_value=1, max_value=2),
-    n=st.just(2),
+    epochs=st.just(1),
 )
 def test_bayesian_neural_network_mo_update(
-    activation, n_features, hidden_dim_list, n_samples, update_method, n_objectives, n
+    activation, n_features, hidden_dim_list, n_samples, update_method, n_objectives, epochs
 ):
     models = [
         BayesianNeuralNetwork.cold_start(
@@ -1172,7 +1188,7 @@ def test_bayesian_neural_network_mo_update(
             hidden_dim_list,
             update_method=update_method,
             activation=activation,
-            update_kwargs={"fit": {"n": n}},  # Use minimal iterations for faster tests
+            update_kwargs={"epochs": epochs},  # Use minimal iterations for faster tests
         )
         for _ in range(n_objectives)
     ]


### PR DESCRIPTION
### Changes:
* Removed the `initval` parameter from `to_pymc_distribution` method in `BaseLocationScaleArray`.
* Updated `BaseBayesianNeuralNetwork` to handle `epochs` parameter for variational inference, ensuring compatibility with `n`.
* Added validation to prevent simultaneous specification of `epochs` and `n` in update kwargs.
* Adjusted tests to reflect changes in parameter handling for Bayesian Neural Network updates.