### PR TITLE
🔒 fix: Replace unsafe eval() for key deserialization

### DIFF
--- a/pybandits/quantitative_model.py
+++ b/pybandits/quantitative_model.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import ast
 import functools
 import inspect
 import json
@@ -183,7 +184,7 @@ class QuantitativeModelCC(BaseModelCC, ABC):
             globals()[func_name].__source__ = code.strip()  # Register the function in the global scope
         else:
             func_name = code.strip()
-        return eval(func_name)
+        return globals()[func_name]
 
     @staticmethod
     def serialize_cost(cost_value) -> str:
@@ -205,7 +206,7 @@ class QuantitativeModelCC(BaseModelCC, ABC):
                 func_str = ",".join(inner_func_split[:-2]).strip()
                 func = cls._deserialize_function(func_str)
                 args_str = ")".join(",".join(inner_func_split[-2:]).split(")")[:-1]).strip()
-                args_parts = eval(args_str) if args_str else ((), {})
+                args_parts = ast.literal_eval(args_str) if args_str else ((), {})
                 return functools.partial(func, *args_parts[0], **args_parts[1])
             else:
                 return cls._deserialize_function(value)
@@ -448,7 +449,7 @@ class ZoomingModel(QuantitativeModel, ABC):
 
     @staticmethod
     def _deserialize_sub_action_key(key: str) -> Tuple[Tuple[Float01, Float01], ...]:
-        key = eval(key)
+        key = ast.literal_eval(key)
         if isinstance(key, tuple):
             if not isinstance(key[0], tuple):  # case of dimension = 1
                 key = (key,)


### PR DESCRIPTION
This PR addresses a security vulnerability where `eval()` was used for deserializing keys and cost functions in `pybandits/quantitative_model.py`. This could allow an attacker to execute arbitrary code by providing a malicious string.

The fix involves:
1.  Using `ast.literal_eval()` for parsing literal structures like tuples and lists, which is safe as it doesn't execute any code.
2.  Using a `globals()` dictionary lookup for retrieving functions by name, ensuring that only existing objects in the global namespace can be accessed.

These changes effectively eliminate the code injection vector while maintaining the original functionality for valid inputs.

---
*PR created automatically by Jules for task [1835057178953127085](https://jules.google.com/task/1835057178953127085) started by @Periecle*