### PR TITLE
🧹 Refactor: Rename unused `shape` argument to `_shape` in `NormalArray._get_distribution_specific_params`

### DIFF
--- a/pybandits/model.py
+++ b/pybandits/model.py
@@ -767,7 +767,7 @@ class NormalArray(BaseLocationScaleArray):
         Parameters
         ----------
         _shape : Tuple[PositiveInt, ...]
-            Shape of the distribution array.
+            Shape of the distribution array. Unused for the Normal distribution.
 
         Returns
         -------

--- a/pybandits/model.py
+++ b/pybandits/model.py
@@ -757,7 +757,7 @@ class NormalArray(BaseLocationScaleArray):
     _pymc_class: ClassVar[type] = PymcNormal
 
     @classmethod
-    def _get_distribution_specific_params(cls, shape: Tuple[PositiveInt, ...]) -> Dict[str, np.ndarray]:
+    def _get_distribution_specific_params(cls, _shape: Tuple[PositiveInt, ...]) -> Dict[str, np.ndarray]:
         """
         Get distribution-specific parameters for Normal distribution.
 
@@ -766,7 +766,7 @@ class NormalArray(BaseLocationScaleArray):
 
         Parameters
         ----------
-        shape : Tuple[PositiveInt, ...]
+        _shape : Tuple[PositiveInt, ...]
             Shape of the distribution array.
 
         Returns


### PR DESCRIPTION
The `NormalArray._get_distribution_specific_params` method is documented as returning an empty dictionary and ignoring the `shape` parameter. Renaming it to `_shape` in the method signature and docstring signals to developers and static analysis tools that it is intentionally unused while maintaining compatibility with the base class's call in `BaseLocationScaleArray.cold_start`.

🎯 What: Renamed unused `shape` parameter to `_shape` in `NormalArray._get_distribution_specific_params`.
💡 Why: Improves code health by signaling intentionally unused arguments, following standard Python conventions.
✅ Verification: Manually verified the change in `pybandits/model.py`.
✨ Result: Resolved the unused class method argument issue.

---
*PR created automatically by Jules for task [15068610962201323144](https://jules.google.com/task/15068610962201323144) started by @Periecle*