### PR TITLE
Add transfer learning functionality

### DIFF
--- a/docs/src/tutorials/transfer_learning.ipynb
+++ b/docs/src/tutorials/transfer_learning.ipynb
@@ -1,0 +1,222 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Transfer Learning for Contextual Multi-Armed Bandits\n",
+    "\n",
+    "This tutorial shows how to evolve a trained CMAB without starting from scratch:\n",
+    "\n",
+    "1. **Train** a CMAB with 3 context features and 2 actions\n",
+    "2. **Evolve** it to use 4 features and add a new action — preserving everything learned\n",
+    "3. **Continue training** the evolved model\n",
+    "\n",
+    "The key function is `edit_model_on_the_fly(current_mab, new_mab)`.  \n",
+    "It takes `new_mab` as the template (defines actions and config) and transfers\n",
+    "learned weights from `current_mab` for overlapping actions.  \n",
+    "When the template has more features, it automatically expands the current model's\n",
+    "weight matrices and fills the new rows from the template's cold-start weights."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "from pybandits.cmab import CmabBernoulli\n",
+    "from pybandits.strategy import ClassicBandit\n",
+    "from pybandits.transfer import edit_model_on_the_fly\n",
+    "\n",
+    "np.random.seed(42)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## Step 1: Train a CMAB with 3 features and 2 actions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "N_FEATURES_V1 = 3\n",
+    "ACTIONS_V1 = {\"action_A\", \"action_B\"}\n",
+    "\n",
+    "mab_v1 = CmabBernoulli.cold_start(\n",
+    "    action_ids=ACTIONS_V1,\n",
+    "    n_features=N_FEATURES_V1,\n",
+    "    activation=\"tanh\",\n",
+    "    strategy=ClassicBandit(),\n",
+    "    update_kwargs={\"fit\": {\"n\": 200}},\n",
+    ")\n",
+    "\n",
+    "print(f\"Actions : {sorted(mab_v1.actions)}\")\n",
+    "print(f\"Features: {N_FEATURES_V1}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Simulate an initial batch of interactions\n",
+    "N_TRAIN = 200\n",
+    "context_v1 = np.random.randn(N_TRAIN, N_FEATURES_V1)\n",
+    "\n",
+    "# Predict\n",
+    "actions, probs, _ = mab_v1.predict(context=context_v1)\n",
+    "\n",
+    "# Simulate rewards: action_A has higher reward probability\n",
+    "rewards = [int(np.random.rand() < (0.7 if a == \"action_A\" else 0.3)) for a in actions]\n",
+    "\n",
+    "# Update the model\n",
+    "mab_v1.update(actions=actions, rewards=rewards, context=context_v1)\n",
+    "\n",
+    "print(\"Training complete.\")\n",
+    "for aid in sorted(mab_v1.actions):\n",
+    "    act = mab_v1.actions[aid]\n",
+    "    print(f\"  {aid}: n_successes={act.n_successes}, n_failures={act.n_failures}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
+   "metadata": {},
+   "source": [
+    "## Step 2: Evolve — add a new action and expand to 4 features\n",
+    "\n",
+    "Create a cold-start template with the desired final configuration:\n",
+    "- Same `activation` (structural — must match to allow weight transfer)\n",
+    "- One extra feature (`n_features=4`)\n",
+    "- The two original actions **plus** a new `action_C`\n",
+    "\n",
+    "`edit_model_on_the_fly` will:\n",
+    "1. Detect the dimension gap (3 → 4) and expand `mab_v1`'s weight matrices\n",
+    "2. Merge with the template: `action_A` and `action_B` keep their learned weights; `action_C` starts cold"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "N_FEATURES_V2 = 4\n",
+    "ACTIONS_V2 = {\"action_A\", \"action_B\", \"action_C\"}\n",
+    "\n",
+    "template_v2 = CmabBernoulli.cold_start(\n",
+    "    action_ids=ACTIONS_V2,\n",
+    "    n_features=N_FEATURES_V2,\n",
+    "    activation=\"tanh\",  # must match mab_v1\n",
+    "    strategy=ClassicBandit(),\n",
+    "    update_kwargs={\"fit\": {\"n\": 200}},\n",
+    ")\n",
+    "\n",
+    "mab_v2 = edit_model_on_the_fly(mab_v1, template_v2)\n",
+    "\n",
+    "print(f\"Actions : {sorted(mab_v2.actions)}\")\n",
+    "print(f\"Features: {mab_v2.input_dim}\")\n",
+    "print()\n",
+    "print(\"Learned state preserved for existing actions:\")\n",
+    "for aid in sorted(ACTIONS_V1):  # original actions\n",
+    "    orig = mab_v1.actions[aid]\n",
+    "    evolved = mab_v2.actions[aid]\n",
+    "    assert evolved.n_successes == orig.n_successes\n",
+    "    assert evolved.n_failures == orig.n_failures\n",
+    "    print(f\"  {aid}: n_successes={evolved.n_successes}, n_failures={evolved.n_failures}  ✓\")\n",
+    "print()\n",
+    "print(\"New action starts cold:\")\n",
+    "new_act = mab_v2.actions[\"action_C\"]\n",
+    "print(f\"  action_C: n_successes={new_act.n_successes}, n_failures={new_act.n_failures}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "## Step 3: Continue training the evolved model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "N_TRAIN_V2 = 200\n",
+    "context_v2 = np.random.randn(N_TRAIN_V2, N_FEATURES_V2)  # 4 features now\n",
+    "\n",
+    "actions_v2, probs_v2, _ = mab_v2.predict(context=context_v2)\n",
+    "\n",
+    "rewards_v2 = [\n",
+    "    int(np.random.rand() < (0.7 if a == \"action_A\" else (0.5 if a == \"action_C\" else 0.3))) for a in actions_v2\n",
+    "]\n",
+    "\n",
+    "mab_v2.update(actions=actions_v2, rewards=rewards_v2, context=context_v2)\n",
+    "\n",
+    "print(\"Continued training complete.\")\n",
+    "for aid in sorted(mab_v2.actions):\n",
+    "    act = mab_v2.actions[aid]\n",
+    "    print(f\"  {aid}: n_successes={act.n_successes}, n_failures={act.n_failures}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "| Step | Actions | Features | How |\n",
+    "|------|---------|----------|-----|\n",
+    "| v1 (initial) | A, B | 3 | `cold_start` |\n",
+    "| v1 (trained) | A, B | 3 | `update` |\n",
+    "| v2 (evolved) | A, B, **C** | **4** | `edit_model_on_the_fly` |\n",
+    "| v2 (trained) | A, B, C | 4 | `update` |\n",
+    "\n",
+    "**What `edit_model_on_the_fly` did:**\n",
+    "- Expanded `action_A` and `action_B` weight matrices from shape `(3, ...)` to `(4, ...)`\n",
+    "- The new 4th-feature row is initialised from the template's cold-start weights\n",
+    "- All existing learned weights (and n_successes / n_failures counts) were copied unchanged\n",
+    "- `action_C` was added fresh from the template\n",
+    "\n",
+    "**Constraints to keep in mind:**\n",
+    "- `activation` and `use_residual_connections` are *structural* — they must be identical in both MABs\n",
+    "- The template must have **≥** as many features as the current model (can expand, cannot shrink)\n",
+    "- `dist_type`, `hidden_dim_list`, `update_kwargs` and `update_method` are all freely changeable"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pybandits/base_model.py
+++ b/pybandits/base_model.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 from abc import ABC, abstractmethod
-from typing import Callable, List, Union
+from typing import Callable, ClassVar, List, Tuple, Union
 
 import numpy as np
 
@@ -105,6 +105,34 @@ class BaseModelSO(BaseModel, ABC):
 
     n_successes: PositiveInt = 1
     n_failures: PositiveInt = 1
+
+    # --- Transfer learning keys (own contributions for this class) ---
+    _transfer_learned_keys: ClassVar[Tuple[str, ...]] = ("n_successes", "n_failures")
+    _transfer_extendable_keys: ClassVar[Tuple[str, ...]] = ()
+    _transfer_structural_keys: ClassVar[Tuple[str, ...]] = ()
+
+    # --- Transfer learning keys (accumulated up the MRO, used by transfer.py) ---
+    # For BaseModelSO itself these equal the own contributions above.
+    # For subclasses they are auto-computed by __init_subclass__.
+    transfer_learned_keys: ClassVar[Tuple[str, ...]] = ("n_successes", "n_failures")
+    """Accumulated learned-state keys from all classes in the MRO.  Used by transfer.py to decide which keys to copy from source to target."""
+    transfer_extendable_keys: ClassVar[Tuple[str, ...]] = ()
+    """Accumulated extendable keys from all classes in the MRO.  Changes to these emit warnings (but not errors) during transfer."""
+    transfer_structural_keys: ClassVar[Tuple[str, ...]] = ()
+    """Accumulated structural keys from all classes in the MRO.  Mismatches in these raise ValueError during transfer."""
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        super().__init_subclass__(**kwargs)
+        for pub, priv in (
+            ("transfer_learned_keys", "_transfer_learned_keys"),
+            ("transfer_extendable_keys", "_transfer_extendable_keys"),
+            ("transfer_structural_keys", "_transfer_structural_keys"),
+        ):
+            accumulated: Tuple[str, ...] = ()
+            for base in reversed(cls.__mro__):
+                if priv in base.__dict__:
+                    accumulated += base.__dict__[priv]
+            setattr(cls, pub, accumulated)
 
     @abstractmethod
     def sample_proba(

--- a/pybandits/cmab.py
+++ b/pybandits/cmab.py
@@ -76,6 +76,11 @@ class BaseCmabBernoulli(BaseMab, ABC):
     actions_manager: CmabActionsManager[CmabModelType]
     _predict_with_proba: bool
 
+    @property
+    def input_dim(self) -> int:
+        """Returns the input feature dimension (number of context features)."""
+        return next(iter(self.actions.values())).input_dim
+
     @staticmethod
     def _extract_element_from_probability_weight(
         index: int, prob_weight: Union[ProbabilityWeight, MOProbabilityWeight]

--- a/pybandits/model.py
+++ b/pybandits/model.py
@@ -901,7 +901,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
 
     _logit_var_name: ClassVar[str] = "logit"
     _prob_var_name: ClassVar[str] = "prob"
-    _weight_var_name: ClassVar[str] = "weight"
+    weight_var_name: ClassVar[str] = "weight"
     _bias_var_name: ClassVar[str] = "bias"
     _vi_update_params: ClassVar[list] = [
         "optimizer_type",
@@ -962,6 +962,10 @@ class BaseBayesianNeuralNetwork(Model, ABC):
     class Config:
         arbitrary_types_allowed = True
 
+    _transfer_learned_keys: ClassVar[Tuple[str, ...]] = ("model_params",)
+    _transfer_extendable_keys: ClassVar[Tuple[str, ...]] = ("update_method",)
+    _transfer_structural_keys: ClassVar[Tuple[str, ...]] = ("activation", "use_residual_connections")
+
     @field_validator("activation")
     @classmethod
     def validate_activation(cls, v):
@@ -1010,7 +1014,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
 
     @classmethod
     def get_layer_params_name(cls, layer_ind: PositiveInt) -> Tuple[str, str]:
-        weight_layer_params_name = f"{cls._weight_var_name}_{layer_ind}"
+        weight_layer_params_name = f"{cls.weight_var_name}_{layer_ind}"
         bias_layer_params_name = f"{cls._bias_var_name}_{layer_ind}"
         return weight_layer_params_name, bias_layer_params_name
 
@@ -1558,6 +1562,19 @@ class BaseBayesianNeuralNetworkMO(ModelMO, ABC):
         for model in self.models[1:]:
             if model.input_dim != n_features:
                 raise ValueError(f"All models must have the same number of features: {model.input_dim} != {n_features}")
+
+    @property
+    def input_dim(self) -> PositiveInt:
+        """
+        Returns the expected input dimension of the model.
+
+        Returns
+        -------
+        PositiveInt
+            The number of input features expected by the model, derived from
+            the shape of the weight matrix in the first layer's parameters of the first objective model.
+        """
+        return self.models[0].input_dim
 
     @classmethod
     def cold_start(

--- a/pybandits/quantitative_model.py
+++ b/pybandits/quantitative_model.py
@@ -63,6 +63,7 @@ class QuantitativeModel(BaseModelSO, ABC):
     """
 
     dimension: PositiveInt
+    _transfer_structural_keys: ClassVar[Tuple[str, ...]] = ("dimension",)
 
     @abstractmethod
     def sample_proba(self, **kwargs) -> List[QuantitativeProbability]:
@@ -396,6 +397,7 @@ class ZoomingModel(QuantitativeModel, ABC):
     sub_actions: Dict[Tuple[Tuple[Float01, Float01], ...], Optional[Model]]
     _base_model: Model = PrivateAttr()
     _n_initial_segments: ClassVar = 4
+    _transfer_learned_keys: ClassVar[Tuple[str, ...]] = ("sub_actions",)
 
     if pydantic_version == PYDANTIC_VERSION_1:
 
@@ -919,6 +921,11 @@ class BaseCmabZoomingModel(ZoomingModel, ABC):
         if "n_features" not in value:
             raise KeyError("n_features must be in base_model_cold_start_kwargs.")
         return value
+
+    @property
+    def input_dim(self) -> int:
+        """Returns the input feature dimension (number of context features)."""
+        return self.base_model_cold_start_kwargs["n_features"]
 
     def _init_base_model(self):
         """

--- a/pybandits/transfer.py
+++ b/pybandits/transfer.py
@@ -1,0 +1,629 @@
+# MIT License
+#
+# Copyright (c) 2023 Playtika Ltd.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Transfer learning functionality for Multi-Armed Bandits.
+
+This module provides the edit_model_on_the_fly() function for transfer learning,
+which enables updating MAB configuration while preserving learned state and
+automatically handling input dimension changes for contextual MABs.
+"""
+
+import json
+from typing import Any, Dict, Tuple, Type
+
+from loguru import logger
+
+from pybandits.base_model import BaseModelMO, BaseModelSO
+from pybandits.cmab import BaseCmabBernoulli
+from pybandits.mab import BaseMab
+from pybandits.model import BaseBayesianNeuralNetwork
+from pybandits.pydantic_version_compatibility import validate_call
+from pybandits.quantitative_model import QuantitativeModel
+
+
+def _pick_learned_state(source_state: Dict[str, Any], model_cls: Type[BaseModelSO]) -> Dict[str, Any]:
+    """Extract transferable learned parameters from a source state dict.
+
+    Parameters
+    ----------
+    source_state : Dict[str, Any]
+        Source action state dictionary.
+    model_cls : Type[BaseModelSO]
+        Model class whose transfer_learned_keys declares which keys to extract.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Subset of source_state containing only the declared learned keys.
+    """
+    return {k: source_state[k] for k in model_cls.transfer_learned_keys if k in source_state}
+
+
+def _get_state_dict(mab: BaseMab) -> Dict[str, Any]:
+    """Convert MAB to dictionary via JSON serialization.
+
+    Parameters
+    ----------
+    mab : BaseMab
+        MAB instance to convert.
+
+    Returns
+    -------
+    state_dict : Dict[str, Any]
+        Dictionary representation of MAB state.
+    """
+    _, state_json = mab.get_state()
+    return json.loads(state_json)
+
+
+def _reconstruct_mab(mab_class: Type[BaseMab], state_dict: Dict[str, Any]) -> BaseMab:
+    """Reconstruct MAB from state dictionary.
+
+    Parameters
+    ----------
+    mab_class : Type[BaseMab]
+        MAB class to instantiate.
+    state_dict : Dict[str, Any]
+        State dictionary to reconstruct from.
+
+    Returns
+    -------
+    mab : BaseMab
+        Reconstructed MAB instance.
+    """
+    state_json = json.dumps(state_dict)
+    return mab_class.from_state(state_json)
+
+
+_VARIANT_LABELS = (
+    ("CMAB", "SMAB", "context type (CMAB vs SMAB)"),
+    ("MO", "SO", "objective type (MO vs SO)"),
+    ("quantitative", "standard", "action type (quantitative vs standard)"),
+)
+
+
+def _mab_variant(mab: BaseMab) -> Tuple[bool, bool, bool]:
+    """Return (is_cmab, is_mo, is_quantitative) for a MAB based on its type and action models."""
+    first_model = next(iter(mab.actions.values()), None)
+    return (
+        isinstance(mab, BaseCmabBernoulli),
+        isinstance(first_model, BaseModelMO),
+        isinstance(first_model, QuantitativeModel),
+    )
+
+
+def _validate_mab_compatibility(mab1: BaseMab, mab2: BaseMab) -> None:
+    """Validate that two MABs can be merged.
+
+    Checks that both MABs share the same three variant dimensions:
+    - Context type: CMAB (contextual) vs SMAB (stochastic)
+    - Objective type: MO (multi-objective) vs SO (single-objective)
+    - Action type: quantitative (zooming) vs standard (Bernoulli/Beta)
+
+    Parameters
+    ----------
+    mab1 : BaseMab
+        First MAB to check.
+    mab2 : BaseMab
+        Second MAB to check.
+
+    Raises
+    ------
+    TypeError
+        If MABs have incompatible variant dimensions.
+    """
+
+    v1 = _mab_variant(mab1)
+    v2 = _mab_variant(mab2)
+
+    for (val1, val2), (pos_label, neg_label, dimension) in zip(zip(v1, v2), _VARIANT_LABELS):
+        if val1 != val2:
+            raise TypeError(
+                f"Cannot merge MABs with different {dimension}: "
+                f"mab1 is {pos_label if val1 else neg_label}, "
+                f"mab2 is {pos_label if val2 else neg_label}."
+            )
+
+
+def _validate_single_objective_model(src: Any, tgt: Any, action_id: str, model_label: str = "") -> None:
+    """Validate a single SO model or one objective within MO."""
+    prefix = f" (objective {model_label})" if model_label else ""
+
+    for key in type(src).transfer_structural_keys:
+        src_val = getattr(src, key)
+        tgt_val = getattr(tgt, key, None)
+        if src_val != tgt_val:
+            raise ValueError(
+                f"Cannot transfer learned state for action '{action_id}'{prefix}: "
+                f"{key} mismatch (source: {src_val!r}, template: {tgt_val!r})."
+            )
+
+    for key in type(src).transfer_extendable_keys:
+        src_val = getattr(src, key)
+        tgt_val = getattr(tgt, key, None)
+        if src_val != tgt_val:
+            logger.warning(
+                f"Transfer learning for action '{action_id}'{prefix}: "
+                f"{key} changing from {src_val!r} to {tgt_val!r}. "
+                f"This changes the inference method but does not affect learned weights."
+            )
+
+
+def _validate_model_compatibility(
+    source_model: Any,
+    target_model: Any,
+    action_id: str,
+) -> None:
+    """Validate that source and target model instances have compatible structures for transfer learning.
+
+    Structural params are compared via getattr using each class's transfer_structural_keys.
+    Extendable params are compared via getattr using each class's transfer_extendable_keys.
+
+    For MO (multi-objective) models, validates each objective's model separately.
+
+    Parameters
+    ----------
+    source_model : Any
+        Source model instance (from mab1.actions[action_id]).
+    target_model : Any
+        Target model instance (from mab2.actions[action_id]).
+    action_id : str
+        Action ID for error messages.
+
+    Raises
+    ------
+    ValueError
+        If models have incompatible structures that prevent weight transfer.
+    """
+
+    # MO models have a .models list of SO models; validate per-objective
+    if isinstance(source_model, BaseModelMO):
+        if len(source_model.models) != len(target_model.models):
+            raise ValueError(
+                f"Cannot transfer learned state for action '{action_id}': "
+                f"number of objectives mismatch "
+                f"(source: {len(source_model.models)}, template: {len(target_model.models)})."
+            )
+        for obj_idx, (src_obj, tgt_obj) in enumerate(zip(source_model.models, target_model.models)):
+            _validate_single_objective_model(src_obj, tgt_obj, action_id, str(obj_idx))
+    else:
+        _validate_single_objective_model(source_model, target_model, action_id)
+
+
+def _transfer_learned_state(
+    target_action_state: Dict[str, Any],
+    source_action_state: Dict[str, Any],
+    model_instance: Any,
+) -> Dict[str, Any]:
+    """Transfer learned state from source to target action.
+
+    Takes the target action's structure and configuration,
+    but replaces learned state with values from source. The set of parameters
+    that counts as learned state is determined by the model class itself via
+    get_transfer_learned_params().
+
+    Since we work with state dicts from JSON serialization, objects are already
+    independent copies, so we don't need deepcopy.
+
+    Parameters
+    ----------
+    target_action_state : Dict[str, Any]
+        Target action state (defines structure and configuration).
+    source_action_state : Dict[str, Any]
+        Source action state (provides learned state to transfer).
+    model_instance : Any
+        The actual model object from the source MAB for this action. Used to dispatch
+        to the correct model class without relying on field presence.
+
+    Returns
+    -------
+    merged_action_state : Dict[str, Any]
+        Action state with target's configuration and source's learned state.
+    """
+    result = target_action_state.copy()
+
+    if isinstance(model_instance, BaseModelMO):
+        # MO: transfer learned state per objective using each objective's model class
+        result["models"] = [
+            {**tgt_obj, **_pick_learned_state(src_obj, type(obj_model))}
+            for obj_model, src_obj, tgt_obj in zip(
+                model_instance.models, source_action_state["models"], target_action_state["models"]
+            )
+        ]
+    else:
+        # SO: use the model class's declared transferable keys
+        result.update(_pick_learned_state(source_action_state, type(model_instance)))
+
+    return result
+
+
+@validate_call
+def _merge_mabs(
+    mab1: BaseMab,
+    mab2: BaseMab,
+) -> BaseMab:
+    """Merge two MABs using mab2 as template with learned state transfer.
+
+    Uses mab2 to define the structure of the resulting MAB (which actions exist and their
+    configuration), while transferring learned state from mab1 for overlapping actions.
+    This enables transfer learning scenarios like updating hyperparameters or changing the
+    action set while preserving learned knowledge.
+
+    The resulting MAB contains:
+    - Actions: Only actions from mab2 (mab2 defines the final action set)
+    - Configuration: All parameters (epsilon, delta, update_kwargs, etc.) from mab2
+    - Learned state: For overlapping actions, transferable parameters (n_successes,
+      n_failures, model_params) from mab1
+    - Strategy: From mab2
+
+    Parameters
+    ----------
+    mab1 : BaseMab
+        Source MAB providing learned state for overlapping actions.
+    mab2 : BaseMab
+        Template MAB defining which actions exist and their configuration.
+
+    Returns
+    -------
+    merged_mab : BaseMab
+        New MAB with mab2's structure and mab1's learned state for overlapping actions.
+
+    Raises
+    ------
+    TypeError
+        If MAB classes don't match (e.g., SmabBernoulli vs CmabBernoulli).
+
+    Examples
+    --------
+    >>> from pybandits.smab import SmabBernoulli
+    >>> from pybandits.strategy import ClassicBandit
+    >>>
+    >>> # Example 1: No overlapping actions - simple combination
+    >>> mab1 = SmabBernoulli.cold_start(action_ids={'a1', 'a2'}, strategy=ClassicBandit())
+    >>> mab2 = SmabBernoulli.cold_start(action_ids={'a3', 'a4'}, strategy=ClassicBandit())
+    >>> merged = merge_mabs(mab1, mab2)
+    >>> sorted(merged.actions.keys())  # Only actions from mab2
+    ['a3', 'a4']
+    >>>
+    >>> # Example 2: Overlapping actions - transfer learned state
+    >>> mab1 = SmabBernoulli.cold_start(action_ids={'a1', 'a2'}, strategy=ClassicBandit())
+    >>> mab1.update(actions=['a1'], rewards=[1])  # Train a1 in mab1
+    >>> mab2 = SmabBernoulli.cold_start(action_ids={'a1', 'a3'}, strategy=ClassicBandit())
+    >>> merged = merge_mabs(mab1, mab2)
+    >>> # Result has only actions from mab2: a1 (with learned state from mab1) and a3
+    >>> sorted(merged.actions.keys())  # a2 is discarded (not in mab2)
+    ['a1', 'a3']
+    >>> merged.actions['a1'].n_successes  # Learned state from mab1
+    2
+    >>> merged.actions['a3'].n_successes  # Cold start from mab2
+    1
+    >>>
+    >>> # Example 3: Update hyperparameters while keeping learned weights
+    >>> from pybandits.cmab import CmabBernoulli
+    >>> mab1 = CmabBernoulli.cold_start(action_ids={'a1'}, n_features=5,
+    ...                                  update_kwargs={'fit': {'n': 50}})
+    >>> # ... train mab1 ...
+    >>> mab2 = CmabBernoulli.cold_start(action_ids={'a1'}, n_features=5,
+    ...                                  update_kwargs={'fit': {'n': 200}})
+    >>> merged = merge_mabs(mab1, mab2)
+    >>> merged.actions['a1'].update_kwargs['fit']['n']  # New config from mab2
+    200
+    >>> # But model_params (learned weights) come from mab1
+    """
+    _validate_mab_compatibility(mab1, mab2)
+    state1 = _get_state_dict(mab1)
+    state2 = _get_state_dict(mab2)
+
+    # Extract actions
+    actions1 = state1["actions_manager"]["actions"]
+    actions2 = state2["actions_manager"]["actions"]
+
+    # Count overlapping actions
+    overlapping = set(actions1.keys()) & set(actions2.keys())
+
+    # Use mab2 as template (defines which actions exist and their configuration)
+    # Transfer learned state from mab1 for overlapping actions
+    merged_actions = {}
+    for action_id, action_state in actions2.items():
+        if action_id in actions1:
+            source_model = mab1.actions[action_id]
+            target_model = mab2.actions[action_id]
+
+            # Validate model compatibility before transfer
+            _validate_model_compatibility(source_model, target_model, action_id)
+
+            # Action exists in both: use mab2's config, mab1's learned state
+            merged_actions[action_id] = _transfer_learned_state(
+                target_action_state=action_state,
+                source_action_state=actions1[action_id],
+                model_instance=source_model,
+            )
+        else:
+            # Action only in mab2: use as-is (cold start)
+            # No need to copy - already from JSON deserialization
+            merged_actions[action_id] = action_state
+
+    logger.info(
+        f"Merged {type(mab1).__name__}: used mab2 as template with {len(actions2)} action(s), "
+        f"transferred learned state from mab1 for {len(overlapping)} overlapping action(s)."
+    )
+
+    # Create merged state using mab2 as base (provides all configuration)
+    # Then replace actions with merged versions (which have learned state from mab1)
+    merged_state = state2
+    merged_state["actions_manager"]["actions"] = merged_actions
+
+    # Merge actions_with_change sets (for adaptive windowing)
+    actions_with_change_1 = set(state1["actions_manager"].get("actions_with_change", []))
+    actions_with_change_2 = set(state2["actions_manager"].get("actions_with_change", []))
+    merged_state["actions_manager"]["actions_with_change"] = list(actions_with_change_1 | actions_with_change_2)
+
+    # Reconstruct MAB using mab2's type (mab2 is the template defining final structure)
+    return _reconstruct_mab(type(mab2), merged_state)
+
+
+def _append_template_bnn_features(
+    current_model_params: Dict[str, Any],
+    template_model_params: Dict[str, Any],
+    current_dim: int,
+) -> None:
+    """Append template's new feature weights to current model parameters (in-place).
+
+    Parameters
+    ----------
+    current_model_params : Dict[str, Any]
+        Model parameters dict to expand (modified in-place).
+    template_model_params : Dict[str, Any]
+        Template model parameters with additional features.
+    current_dim : int
+        Current input dimension (number of features in current model).
+    """
+    # For both learned and init params
+    for params_key in ["bnn_layer_params", "bnn_layer_params_init"]:
+        if params_key not in current_model_params or params_key not in template_model_params:
+            continue
+
+        current_layer = current_model_params[params_key][0]
+        template_layer = template_model_params[params_key][0]
+
+        # Expand weight distribution parameters
+        current_weight = current_layer[BaseBayesianNeuralNetwork.weight_var_name]
+        template_weight = template_layer[BaseBayesianNeuralNetwork.weight_var_name]
+
+        for field_name in current_weight:
+            if isinstance(current_weight[field_name], list) and current_weight[field_name]:
+                if isinstance(current_weight[field_name][0], list):
+                    # This is 2D array (input_dim, output_dim)
+                    # Append the new rows from template (from current_dim onward)
+                    new_rows = template_weight[field_name][current_dim:]
+                    current_weight[field_name].extend(new_rows)
+
+
+def _expand_with_template_weights(
+    current_cmab: BaseCmabBernoulli,
+    template_cmab: BaseCmabBernoulli,
+) -> BaseCmabBernoulli:
+    """Expand current CMAB to match template's input dimension using template's weights for new features.
+
+    Parameters
+    ----------
+    current_cmab : BaseCmabBernoulli
+        CMAB with smaller input dimension.
+    template_cmab : BaseCmabBernoulli
+        Template CMAB with larger input dimension.
+
+    Returns
+    -------
+    expanded_cmab : BaseCmabBernoulli
+        Expanded CMAB with current's existing feature weights and template's new feature weights.
+    """
+    current_dim = current_cmab.input_dim
+    template_dim = template_cmab.input_dim
+    n_new_features = template_dim - current_dim
+
+    logger.info(
+        f"Expanding current CMAB from {current_dim} to {template_dim} features "
+        f"using template's weights for {n_new_features} new feature(s)"
+    )
+
+    # Get state dicts
+    current_state = _get_state_dict(current_cmab)
+    template_state = _get_state_dict(template_cmab)
+
+    current_actions = current_state["actions_manager"]["actions"]
+    template_actions = template_state["actions_manager"]["actions"]
+
+    # For each overlapping action, expand by appending template's new features
+    for action_id in set(current_actions.keys()) & set(template_actions.keys()):
+        current_action = current_actions[action_id]
+        template_action = template_actions[action_id]
+        action_model = current_cmab.actions[action_id]
+
+        if isinstance(action_model, BaseModelMO):
+            # Multi-objective: each objective has its own BNN model
+            for model_idx in range(len(current_action["models"])):
+                if model_idx >= len(template_action["models"]):
+                    continue
+                _append_template_bnn_features(
+                    current_action["models"][model_idx]["model_params"],
+                    template_action["models"][model_idx]["model_params"],
+                    current_dim,
+                )
+        elif isinstance(action_model, BaseBayesianNeuralNetwork):
+            # Single-objective BNN
+            _append_template_bnn_features(
+                current_action["model_params"],
+                template_action["model_params"],
+                current_dim,
+            )
+        else:
+            raise TypeError(
+                f"Unsupported model type for feature expansion: {type(action_model).__name__}. "
+                "Only BNN-based CMAB models support input dimension expansion."
+            )
+
+    return _reconstruct_mab(type(current_cmab), current_state)
+
+
+@validate_call
+def edit_model_on_the_fly(
+    current_mab: BaseMab,
+    new_mab: BaseMab,
+) -> BaseMab:
+    """Update MAB configuration and actions using new_mab as template.
+
+    Uses new_mab to define which actions exist and their configuration (editable parameters),
+    while preserving learned state (non-editable parameters) from current_mab for overlapping
+    actions. This is useful for transfer learning scenarios where you want to:
+    - Update hyperparameters while keeping learned weights
+    - Add or remove actions while preserving knowledge of existing ones
+    - Change model configuration without retraining from scratch
+    - Add new input features to CMAB models while preserving existing feature weights
+
+    Model Compatibility Validation
+    -------------------------------
+    Transfer learning requires structural compatibility between models. The function validates
+    that overlapping actions have compatible model structures using a 3-tier system:
+
+    **STRUCTURAL_IMMUTABLE (must match - raises ValueError):**
+        - activation: Activation function (tanh, relu, sigmoid, gelu)
+        - use_residual_connections: Whether skip connections are used
+
+    **STRUCTURAL_EXTENDABLE (warns but allows):**
+        - update_method: Inference method (VI vs MCMC) - emits warning if changed
+
+    **CONFIGURABLE_MUTABLE (safe to change):**
+        - update_kwargs: Training hyperparameters (epochs, learning rate, etc.)
+        - use_layerwise_scaling: Only affects initialization
+        - epsilon, delta: Exploration parameters
+
+    For Beta models (simple Bernoulli), no structural validation is needed as they only
+    store n_successes and n_failures counts.
+
+    For CMABs with different input dimensions:
+    - If template has MORE features: automatically expands current MAB using template's weights for new features
+    - If template has FEWER features: raises ValueError (cannot reduce dimensions)
+
+    The resulting MAB will have:
+    - Actions: All actions from new_mab
+    - Configuration: All parameters from new_mab (epsilon, delta, update_kwargs, etc.)
+    - Learned state: For actions that exist in both MABs, transferable parameters
+      (n_successes, n_failures, model_params) from current_mab
+    - Strategy: From new_mab
+    - Input features (CMAB): Existing features from current_mab + new features from template
+
+    Parameters
+    ----------
+    current_mab : BaseMab
+        MAB with current actions and learned state.
+    new_mab : BaseMab
+        MAB defining desired actions and configuration.
+
+    Returns
+    -------
+    updated_mab : BaseMab
+        New MAB with actions from new_mab, configuration from new_mab,
+        and learned state from current_mab for overlapping actions.
+
+    Raises
+    ------
+    TypeError
+        If MAB classes don't match.
+    ValueError
+        If template CMAB has fewer features than current CMAB, or if overlapping actions
+        have incompatible model structures (different activation or residual connections).
+
+    Examples
+    --------
+    >>> from pybandits.smab import SmabBernoulli
+    >>> from pybandits.cmab import CmabBernoulli
+    >>> from pybandits.strategy import ClassicBandit
+    >>>
+    >>> # Example 1: Simple MAB - update actions
+    >>> current = SmabBernoulli.cold_start(action_ids={'a1', 'a2'}, strategy=ClassicBandit())
+    >>> current.update(actions=['a1', 'a1'], rewards=[1, 1])  # Train a1
+    >>> new = SmabBernoulli.cold_start(action_ids={'a1', 'a3'}, strategy=ClassicBandit())
+    >>> merged = edit_model_on_the_fly(current, new)
+    >>> len(merged.actions)
+    2
+    >>> merged.actions['a1'].n_successes  # Learned state from current
+    3
+    >>> merged.actions['a3'].n_successes  # Cold start from new
+    1
+    >>>
+    >>> # Example 2: CMAB - update hyperparameters (ALLOWED)
+    >>> current = CmabBernoulli.cold_start(action_ids={'a1'}, n_features=5,
+    ...                                      activation='relu', update_kwargs={'fit': {'n': 50}})
+    >>> # ... train current ...
+    >>> new = CmabBernoulli.cold_start(action_ids={'a1'}, n_features=5,
+    ...                                 activation='relu', update_kwargs={'fit': {'n': 200}})
+    >>> merged = edit_model_on_the_fly(current, new)  # Success - only hyperparameters changed
+    >>>
+    >>> # Example 3: CMAB - incompatible activation (RAISES ValueError)
+    >>> current = CmabBernoulli.cold_start(action_ids={'a1'}, n_features=5, activation='relu')
+    >>> new = CmabBernoulli.cold_start(action_ids={'a1'}, n_features=5, activation='tanh')
+    >>> try:
+    ...     merged = edit_model_on_the_fly(current, new)
+    ... except ValueError as e:
+    ...     print("Error: activation mismatch prevents transfer")
+    >>>
+    >>> # Example 4: CMAB - update_method change (WARNS but allows)
+    >>> current = CmabBernoulli.cold_start(action_ids={'a1'}, n_features=5, update_method='VI')
+    >>> new = CmabBernoulli.cold_start(action_ids={'a1'}, n_features=5, update_method='MCMC')
+    >>> merged = edit_model_on_the_fly(current, new)  # Success with warning
+    """
+    _validate_mab_compatibility(current_mab, new_mab)
+
+    # Check if we're dealing with CMABs and handle input dimension mismatches
+    if isinstance(current_mab, BaseCmabBernoulli) and isinstance(new_mab, BaseCmabBernoulli):
+        # Get input dimensions via the property on BaseCmabBernoulli
+        try:
+            current_dim = current_mab.input_dim
+            new_dim = new_mab.input_dim
+
+            if current_dim != new_dim:
+                if new_dim < current_dim:
+                    raise ValueError(
+                        f"Template MAB has fewer features ({new_dim}) than current MAB ({current_dim}). "
+                        "Cannot reduce feature dimensions. Template must have same or more features."
+                    )
+                else:
+                    # new_dim > current_dim: expand current_mab to match template's dimension
+                    logger.info(
+                        f"Template has more features ({new_dim}) than current ({current_dim}). "
+                        f"Expanding current MAB to match template's dimension."
+                    )
+                    current_mab = _expand_with_template_weights(current_mab, new_mab)
+        except (StopIteration, AttributeError):
+            # No actions or not a CMAB with input_dim, proceed normally
+            pass
+
+    # Merge using new_mab as template with learned state transfer from current_mab
+    merged_mab = _merge_mabs(current_mab, new_mab)
+
+    logger.info(
+        f"Updated MAB using new_mab as template. "
+        f"Final MAB has {len(merged_mab.actions)} action(s) with new_mab's configuration "
+        f"and current_mab's learned state for overlapping actions."
+    )
+
+    return merged_mab

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybandits"
-version = "4.1.3"
+version = "4.2.0"
 description = "Python Multi-Armed Bandit Library"
 authors = [
     "Dario d'Andrea <dariod@playtika.com>",

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1,0 +1,727 @@
+# MIT License
+#
+# Copyright (c) 2023 Playtika Ltd.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Tests for transfer learning functionality."""
+
+import logging
+from typing import Any, Dict, Tuple
+
+import numpy as np
+import pytest
+from _pytest.logging import LogCaptureFixture
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+from pytest import MonkeyPatch
+
+import pybandits
+from pybandits.cmab import CmabBernoulli, CmabBernoulliMO
+from pybandits.model import BaseBayesianNeuralNetwork
+from pybandits.smab import SmabBernoulli, SmabBernoulliCC, SmabBernoulliMO
+from pybandits.strategy import (
+    ClassicBandit,
+    CostControlBandit,
+    MultiObjectiveBandit,
+)
+from pybandits.transfer import (
+    _merge_mabs,
+    edit_model_on_the_fly,
+)
+from tests.utils import FakeApproximation
+
+# ---------------------------------------------------------------------------
+# Module-level constants shared across tests
+# ---------------------------------------------------------------------------
+_N_FEATURES = 5
+_ACTION_ID = "a1"
+
+# Contrasting value pairs for each structural key — both must produce valid CmabBernoulli models.
+# Keyed by the attribute name as it appears in transfer_structural_keys AND in cold_start kwargs.
+_BNN_STRUCTURAL_KEY_VALUES: Dict[str, Tuple[Any, Any]] = {
+    "activation": ("relu", "tanh"),
+    "use_residual_connections": (False, True),
+}
+
+# Contrasting value pairs for each extendable key.
+_BNN_EXTENDABLE_KEY_VALUES: Dict[str, Tuple[Any, Any]] = {
+    "update_method": ("VI", "MCMC"),
+}
+
+# Guard: these dicts must stay in sync with the actual ClassVar declarations.
+assert set(_BNN_STRUCTURAL_KEY_VALUES) == set(BaseBayesianNeuralNetwork.transfer_structural_keys), (
+    "_BNN_STRUCTURAL_KEY_VALUES must cover exactly BaseBayesianNeuralNetwork.transfer_structural_keys. "
+    f"Missing: {set(BaseBayesianNeuralNetwork.transfer_structural_keys) - set(_BNN_STRUCTURAL_KEY_VALUES)}, "
+    f"Extra: {set(_BNN_STRUCTURAL_KEY_VALUES) - set(BaseBayesianNeuralNetwork.transfer_structural_keys)}"
+)
+assert set(_BNN_EXTENDABLE_KEY_VALUES) == set(BaseBayesianNeuralNetwork.transfer_extendable_keys), (
+    "_BNN_EXTENDABLE_KEY_VALUES must cover exactly BaseBayesianNeuralNetwork.transfer_extendable_keys. "
+    f"Missing: {set(BaseBayesianNeuralNetwork.transfer_extendable_keys) - set(_BNN_EXTENDABLE_KEY_VALUES)}, "
+    f"Extra: {set(_BNN_EXTENDABLE_KEY_VALUES) - set(BaseBayesianNeuralNetwork.transfer_extendable_keys)}"
+)
+
+# Hypothesis strategies for test data generation
+single_action_id_strategy = st.text(
+    min_size=1, max_size=10, alphabet=st.characters(whitelist_categories=("Lu", "Ll", "Nd"))
+)
+action_ids_strategy = st.lists(
+    single_action_id_strategy,
+    min_size=1,
+    max_size=5,
+    unique=True,
+).map(set)
+n_features_strategy = st.integers(min_value=2, max_value=10)
+n_objectives_strategy = st.integers(min_value=2, max_value=4)
+epsilon_strategy = st.floats(min_value=0.0, max_value=0.5)
+subsidy_factor_strategy = st.floats(min_value=0.1, max_value=1.0)
+cost_strategy = st.floats(min_value=0.1, max_value=10.0)
+
+
+class TestMergeMABs:
+    """Test suite for _merge_mabs function."""
+
+    @settings(suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        action_ids1=action_ids_strategy,
+        action_ids2=action_ids_strategy,
+    )
+    def test_merge_compatible_smabs(self, action_ids1: set, action_ids2: set) -> None:
+        """Test merging two compatible SmabBernoulli instances uses mab2 as template."""
+        # Ensure no overlap
+        action_ids2 = {f"b_{aid}" for aid in action_ids2}
+
+        mab1 = SmabBernoulli.cold_start(action_ids=action_ids1, strategy=ClassicBandit())
+        mab2 = SmabBernoulli.cold_start(action_ids=action_ids2, strategy=ClassicBandit())
+
+        merged = _merge_mabs(mab1, mab2)
+
+        # Result should only have actions from mab2 (template)
+        assert len(merged.actions) == len(action_ids2)
+        assert set(merged.actions.keys()) == action_ids2
+        assert isinstance(merged, SmabBernoulli)
+        assert isinstance(merged.strategy, ClassicBandit)
+
+    @given(
+        action_ids1=action_ids_strategy,
+        action_ids2=action_ids_strategy,
+        n_features=n_features_strategy,
+    )
+    def test_merge_compatible_cmabs(self, action_ids1: set, action_ids2: set, n_features: int) -> None:
+        """Test merging two compatible CmabBernoulli instances uses mab2 as template."""
+        # Ensure no overlap
+        action_ids2 = {f"b_{aid}" for aid in action_ids2}
+
+        mab1 = CmabBernoulli.cold_start(
+            action_ids=action_ids1, n_features=n_features, strategy=ClassicBandit(), update_method="VI"
+        )
+        mab2 = CmabBernoulli.cold_start(
+            action_ids=action_ids2, n_features=n_features, strategy=ClassicBandit(), update_method="VI"
+        )
+
+        merged = _merge_mabs(mab1, mab2)
+
+        # Result should only have actions from mab2 (template)
+        assert len(merged.actions) == len(action_ids2)
+        assert set(merged.actions.keys()) == action_ids2
+        assert isinstance(merged, CmabBernoulli)
+
+    @given(
+        common_actions=action_ids_strategy,
+        unique_actions1=action_ids_strategy,
+        unique_actions2=action_ids_strategy,
+    )
+    def test_merge_with_overlapping_actions(
+        self, common_actions: set, unique_actions1: set, unique_actions2: set
+    ) -> None:
+        """Test that merge uses mab2 as template and transfers learned state for overlapping actions."""
+        # Ensure we have at least one common action
+        if not common_actions:
+            pytest.skip("Need at least one common action")
+
+        # Create distinct action sets with overlap
+        action_ids1 = common_actions.union({f"a_{aid}" for aid in unique_actions1})
+        action_ids2 = common_actions.union({f"b_{aid}" for aid in unique_actions2})
+
+        mab1 = SmabBernoulli.cold_start(action_ids=action_ids1, strategy=ClassicBandit())
+        mab2 = SmabBernoulli.cold_start(action_ids=action_ids2, strategy=ClassicBandit())
+
+        # Train overlapping actions in mab1
+        common_action = next(iter(common_actions))
+        mab1.update(actions=[common_action], rewards=[1])
+
+        # Merge: should use mab2 as template
+        merged = _merge_mabs(mab1, mab2)
+
+        # Result should only have actions from mab2
+        assert set(merged.actions.keys()) == action_ids2
+
+        # Overlapping action should have learned state from mab1
+        assert merged.actions[common_action].n_successes == 2  # 1 (cold start) + 1 (update)
+
+    @given(
+        action_id1=single_action_id_strategy,
+        action_id2=single_action_id_strategy,
+        n_features=n_features_strategy,
+    )
+    def test_merge_incompatible_types_raises(self, action_id1: str, action_id2: str, n_features: int) -> None:
+        """Test that merging different MAB types raises TypeError."""
+        mab1 = SmabBernoulli.cold_start(action_ids={action_id1}, strategy=ClassicBandit())
+        mab2 = CmabBernoulli.cold_start(action_ids={action_id2}, n_features=n_features, strategy=ClassicBandit())
+
+        with pytest.raises(TypeError, match="Cannot merge MABs"):
+            _merge_mabs(mab1, mab2)
+
+    @given(
+        action_id1=single_action_id_strategy,
+        action_id2=single_action_id_strategy,
+        cost=cost_strategy,
+        subsidy_factor=subsidy_factor_strategy,
+    )
+    def test_merge_cc_and_noncc_is_allowed(
+        self, action_id1: str, action_id2: str, cost: float, subsidy_factor: float
+    ) -> None:
+        """Test that merging CC and non-CC MABs is allowed (CC is a config, not a structural constraint)."""
+        mab1 = SmabBernoulli.cold_start(action_ids={action_id1}, strategy=ClassicBandit())
+        mab2 = SmabBernoulliCC.cold_start(
+            action_ids_cost={action_id2: cost}, strategy=CostControlBandit(subsidy_factor=subsidy_factor)
+        )
+
+        # CC ↔ non-CC merging is allowed: result has mab2's type (template)
+        merged = _merge_mabs(mab1, mab2)
+        assert isinstance(merged, SmabBernoulliCC)
+        merged_rev = _merge_mabs(mab2, mab1)
+        assert isinstance(merged_rev, SmabBernoulli)
+
+    @given(
+        action_ids1=action_ids_strategy,
+        action_ids2=action_ids_strategy,
+    )
+    def test_merge_strategy_from_first_mab(self, action_ids1: set, action_ids2: set) -> None:
+        """Test that merged MAB uses strategy from first MAB."""
+        # Ensure no overlap
+        action_ids2 = {f"b_{aid}" for aid in action_ids2}
+
+        mab1 = SmabBernoulli.cold_start(action_ids=action_ids1, strategy=ClassicBandit())
+        mab2 = SmabBernoulli.cold_start(action_ids=action_ids2, strategy=ClassicBandit())
+
+        merged = _merge_mabs(mab1, mab2)
+
+        assert isinstance(merged.strategy, ClassicBandit)
+
+    @given(
+        action_ids1=action_ids_strategy,
+        action_ids2=action_ids_strategy,
+        epsilon1=epsilon_strategy,
+        epsilon2=epsilon_strategy,
+    )
+    def test_merge_epsilon_from_first_mab(
+        self, action_ids1: set, action_ids2: set, epsilon1: float, epsilon2: float
+    ) -> None:
+        """Test that merged MAB uses epsilon from second MAB (template)."""
+        # Ensure no overlap
+        action_ids2 = {f"b_{aid}" for aid in action_ids2}
+
+        mab1 = SmabBernoulli.cold_start(action_ids=action_ids1, strategy=ClassicBandit(), epsilon=epsilon1)
+        mab2 = SmabBernoulli.cold_start(action_ids=action_ids2, strategy=ClassicBandit(), epsilon=epsilon2)
+
+        merged = _merge_mabs(mab1, mab2)
+
+        assert merged.epsilon == epsilon2
+
+    @given(
+        action_ids1=action_ids_strategy,
+        action_ids2=action_ids_strategy,
+        n_objectives=n_objectives_strategy,
+    )
+    def test_merge_mo_mabs(self, action_ids1: set, action_ids2: set, n_objectives: int) -> None:
+        """Test merging multi-objective MABs uses mab2 as template."""
+        # Ensure no overlap
+        action_ids2 = {f"b_{aid}" for aid in action_ids2}
+
+        mab1 = SmabBernoulliMO.cold_start(
+            action_ids=action_ids1, n_objectives=n_objectives, strategy=MultiObjectiveBandit()
+        )
+        mab2 = SmabBernoulliMO.cold_start(
+            action_ids=action_ids2, n_objectives=n_objectives, strategy=MultiObjectiveBandit()
+        )
+
+        merged = _merge_mabs(mab1, mab2)
+
+        # Result should only have actions from mab2 (template)
+        assert len(merged.actions) == len(action_ids2)
+        assert isinstance(merged, SmabBernoulliMO)
+
+    @given(
+        action_ids1=action_ids_strategy,
+        action_ids2=action_ids_strategy,
+        subsidy_factor=subsidy_factor_strategy,
+    )
+    def test_merge_cc_mabs(self, action_ids1: set, action_ids2: set, subsidy_factor: float) -> None:
+        """Test merging cost-control MABs uses mab2 as template."""
+        # Ensure no overlap
+        action_ids2 = {f"b_{aid}" for aid in action_ids2}
+
+        # Generate random costs for each action
+        action_ids_cost1 = {aid: np.random.uniform(0.5, 5.0) for aid in action_ids1}
+        action_ids_cost2 = {aid: np.random.uniform(0.5, 5.0) for aid in action_ids2}
+
+        mab1 = SmabBernoulliCC.cold_start(
+            action_ids_cost=action_ids_cost1, strategy=CostControlBandit(subsidy_factor=subsidy_factor)
+        )
+        mab2 = SmabBernoulliCC.cold_start(
+            action_ids_cost=action_ids_cost2, strategy=CostControlBandit(subsidy_factor=subsidy_factor)
+        )
+
+        merged = _merge_mabs(mab1, mab2)
+
+        # Result should only have actions from mab2 (template)
+        assert len(merged.actions) == len(action_ids2)
+        assert isinstance(merged, SmabBernoulliCC)
+
+    @given(
+        action_id1=single_action_id_strategy,
+        action_id2=single_action_id_strategy,
+        n_updates1=st.integers(min_value=1, max_value=10),
+        n_updates2=st.integers(min_value=1, max_value=10),
+        rewards1=st.lists(st.integers(min_value=0, max_value=1), min_size=1, max_size=5),
+        rewards2=st.lists(st.integers(min_value=0, max_value=1), min_size=1, max_size=5),
+    )
+    def test_merge_preserves_learned_state(
+        self,
+        action_id1: str,
+        action_id2: str,
+        n_updates1: int,
+        n_updates2: int,
+        rewards1: list,
+        rewards2: list,
+    ) -> None:
+        """Test that merge uses mab2 as template and preserves learned state for overlapping actions."""
+        # Create MABs with overlapping actions
+        mab1 = SmabBernoulli.cold_start(action_ids={action_id1, action_id2}, strategy=ClassicBandit())
+        mab2 = SmabBernoulli.cold_start(action_ids={action_id2}, strategy=ClassicBandit())
+
+        # Train both MABs (use limited updates to match rewards list size)
+        n_updates1 = min(n_updates1, len(rewards1))
+        n_updates2 = min(n_updates2, len(rewards2))
+
+        mab1.update(actions=[action_id2] * n_updates1, rewards=rewards1[:n_updates1])
+        mab2.update(actions=[action_id2] * n_updates2, rewards=rewards2[:n_updates2])
+
+        merged = _merge_mabs(mab1, mab2)
+
+        # Result should only have actions from mab2 (template)
+        assert set(merged.actions.keys()) == {action_id2}
+        # action_id2 should have learned state from mab1 (not mab2)
+        assert merged.actions[action_id2].n_successes == 1 + sum(rewards1[:n_updates1])
+        assert merged.actions[action_id2].n_failures == 1 + n_updates1 - sum(rewards1[:n_updates1])
+
+
+class TestEditModelOnTheFly:
+    """Test suite for edit_model_on_the_fly function."""
+
+    @given(
+        action_ids1=action_ids_strategy,
+        action_ids2=action_ids_strategy,
+    )
+    def test_edit_uses_new_as_template(self, action_ids1: set, action_ids2: set) -> None:
+        """Test that edit_model_on_the_fly uses new_mab as template."""
+        # Ensure no overlap
+        action_ids2 = {f"b_{aid}" for aid in action_ids2}
+
+        current = SmabBernoulli.cold_start(action_ids=action_ids1, strategy=ClassicBandit())
+        new = SmabBernoulli.cold_start(action_ids=action_ids2, strategy=ClassicBandit())
+
+        merged = edit_model_on_the_fly(current, new)
+
+        # Result should only have actions from new_mab (template)
+        assert len(merged.actions) == len(action_ids2)
+        assert set(merged.actions.keys()) == action_ids2
+
+    @given(
+        action_ids1=action_ids_strategy,
+        action_ids2=action_ids_strategy,
+        n_features=n_features_strategy,
+        n_iterations=st.integers(min_value=1, max_value=10),
+    )
+    def test_edit_uses_new_config(self, action_ids1: set, action_ids2: set, n_features: int, n_iterations: int) -> None:
+        """Test that edit_model_on_the_fly uses new_mab's configuration."""
+        # Ensure no overlap
+        action_ids2 = {f"b_{aid}" for aid in action_ids2}
+
+        current = CmabBernoulli.cold_start(
+            action_ids=action_ids1,
+            n_features=n_features,
+            strategy=ClassicBandit(),
+            update_kwargs={"fit": {"n": n_iterations}},
+        )
+        new = CmabBernoulli.cold_start(
+            action_ids=action_ids2,
+            n_features=n_features,
+            strategy=ClassicBandit(),
+            update_kwargs={"fit": {"n": n_iterations}},
+        )
+
+        merged = edit_model_on_the_fly(current, new)
+
+        # Result should only have actions from new_mab with their configuration
+        assert set(merged.actions.keys()) == action_ids2
+        for action_id in action_ids2:
+            assert merged.actions[action_id].update_kwargs["fit"]["n"] == n_iterations
+
+    @given(
+        action_ids1=action_ids_strategy,
+        action_ids2=action_ids_strategy,
+    )
+    def test_edit_uses_new_as_template_simple(self, action_ids1: set, action_ids2: set) -> None:
+        """Test that edit_model_on_the_fly uses new_mab as template."""
+        # Ensure no overlap
+        action_ids2 = {f"b_{aid}" for aid in action_ids2}
+
+        current = SmabBernoulli.cold_start(action_ids=action_ids1, strategy=ClassicBandit())
+        new = SmabBernoulli.cold_start(action_ids=action_ids2, strategy=ClassicBandit())
+
+        merged = edit_model_on_the_fly(current, new)
+
+        # Result should only have actions from new_mab (template)
+        assert len(merged.actions) == len(action_ids2)
+        assert set(merged.actions.keys()) == action_ids2
+
+    @given(
+        action_id1=single_action_id_strategy,
+        action_id2=single_action_id_strategy,
+        n_updates=st.integers(min_value=1, max_value=10),
+        rewards=st.lists(st.integers(min_value=0, max_value=1), min_size=1, max_size=5),
+    )
+    def test_edit_preserves_learned_state(
+        self, action_id1: str, action_id2: str, n_updates: int, rewards: list
+    ) -> None:
+        """Test that learned state is preserved during edit for overlapping actions."""
+        # Ensure distinct action IDs
+        if action_id1 == action_id2:
+            action_id2 = f"b_{action_id2}"
+
+        # Create MABs with one overlapping action
+        current = SmabBernoulli.cold_start(action_ids={action_id1, action_id2}, strategy=ClassicBandit())
+        new = SmabBernoulli.cold_start(action_ids={action_id1}, strategy=ClassicBandit())
+
+        # Train current (use limited updates to match rewards list size)
+        n_updates = min(n_updates, len(rewards))
+        current.update(actions=[action_id1] * n_updates, rewards=rewards[:n_updates])
+
+        merged = edit_model_on_the_fly(current, new)
+
+        # Result should only have actions from new (template)
+        assert set(merged.actions.keys()) == {action_id1}
+        # action_id1 should have learned state from current
+        assert merged.actions[action_id1].n_successes == 1 + sum(rewards[:n_updates])
+        assert merged.actions[action_id1].n_failures == 1 + n_updates - sum(rewards[:n_updates])
+
+    @given(
+        action_id1=single_action_id_strategy,
+        action_id2=single_action_id_strategy,
+        n_features=n_features_strategy,
+    )
+    def test_edit_incompatible_raises(self, action_id1: str, action_id2: str, n_features: int) -> None:
+        """Test that editing incompatible MABs raises error."""
+        current = SmabBernoulli.cold_start(action_ids={action_id1}, strategy=ClassicBandit())
+        new = CmabBernoulli.cold_start(action_ids={action_id2}, n_features=n_features, strategy=ClassicBandit())
+
+        with pytest.raises(TypeError, match="Cannot merge MABs"):
+            edit_model_on_the_fly(current, new)
+
+    @given(
+        action_id1=single_action_id_strategy,
+        action_id2=single_action_id_strategy,
+        cost=cost_strategy,
+        subsidy_factor=subsidy_factor_strategy,
+    )
+    def test_edit_cc_to_standard_allowed(
+        self, action_id1: str, action_id2: str, cost: float, subsidy_factor: float
+    ) -> None:
+        """Test that changing CC model to standard (non-CC) and vice versa is allowed."""
+        current_cc = SmabBernoulliCC.cold_start(
+            action_ids_cost={action_id1: cost}, strategy=CostControlBandit(subsidy_factor=subsidy_factor)
+        )
+        current_std = SmabBernoulli.cold_start(action_ids={action_id2}, strategy=ClassicBandit())
+
+        # CC → non-CC: result is SmabBernoulli (new_mab is the template)
+        result = edit_model_on_the_fly(current_cc, current_std)
+        assert isinstance(result, SmabBernoulli)
+
+        # non-CC → CC: result is SmabBernoulliCC (new_mab is the template)
+        result_rev = edit_model_on_the_fly(current_std, current_cc)
+        assert isinstance(result_rev, SmabBernoulliCC)
+
+
+class TestIntegration:
+    """Integration tests for transfer learning workflows."""
+
+    @given(
+        old_action=single_action_id_strategy,
+        new_action=single_action_id_strategy,
+        n_updates=st.integers(min_value=1, max_value=10),
+        rewards=st.lists(st.integers(min_value=0, max_value=1), min_size=5, max_size=30),
+    )
+    def test_transfer_learning_workflow(self, old_action: str, new_action: str, n_updates: int, rewards: list) -> None:
+        """Test a complete transfer learning workflow with overlapping action."""
+        # Ensure distinct action IDs
+        if old_action == new_action:
+            new_action = f"new_{new_action}"
+
+        # Create source MAB and train it
+        source = SmabBernoulli.cold_start(action_ids={old_action, new_action}, strategy=ClassicBandit())
+        n_updates = min(n_updates, len(rewards))
+        source.update(actions=[old_action] * n_updates, rewards=rewards[:n_updates])
+
+        # Create target MAB with overlapping action and one new action
+        target = SmabBernoulli.cold_start(action_ids={old_action}, strategy=ClassicBandit())
+
+        # Merge using target as template
+        combined = _merge_mabs(source, target)
+
+        # Result should only have actions from target (template)
+        assert set(combined.actions.keys()) == {old_action}
+        # old_action should have learned state from source
+        assert combined.actions[old_action].n_successes == 1 + sum(rewards[:n_updates])
+        assert combined.actions[old_action].n_failures == 1 + n_updates - sum(rewards[:n_updates])
+
+    @given(
+        action_ids=action_ids_strategy.filter(lambda x: len(x) >= 2),
+        n_features=n_features_strategy,
+        n_initial=st.integers(min_value=1, max_value=10),
+        n_updated=st.integers(min_value=11, max_value=20),
+        learning_rate=st.floats(min_value=0.0001, max_value=0.01),
+    )
+    def test_hyperparameter_tuning_workflow(
+        self,
+        action_ids: set,
+        n_features: int,
+        n_initial: int,
+        n_updated: int,
+        learning_rate: float,
+        monkeymodule: MonkeyPatch,
+    ) -> None:
+        """Test using transfer learning for hyperparameter tuning."""
+        # Mock the VI/MCMC fitting
+        monkeymodule.setattr(
+            pybandits.model,
+            "fit",
+            lambda *args, **kwargs: FakeApproximation(n_features=n_features, hidden_dim_list=[]),
+        )
+        monkeymodule.setattr(
+            pybandits.model,
+            "sample",
+            FakeApproximation(n_features=n_features, hidden_dim_list=[]).sample,
+        )
+
+        # Create MAB with initial hyperparameters
+        mab = CmabBernoulli.cold_start(
+            action_ids=action_ids,
+            n_features=n_features,
+            strategy=ClassicBandit(),
+            update_kwargs={"fit": {"n": n_initial}},
+        )
+
+        # Create new MAB with updated hyperparameters
+        new_mab = CmabBernoulli.cold_start(
+            action_ids=action_ids,
+            n_features=n_features,
+            strategy=ClassicBandit(),
+            update_kwargs={"fit": {"n": n_updated, "learning_rate": learning_rate}},
+        )
+
+        # Use edit_model_on_the_fly to merge (preserves learned state, updates config)
+        tuned_mab = edit_model_on_the_fly(mab, new_mab)
+
+        # Verify hyperparameters updated
+        for action in tuned_mab.actions.values():
+            assert action.update_kwargs["fit"]["n"] == n_updated
+            assert action.update_kwargs["fit"]["learning_rate"] == learning_rate
+
+    @given(
+        n_actions_per_exp=st.lists(st.integers(min_value=1, max_value=3), min_size=3, max_size=3),
+    )
+    def test_model_consolidation_workflow(self, n_actions_per_exp: list) -> None:
+        """Test updating action set while preserving learned state."""
+        # Create an initial experiment with some actions
+        initial_actions = {f"exp1_a{i}" for i in range(n_actions_per_exp[0])}
+
+        current = SmabBernoulli.cold_start(action_ids=initial_actions, strategy=ClassicBandit())
+
+        # Train one action
+        if initial_actions:
+            trained_action = next(iter(initial_actions))
+            current.update(actions=[trained_action], rewards=[1])
+
+        # Create new template with some overlapping and some new actions
+        new_actions = {f"exp1_a{i}" for i in range(min(1, n_actions_per_exp[0]))}  # Keep at least one
+        new_actions.update({f"exp2_a{i}" for i in range(n_actions_per_exp[1])})  # Add new ones
+
+        new_template = SmabBernoulli.cold_start(action_ids=new_actions, strategy=ClassicBandit())
+
+        # Update action set using new template
+        updated = _merge_mabs(current, new_template)
+
+        # Result should only have actions from new_template
+        assert set(updated.actions.keys()) == new_actions
+
+        # If there was overlap, learned state should be preserved
+        overlap = initial_actions & new_actions
+        if overlap and trained_action in overlap:
+            assert updated.actions[trained_action].n_successes == 2  # 1 (cold start) + 1 (update)
+
+
+class TestModelCompatibilityValidation:
+    """Test suite for model compatibility validation during transfer learning."""
+
+    @pytest.mark.parametrize(
+        "key,val1,val2",
+        [(k, v[0], v[1]) for k, v in _BNN_STRUCTURAL_KEY_VALUES.items()],
+    )
+    def test_transfer_structural_key_mismatch_raises_error(self, key: str, val1: Any, val2: Any) -> None:
+        """Test that a mismatched structural key raises ValueError (parametrized over transfer_structural_keys)."""
+        current = CmabBernoulli.cold_start(
+            action_ids={_ACTION_ID}, n_features=_N_FEATURES, **{key: val1}, strategy=ClassicBandit()
+        )
+        template = CmabBernoulli.cold_start(
+            action_ids={_ACTION_ID}, n_features=_N_FEATURES, **{key: val2}, strategy=ClassicBandit()
+        )
+        with pytest.raises(ValueError, match=key):
+            edit_model_on_the_fly(current, template)
+
+    @pytest.mark.parametrize(
+        "key,val1,val2",
+        [(k, v[0], v[1]) for k, v in _BNN_EXTENDABLE_KEY_VALUES.items()],
+    )
+    def test_transfer_extendable_key_change_warns(
+        self, key: str, val1: Any, val2: Any, caplog: LogCaptureFixture
+    ) -> None:
+        """Test that changing an extendable key emits a warning but succeeds (parametrized over transfer_extendable_keys)."""
+        caplog.set_level(logging.WARNING)
+        current = CmabBernoulli.cold_start(
+            action_ids={_ACTION_ID}, n_features=_N_FEATURES, **{key: val1}, strategy=ClassicBandit()
+        )
+        template = CmabBernoulli.cold_start(
+            action_ids={_ACTION_ID}, n_features=_N_FEATURES, **{key: val2}, strategy=ClassicBandit()
+        )
+        result = edit_model_on_the_fly(current, template)
+        assert result is not None
+        assert getattr(result.actions[_ACTION_ID], key) == val2
+
+    def test_transfer_dist_type_change_allowed(self) -> None:
+        """Test that changing distribution type (StudentT vs Normal) is allowed."""
+        current = CmabBernoulli.cold_start(
+            action_ids={_ACTION_ID}, n_features=_N_FEATURES, dist_type="studentt", strategy=ClassicBandit()
+        )
+        template = CmabBernoulli.cold_start(
+            action_ids={_ACTION_ID}, n_features=_N_FEATURES, dist_type="normal", strategy=ClassicBandit()
+        )
+        result = edit_model_on_the_fly(current, template)
+        assert set(result.actions.keys()) == {_ACTION_ID}
+
+    def test_transfer_hidden_dims_change_allowed(self) -> None:
+        """Test that changing hidden layer dimensions is allowed (shape is not a structural constraint)."""
+        current = CmabBernoulli.cold_start(
+            action_ids={_ACTION_ID}, n_features=_N_FEATURES, hidden_dim_list=[16], strategy=ClassicBandit()
+        )
+        template = CmabBernoulli.cold_start(
+            action_ids={_ACTION_ID}, n_features=_N_FEATURES, hidden_dim_list=[32], strategy=ClassicBandit()
+        )
+        result = edit_model_on_the_fly(current, template)
+        assert _ACTION_ID in result.actions
+
+    def test_transfer_valid_same_structure_succeeds(self) -> None:
+        """Test that transfer with same structure succeeds without error."""
+        action_ids = {_ACTION_ID, "a2"}
+        shared_kwargs = dict(n_features=_N_FEATURES, activation="relu", hidden_dim_list=[16], strategy=ClassicBandit())
+        current = CmabBernoulli.cold_start(action_ids=action_ids, **shared_kwargs)
+        template = CmabBernoulli.cold_start(action_ids=action_ids, **shared_kwargs)
+        result = edit_model_on_the_fly(current, template)
+        assert action_ids.issubset(result.actions)
+
+    def test_transfer_update_kwargs_change_allowed(self) -> None:
+        """Test that changing update_kwargs is allowed (configurable hyperparameter)."""
+        shared_kwargs = dict(n_features=_N_FEATURES, activation="relu", strategy=ClassicBandit())
+        current = CmabBernoulli.cold_start(action_ids={_ACTION_ID}, **shared_kwargs, update_kwargs={"fit": {"n": 50}})
+        template = CmabBernoulli.cold_start(action_ids={_ACTION_ID}, **shared_kwargs, update_kwargs={"fit": {"n": 200}})
+        result = edit_model_on_the_fly(current, template)
+        assert result.actions[_ACTION_ID].update_kwargs["fit"]["n"] == 200
+
+    def test_transfer_beta_models_no_validation(self) -> None:
+        """Test that Beta models skip structural validation."""
+        current = SmabBernoulli.cold_start(action_ids={_ACTION_ID, "a2"}, strategy=ClassicBandit())
+        current.update(actions=[_ACTION_ID], rewards=[1])
+        template = SmabBernoulli.cold_start(action_ids={_ACTION_ID, "a3"}, strategy=ClassicBandit())
+        result = edit_model_on_the_fly(current, template)
+        assert set(result.actions.keys()) == {_ACTION_ID, "a3"}
+        assert result.actions[_ACTION_ID].n_successes == 2
+
+    def test_transfer_mo_validates_all_objectives(self) -> None:
+        """Test that multi-objective models validate each objective separately."""
+        val1, val2 = _BNN_STRUCTURAL_KEY_VALUES["activation"]
+        current = CmabBernoulliMO.cold_start(
+            action_ids={_ACTION_ID},
+            n_features=_N_FEATURES,
+            n_objectives=2,
+            activation=val1,
+            strategy=MultiObjectiveBandit(),
+        )
+        template = CmabBernoulliMO.cold_start(
+            action_ids={_ACTION_ID},
+            n_features=_N_FEATURES,
+            n_objectives=2,
+            activation=val2,
+            strategy=MultiObjectiveBandit(),
+        )
+        with pytest.raises(ValueError, match="activation"):
+            edit_model_on_the_fly(current, template)
+
+    def test_transfer_mo_objective_count_mismatch_raises_error(self) -> None:
+        """Test that changing number of objectives raises ValueError."""
+        shared_kwargs = dict(n_features=_N_FEATURES, strategy=MultiObjectiveBandit())
+        current = CmabBernoulliMO.cold_start(action_ids={_ACTION_ID}, n_objectives=2, **shared_kwargs)
+        template = CmabBernoulliMO.cold_start(action_ids={_ACTION_ID}, n_objectives=3, **shared_kwargs)
+        with pytest.raises(ValueError, match="number of objectives mismatch"):
+            edit_model_on_the_fly(current, template)
+
+    def test_transfer_multiple_actions_validates_each(self) -> None:
+        """Test that validation applies to each overlapping action independently."""
+        val1, val2 = _BNN_STRUCTURAL_KEY_VALUES["activation"]
+        action_ids = {_ACTION_ID, "a2"}
+        current = CmabBernoulli.cold_start(
+            action_ids=action_ids, n_features=_N_FEATURES, activation=val1, strategy=ClassicBandit()
+        )
+        template = CmabBernoulli.cold_start(
+            action_ids=action_ids, n_features=_N_FEATURES, activation=val2, strategy=ClassicBandit()
+        )
+        with pytest.raises(ValueError, match="activation"):
+            edit_model_on_the_fly(current, template)
+
+    def test_transfer_non_overlapping_actions_no_validation(self) -> None:
+        """Test that non-overlapping actions don't trigger validation."""
+        val1, val2 = _BNN_STRUCTURAL_KEY_VALUES["activation"]
+        current = CmabBernoulli.cold_start(
+            action_ids={_ACTION_ID}, n_features=_N_FEATURES, activation=val1, strategy=ClassicBandit()
+        )
+        template = CmabBernoulli.cold_start(
+            action_ids={"a2"}, n_features=_N_FEATURES, activation=val2, strategy=ClassicBandit()
+        )
+        result = edit_model_on_the_fly(current, template)
+        assert set(result.actions.keys()) == {"a2"}


### PR DESCRIPTION
### Changes:
* Added transfer learning functionality under pybandits/transfer.py including:
 - Merging two MABs by uniting their actions.
 - Update action model parameters, e.g. for BNN LR change.
 - Edit MAB on the fly including the two above.
 - Expending cmab input features dimension
* Added transfer learning test suite under tests/test_transfer.py
