### PR TITLE
Add BNN architecture expansion support to transfer learning

### DIFF
--- a/pybandits/model.py
+++ b/pybandits/model.py
@@ -38,7 +38,6 @@ from numpy import sqrt
 from numpyro.distributions import Bernoulli as NumpyroBernoulli
 from numpyro.distributions import Normal as NumpyroNormal
 from numpyro.distributions import StudentT as NumpyroStudentT
-from numpyro.handlers import scale as numpyro_scale
 from numpyro.infer import MCMC, NUTS, SVI, Trace_ELBO, TraceMeanField_ELBO
 from numpyro.infer.autoguide import AutoMultivariateNormal, AutoNormal
 from numpyro.infer.initialization import init_to_median
@@ -1083,7 +1082,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
     _logit_var_name: ClassVar[str] = "logit"
     _prob_var_name: ClassVar[str] = "prob"
     weight_var_name: ClassVar[str] = "weight"
-    _bias_var_name: ClassVar[str] = "bias"
+    bias_var_name: ClassVar[str] = "bias"
     _embedding_var_name: ClassVar[str] = "embedding"
     _vi_update_params: ClassVar[list] = [
         "num_steps",
@@ -1239,7 +1238,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
     @classmethod
     def get_layer_params_name(cls, layer_ind: PositiveInt) -> Tuple[str, str]:
         weight_layer_params_name = f"{cls.weight_var_name}_{layer_ind}"
-        bias_layer_params_name = f"{cls._bias_var_name}_{layer_ind}"
+        bias_layer_params_name = f"{cls.bias_var_name}_{layer_ind}"
         return weight_layer_params_name, bias_layer_params_name
 
     @classmethod
@@ -1361,6 +1360,19 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             from the post-embedding dimension (``feature_config.total_output_dim``).
         """
         return self.feature_config.n_features
+
+    @property
+    def hidden_dim_list(self) -> List[int]:
+        """
+        Returns the hidden layer dimensions of the model.
+
+        Returns
+        -------
+        List[int]
+            Output dimension of each layer except the final output layer.
+            Empty list when no hidden layers are present.
+        """
+        return [layer.weight.shape[1] for layer in self.model_params.bnn_layer_params[:-1]]
 
     def _arrange_update_kwargs(self):
         if self.update_kwargs is None:
@@ -1872,18 +1884,12 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             if not epoch_steps_list:
                 epoch_steps_list = [1]
 
-        # Scale the ELBO by 1/N so the loss is a per-sample average.
-        # This decouples learning rate tuning from dataset size: gradients
-        # have consistent magnitude regardless of N, and the KL prior term
-        # isn't dwarfed by the likelihood when N is large.
-        _scaled_model = numpyro_scale(_model, scale=1.0 / n_samples)
-
         # Set up VI method (guide + loss) dynamically
         vi_method = self._update_kwargs["method"]
         method_config = self._vi_method_config[vi_method]
-        guide = method_config["guide"](_scaled_model, init_loc_fn=init_to_median)
+        guide = method_config["guide"](_model, init_loc_fn=init_to_median)
         loss = method_config["loss"]()
-        svi = SVI(_scaled_model, guide, self._obj_optimizer, loss=loss)
+        svi = SVI(_model, guide, self._obj_optimizer, loss=loss)
 
         # Run the SVI loop via jax.lax.scan to keep the iteration inside XLA.
         # A Python for-loop leaks host-side dispatch/compilation metadata on
@@ -2304,6 +2310,19 @@ class BaseBayesianNeuralNetworkMO(ModelMO, ABC):
             the shape of the weight matrix in the first layer's parameters of the first objective model.
         """
         return self.models[0].input_dim
+
+    @property
+    def hidden_dim_list(self) -> List[int]:
+        """
+        Returns the hidden layer dimensions of the model.
+
+        Returns
+        -------
+        List[int]
+            The output dimension of each layer except the last, derived from
+            the shape of the weight matrices in the layer parameters.
+        """
+        return self.models[0].hidden_dim_list
 
     @classmethod
     def cold_start(

--- a/pybandits/transfer.py
+++ b/pybandits/transfer.py
@@ -28,7 +28,7 @@ automatically handling input dimension changes for contextual MABs.
 """
 
 import json
-from typing import Any, Dict, Tuple, Type
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 from loguru import logger
 
@@ -381,41 +381,139 @@ def _merge_mabs(
     return _reconstruct_mab(type(mab2), merged_state)
 
 
-def _append_template_bnn_features(
+def _sync_and_expand_dist_params(
+    current_params: Dict[str, Any],
+    template_params: Dict[str, Any],
+) -> None:
+    """Synchronize distribution parameter fields and expand dimensions in-place.
+
+    Handles dist_type changes (e.g., StudentT↔Normal) by aligning fields to the template,
+    then expands any dimension differences (new input features or hidden units).
+
+    Parameters
+    ----------
+    current_params : Dict[str, Any]
+        Distribution parameters dict (weight or bias) to modify in-place.
+    template_params : Dict[str, Any]
+        Template distribution parameters providing target fields and expansion values.
+    """
+    # Align fields to template dist_type: drop extra fields, add missing ones
+    for field_name in list(current_params):
+        if field_name not in template_params:
+            del current_params[field_name]
+    for field_name in template_params:
+        if field_name not in current_params:
+            current_params[field_name] = template_params[field_name]
+
+    # Expand dimensions for shared fields
+    for field_name in current_params:
+        current_val = current_params[field_name]
+        template_val = template_params[field_name]
+        if not isinstance(current_val, list) or not current_val:
+            continue
+
+        if isinstance(current_val[0], list):
+            # 2D weight matrix: input_dim × output_dim
+            current_in = len(current_val)
+            current_out = len(current_val[0])
+            new_in = len(template_val)
+            new_out = len(template_val[0]) if template_val else current_out
+            if new_in > current_in or new_out > current_out:
+                result = []
+                for row_idx in range(new_in):
+                    if row_idx < current_in:
+                        # Existing input: keep current weights, append new output cols from template
+                        result.append(current_val[row_idx] + template_val[row_idx][current_out:])
+                    else:
+                        # New input feature: use template weights for all output units
+                        result.append(template_val[row_idx])
+                current_params[field_name] = result
+        else:
+            # 1D bias vector: output_dim
+            current_out = len(current_val)
+            new_out = len(template_val)
+            if new_out > current_out:
+                current_params[field_name] = current_val + template_val[current_out:]
+
+
+def _expand_bnn_weights(
     current_model_params: Dict[str, Any],
     template_model_params: Dict[str, Any],
-    current_dim: int,
 ) -> None:
-    """Append template's new feature weights to current model parameters (in-place).
+    """Expand BNN model parameters in-place to match template dimensions.
+
+    For each layer, the existing (top-left) block of weights is preserved and template
+    values are used for new connections. This supports simultaneous expansion of both
+    input features and hidden layer dimensions in a single pass:
+
+    - Weight matrix (2D: input_dim × output_dim):
+        * Top-left block [0:current_in, 0:current_out]: keep current learned values
+        * Top-right block [0:current_in, current_out:new_out]: new hidden units — from template
+        * Bottom block [current_in:new_in, :]: new input features — from template
+    - Bias vector (1D: output_dim):
+        * [0:current_out]: keep current learned values
+        * [current_out:new_out]: new hidden units — from template
 
     Parameters
     ----------
     current_model_params : Dict[str, Any]
         Model parameters dict to expand (modified in-place).
     template_model_params : Dict[str, Any]
-        Template model parameters with additional features.
-    current_dim : int
-        Current input dimension (number of features in current model).
+        Template model parameters providing initial values for new connections.
     """
-    # For both learned and init params
     for params_key in ["bnn_layer_params", "bnn_layer_params_init"]:
         if params_key not in current_model_params or params_key not in template_model_params:
             continue
 
-        current_layer = current_model_params[params_key][0]
-        template_layer = template_model_params[params_key][0]
+        for current_layer, template_layer in zip(current_model_params[params_key], template_model_params[params_key]):
+            # Expand weight distribution parameters (2D: input_dim × output_dim)
+            current_w = current_layer[BaseBayesianNeuralNetwork.weight_var_name]
+            template_w = template_layer[BaseBayesianNeuralNetwork.weight_var_name]
+            _sync_and_expand_dist_params(current_w, template_w)
 
-        # Expand weight distribution parameters
-        current_weight = current_layer[BaseBayesianNeuralNetwork.weight_var_name]
-        template_weight = template_layer[BaseBayesianNeuralNetwork.weight_var_name]
+            # Expand bias distribution parameters (1D: output_dim)
+            current_b = current_layer[BaseBayesianNeuralNetwork.bias_var_name]
+            template_b = template_layer[BaseBayesianNeuralNetwork.bias_var_name]
+            _sync_and_expand_dist_params(current_b, template_b)
 
-        for field_name in current_weight:
-            if isinstance(current_weight[field_name], list) and current_weight[field_name]:
-                if isinstance(current_weight[field_name][0], list):
-                    # This is 2D array (input_dim, output_dim)
-                    # Append the new rows from template (from current_dim onward)
-                    new_rows = template_weight[field_name][current_dim:]
-                    current_weight[field_name].extend(new_rows)
+
+def _validate_hidden_dims(
+    src_dims: List[int],
+    tgt_dims: List[int],
+    action_id: str,
+    obj_idx: Optional[int] = None,
+) -> None:
+    """Validate that hidden layer dimensions are compatible for expansion.
+
+    Parameters
+    ----------
+    src_dims : List[int]
+        Source hidden layer dimensions.
+    tgt_dims : List[int]
+        Target hidden layer dimensions.
+    action_id : str
+        Action ID for error messages.
+    obj_idx : Optional[int]
+        Objective index for MO models, or None for SO models.
+
+    Raises
+    ------
+    ValueError
+        If the number of hidden layers differs, or if any hidden layer dimension is reduced.
+    """
+    prefix = f" (objective {obj_idx})" if obj_idx is not None else ""
+    if len(src_dims) != len(tgt_dims):
+        raise ValueError(
+            f"Cannot change the number of hidden layers for action '{action_id}'{prefix}: "
+            f"{len(src_dims)} -> {len(tgt_dims)}. "
+            "Add or remove hidden layers by creating a new MAB from scratch."
+        )
+    for layer_idx, (src_dim, tgt_dim) in enumerate(zip(src_dims, tgt_dims)):
+        if tgt_dim < src_dim:
+            raise ValueError(
+                f"Cannot reduce hidden layer {layer_idx} for action '{action_id}'{prefix}: "
+                f"{src_dim} -> {tgt_dim}. Cannot reduce hidden dimensions."
+            )
 
 
 def _expand_with_template_weights(
@@ -434,16 +532,34 @@ def _expand_with_template_weights(
     Returns
     -------
     expanded_cmab : BaseCmabBernoulli
-        Expanded CMAB with current's existing feature weights and template's new feature weights.
+        Expanded CMAB where existing feature weights and hidden units are preserved from current,
+        and new feature/hidden-unit connections are initialized from template.
     """
     current_dim = current_cmab.input_dim
     template_dim = template_cmab.input_dim
     n_new_features = template_dim - current_dim
 
-    logger.info(
-        f"Expanding current CMAB from {current_dim} to {template_dim} features "
-        f"using template's weights for {n_new_features} new feature(s)"
-    )
+    if n_new_features > 0:
+        logger.info(
+            f"Expanding current CMAB from {current_dim} to {template_dim} features "
+            f"using template's weights for {n_new_features} new feature(s)"
+        )
+
+    # Validate hidden layer architecture changes for overlapping actions
+    for action_id in set(current_cmab.actions.keys()) & set(template_cmab.actions.keys()):
+        src_model = current_cmab.actions[action_id]
+        tgt_model = template_cmab.actions[action_id]
+        if isinstance(src_model, BaseModelMO):
+            if len(src_model.models) != len(tgt_model.models):
+                raise ValueError(
+                    f"Cannot expand action '{action_id}': number of objectives mismatch "
+                    f"(current: {len(src_model.models)}, template: {len(tgt_model.models)})."
+                )
+            for obj_idx, (src_obj, tgt_obj) in enumerate(zip(src_model.models, tgt_model.models)):
+                if isinstance(src_obj, BaseBayesianNeuralNetwork):
+                    _validate_hidden_dims(src_obj.hidden_dim_list, tgt_obj.hidden_dim_list, action_id, obj_idx)
+        elif isinstance(src_model, BaseBayesianNeuralNetwork):
+            _validate_hidden_dims(src_model.hidden_dim_list, tgt_model.hidden_dim_list, action_id)
 
     # Get state dicts
     current_state = _get_state_dict(current_cmab)
@@ -463,17 +579,15 @@ def _expand_with_template_weights(
             for model_idx in range(len(current_action["models"])):
                 if model_idx >= len(template_action["models"]):
                     continue
-                _append_template_bnn_features(
+                _expand_bnn_weights(
                     current_action["models"][model_idx]["model_params"],
                     template_action["models"][model_idx]["model_params"],
-                    current_dim,
                 )
         elif isinstance(action_model, BaseBayesianNeuralNetwork):
             # Single-objective BNN
-            _append_template_bnn_features(
+            _expand_bnn_weights(
                 current_action["model_params"],
                 template_action["model_params"],
-                current_dim,
             )
         else:
             raise TypeError(
@@ -519,9 +633,12 @@ def edit_model_on_the_fly(
     For Beta models (simple Bernoulli), no structural validation is needed as they only
     store n_successes and n_failures counts.
 
-    For CMABs with different input dimensions:
-    - If template has MORE features: automatically expands current MAB using template's weights for new features
-    - If template has FEWER features: raises ValueError (cannot reduce dimensions)
+    For CMABs, architecture changes are handled in a single pass:
+    - More input features, same hidden dims: expands first-layer input rows from template
+    - Same input features, larger hidden dims: expands all layers' output columns from template
+    - Both more features and larger hidden dims: expands rows and columns simultaneously
+    - Fewer input features: raises ValueError (cannot reduce dimensions)
+    - Smaller hidden dims: raises ValueError (cannot reduce hidden dimensions)
 
     The resulting MAB will have:
     - Actions: All actions from new_mab
@@ -593,29 +710,24 @@ def edit_model_on_the_fly(
     """
     _validate_mab_compatibility(current_mab, new_mab)
 
-    # Check if we're dealing with CMABs and handle input dimension mismatches
+    # For CMABs, expand current to match template's architecture (input dim and/or hidden dims).
+    # _expand_with_template_weights is a no-op when dimensions already match.
     if isinstance(current_mab, BaseCmabBernoulli) and isinstance(new_mab, BaseCmabBernoulli):
-        # Get input dimensions via the property on BaseCmabBernoulli
-        try:
-            current_dim = current_mab.input_dim
-            new_dim = new_mab.input_dim
+        overlapping_actions = set(current_mab.actions.keys()) & set(new_mab.actions.keys())
+        if overlapping_actions:
+            try:
+                current_dim = current_mab.input_dim
+                new_dim = new_mab.input_dim
 
-            if current_dim != new_dim:
                 if new_dim < current_dim:
                     raise ValueError(
                         f"Template MAB has fewer features ({new_dim}) than current MAB ({current_dim}). "
                         "Cannot reduce feature dimensions. Template must have same or more features."
                     )
-                else:
-                    # new_dim > current_dim: expand current_mab to match template's dimension
-                    logger.info(
-                        f"Template has more features ({new_dim}) than current ({current_dim}). "
-                        f"Expanding current MAB to match template's dimension."
-                    )
-                    current_mab = _expand_with_template_weights(current_mab, new_mab)
-        except (StopIteration, AttributeError):
-            # No actions or not a CMAB with input_dim, proceed normally
-            pass
+                current_mab = _expand_with_template_weights(current_mab, new_mab)
+            except (StopIteration, AttributeError):
+                # No actions or not a CMAB with input_dim, proceed normally
+                pass
 
     # Merge using new_mab as template with learned state transfer from current_mab
     merged_mab = _merge_mabs(current_mab, new_mab)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybandits"
-version = "6.0.0"
+version = "6.0.1"
 description = "Python Multi-Armed Bandit Library"
 authors = [
     "Dario d'Andrea <dariod@playtika.com>",

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -22,13 +22,14 @@
 
 """Tests for transfer learning functionality."""
 
+import json
 import logging
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, List, Tuple
 
 import numpy as np
 import pytest
 from _pytest.logging import LogCaptureFixture
-from hypothesis import HealthCheck, given, settings
+from hypothesis import assume, given
 from hypothesis import strategies as st
 from pytest import MonkeyPatch
 
@@ -97,7 +98,6 @@ cost_strategy = st.floats(min_value=0.1, max_value=10.0)
 class TestMergeMABs:
     """Test suite for _merge_mabs function."""
 
-    @settings(suppress_health_check=[HealthCheck.too_slow])
     @given(
         action_ids1=action_ids_strategy,
         action_ids2=action_ids_strategy,
@@ -696,6 +696,21 @@ class TestModelCompatibilityValidation:
         with pytest.raises(ValueError, match="number of objectives mismatch"):
             edit_model_on_the_fly(current, template)
 
+    @given(n_objectives_current=n_objectives_strategy, n_objectives_template=n_objectives_strategy)
+    def test_smab_mo_objective_count_mismatch_raises_error(
+        self, n_objectives_current: int, n_objectives_template: int
+    ) -> None:
+        """Test that merging SmabBernoulliMO with different number of objectives raises ValueError."""
+        assume(n_objectives_current != n_objectives_template)
+        current = SmabBernoulliMO.cold_start(
+            action_ids={_ACTION_ID}, n_objectives=n_objectives_current, strategy=MultiObjectiveBandit()
+        )
+        template = SmabBernoulliMO.cold_start(
+            action_ids={_ACTION_ID}, n_objectives=n_objectives_template, strategy=MultiObjectiveBandit()
+        )
+        with pytest.raises(ValueError, match="number of objectives mismatch"):
+            edit_model_on_the_fly(current, template)
+
     def test_transfer_multiple_actions_validates_each(self) -> None:
         """Test that validation applies to each overlapping action independently."""
         val1, val2 = _BNN_STRUCTURAL_KEY_VALUES["activation"]
@@ -717,6 +732,299 @@ class TestModelCompatibilityValidation:
         )
         template = CmabBernoulli.cold_start(
             action_ids={"a2"}, n_features=_N_FEATURES, activation=val2, strategy=ClassicBandit()
+        )
+        result = edit_model_on_the_fly(current, template)
+        assert set(result.actions.keys()) == {"a2"}
+
+
+# ---------------------------------------------------------------------------
+# Strategies for hidden dim expansion tests
+# ---------------------------------------------------------------------------
+_hidden_dims_strategy = st.lists(st.integers(min_value=2, max_value=4), min_size=1, max_size=3)
+_hidden_dim_multiplier_strategy = st.integers(min_value=2, max_value=4)
+_extra_features_strategy = st.integers(min_value=1, max_value=4)
+
+
+def _scaled_hidden(dims: List[int], factor: int) -> List[int]:
+    """Return each dimension multiplied by factor."""
+    return [d * factor for d in dims]
+
+
+class TestHiddenDimExpansion:
+    """Tests for expanding hidden layer dimensions via edit_model_on_the_fly."""
+
+    # ------------------------------------------------------------------
+    # Hidden dims only — no feature change
+    # ------------------------------------------------------------------
+
+    @given(
+        current_hidden=_hidden_dims_strategy,
+        factor=_hidden_dim_multiplier_strategy,
+        action_id=single_action_id_strategy,
+        n_features=n_features_strategy,
+    )
+    def test_hidden_dim_increase_only_so(
+        self, current_hidden: List[int], factor: int, action_id: str, n_features: int
+    ) -> None:
+        """Increasing hidden dims with unchanged input features succeeds for SO CMAB."""
+        new_hidden = _scaled_hidden(current_hidden, factor)
+        current = CmabBernoulli.cold_start(
+            action_ids={action_id}, n_features=n_features, hidden_dim_list=current_hidden, strategy=ClassicBandit()
+        )
+        template = CmabBernoulli.cold_start(
+            action_ids={action_id}, n_features=n_features, hidden_dim_list=new_hidden, strategy=ClassicBandit()
+        )
+        result = edit_model_on_the_fly(current, template)
+        assert result.actions[action_id].hidden_dim_list == new_hidden
+        assert result.actions[action_id].input_dim == n_features
+
+    @given(
+        current_hidden=_hidden_dims_strategy,
+        factor=_hidden_dim_multiplier_strategy,
+        n_objectives=n_objectives_strategy,
+        action_id=single_action_id_strategy,
+        n_features=n_features_strategy,
+    )
+    def test_hidden_dim_increase_only_mo(
+        self, current_hidden: List[int], factor: int, n_objectives: int, action_id: str, n_features: int
+    ) -> None:
+        """Increasing hidden dims with unchanged input features succeeds for MO CMAB."""
+        new_hidden = _scaled_hidden(current_hidden, factor)
+        current = CmabBernoulliMO.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            n_objectives=n_objectives,
+            hidden_dim_list=current_hidden,
+            strategy=MultiObjectiveBandit(),
+        )
+        template = CmabBernoulliMO.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            n_objectives=n_objectives,
+            hidden_dim_list=new_hidden,
+            strategy=MultiObjectiveBandit(),
+        )
+        result = edit_model_on_the_fly(current, template)
+        for obj_model in result.actions[action_id].models:
+            assert obj_model.hidden_dim_list == new_hidden
+            assert obj_model.input_dim == n_features
+
+    # ------------------------------------------------------------------
+    # Features + hidden dims — combined expansion
+    # ------------------------------------------------------------------
+
+    @given(
+        current_hidden=_hidden_dims_strategy,
+        factor=_hidden_dim_multiplier_strategy,
+        n_features=n_features_strategy,
+        extra_features=_extra_features_strategy,
+        action_id=single_action_id_strategy,
+    )
+    def test_features_and_hidden_dim_increase_combined_so(
+        self,
+        current_hidden: List[int],
+        factor: int,
+        n_features: int,
+        extra_features: int,
+        action_id: str,
+    ) -> None:
+        """Increasing both input features and hidden dims in a single pass succeeds for SO CMAB."""
+        new_hidden = _scaled_hidden(current_hidden, factor)
+        new_features = n_features + extra_features
+        current = CmabBernoulli.cold_start(
+            action_ids={action_id}, n_features=n_features, hidden_dim_list=current_hidden, strategy=ClassicBandit()
+        )
+        template = CmabBernoulli.cold_start(
+            action_ids={action_id}, n_features=new_features, hidden_dim_list=new_hidden, strategy=ClassicBandit()
+        )
+        result = edit_model_on_the_fly(current, template)
+        assert result.actions[action_id].hidden_dim_list == new_hidden
+        assert result.actions[action_id].input_dim == new_features
+
+    @given(
+        current_hidden=_hidden_dims_strategy,
+        factor=_hidden_dim_multiplier_strategy,
+        n_features=n_features_strategy,
+        extra_features=_extra_features_strategy,
+        n_objectives=n_objectives_strategy,
+        action_id=single_action_id_strategy,
+    )
+    def test_features_and_hidden_dim_increase_combined_mo(
+        self,
+        current_hidden: List[int],
+        factor: int,
+        n_features: int,
+        extra_features: int,
+        n_objectives: int,
+        action_id: str,
+    ) -> None:
+        """Increasing both input features and hidden dims in a single pass succeeds for MO CMAB."""
+        new_hidden = _scaled_hidden(current_hidden, factor)
+        new_features = n_features + extra_features
+        current = CmabBernoulliMO.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            n_objectives=n_objectives,
+            hidden_dim_list=current_hidden,
+            strategy=MultiObjectiveBandit(),
+        )
+        template = CmabBernoulliMO.cold_start(
+            action_ids={action_id},
+            n_features=new_features,
+            n_objectives=n_objectives,
+            hidden_dim_list=new_hidden,
+            strategy=MultiObjectiveBandit(),
+        )
+        result = edit_model_on_the_fly(current, template)
+        for obj_model in result.actions[action_id].models:
+            assert obj_model.hidden_dim_list == new_hidden
+            assert obj_model.input_dim == new_features
+
+    # ------------------------------------------------------------------
+    # Weight block preservation
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "current_hidden,new_hidden,n_features,extra_features",
+        [
+            ([8], [16], 4, 0),  # hidden only
+            ([8], [16], 4, 3),  # both
+            ([4, 4], [8, 8], 3, 2),  # multi-layer, both
+        ],
+    )
+    def test_learned_weight_block_preserved_after_expansion(
+        self,
+        current_hidden: List[int],
+        new_hidden: List[int],
+        n_features: int,
+        extra_features: int,
+    ) -> None:
+        """After expansion the top-left block of each layer's weight is unchanged."""
+        new_features = n_features + extra_features
+        current = CmabBernoulli.cold_start(
+            action_ids={_ACTION_ID}, n_features=n_features, hidden_dim_list=current_hidden, strategy=ClassicBandit()
+        )
+        template = CmabBernoulli.cold_start(
+            action_ids={_ACTION_ID}, n_features=new_features, hidden_dim_list=new_hidden, strategy=ClassicBandit()
+        )
+        result = edit_model_on_the_fly(current, template)
+
+        current_state = json.loads(current.get_state()[1])
+        result_state = json.loads(result.get_state()[1])
+        current_layers = current_state["actions_manager"]["actions"][_ACTION_ID]["model_params"]["bnn_layer_params"]
+        result_layers = result_state["actions_manager"]["actions"][_ACTION_ID]["model_params"]["bnn_layer_params"]
+
+        assert len(current_layers) == len(result_layers), (
+            f"Layer count changed after expansion: {len(current_layers)} -> {len(result_layers)}"
+        )
+        for layer_idx, (c_layer, r_layer) in enumerate(zip(current_layers, result_layers)):
+            # Weight: top-left block [0:current_rows, 0:current_cols] must be unchanged
+            for field_name, c_vals in c_layer["weight"].items():
+                if isinstance(c_vals, list) and c_vals and isinstance(c_vals[0], list):
+                    current_cols = len(c_vals[0])
+                    r_vals = r_layer["weight"][field_name]
+                    for row_idx, c_row in enumerate(c_vals):
+                        assert r_vals[row_idx][:current_cols] == c_row, (
+                            f"Layer {layer_idx} weight field '{field_name}' row {row_idx} "
+                            "top-left block was modified during expansion"
+                        )
+            # Bias: first current_out elements must be unchanged
+            for field_name, c_vals in c_layer["bias"].items():
+                if isinstance(c_vals, list) and not (c_vals and isinstance(c_vals[0], list)):
+                    r_vals = r_layer["bias"][field_name]
+                    assert r_vals[: len(c_vals)] == c_vals, (
+                        f"Layer {layer_idx} bias field '{field_name}' existing values were modified during expansion"
+                    )
+
+    # ------------------------------------------------------------------
+    # Error cases
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "current_hidden,new_hidden",
+        [
+            ([32], [16]),
+            ([16, 16], [8, 16]),
+            ([16, 16], [16, 8]),
+            ([64], [32]),
+        ],
+    )
+    def test_hidden_dim_decrease_raises(self, current_hidden: List[int], new_hidden: List[int]) -> None:
+        """Reducing any hidden layer dimension raises ValueError."""
+        current = CmabBernoulli.cold_start(
+            action_ids={_ACTION_ID}, n_features=_N_FEATURES, hidden_dim_list=current_hidden, strategy=ClassicBandit()
+        )
+        template = CmabBernoulli.cold_start(
+            action_ids={_ACTION_ID}, n_features=_N_FEATURES, hidden_dim_list=new_hidden, strategy=ClassicBandit()
+        )
+        with pytest.raises(ValueError, match="Cannot reduce"):
+            edit_model_on_the_fly(current, template)
+
+    @pytest.mark.parametrize(
+        "current_hidden,new_hidden",
+        [
+            ([8], [8, 8]),
+            ([8, 8], [8]),
+            ([8], [8, 8, 8]),
+        ],
+    )
+    def test_different_layer_count_raises(self, current_hidden: List[int], new_hidden: List[int]) -> None:
+        """Changing the number of hidden layers raises ValueError."""
+        current = CmabBernoulli.cold_start(
+            action_ids={_ACTION_ID}, n_features=_N_FEATURES, hidden_dim_list=current_hidden, strategy=ClassicBandit()
+        )
+        template = CmabBernoulli.cold_start(
+            action_ids={_ACTION_ID}, n_features=_N_FEATURES, hidden_dim_list=new_hidden, strategy=ClassicBandit()
+        )
+        with pytest.raises(ValueError, match="number of hidden layers"):
+            edit_model_on_the_fly(current, template)
+
+    @pytest.mark.parametrize(
+        "current_hidden,new_hidden",
+        [
+            ([32], [16]),
+            ([16, 8], [8, 4]),
+        ],
+    )
+    def test_hidden_dim_decrease_mo_raises(self, current_hidden: List[int], new_hidden: List[int]) -> None:
+        """Reducing hidden dims in a MO CMAB raises ValueError."""
+        current = CmabBernoulliMO.cold_start(
+            action_ids={_ACTION_ID},
+            n_features=_N_FEATURES,
+            n_objectives=2,
+            hidden_dim_list=current_hidden,
+            strategy=MultiObjectiveBandit(),
+        )
+        template = CmabBernoulliMO.cold_start(
+            action_ids={_ACTION_ID},
+            n_features=_N_FEATURES,
+            n_objectives=2,
+            hidden_dim_list=new_hidden,
+            strategy=MultiObjectiveBandit(),
+        )
+        with pytest.raises(ValueError, match="Cannot reduce"):
+            edit_model_on_the_fly(current, template)
+
+    # ------------------------------------------------------------------
+    # Non-overlapping actions: no validation triggered
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "current_hidden,new_hidden",
+        [
+            ([32], [16]),
+            ([8], [8, 8]),
+        ],
+    )
+    def test_incompatible_hidden_dims_non_overlapping_no_error(
+        self, current_hidden: List[int], new_hidden: List[int]
+    ) -> None:
+        """Incompatible hidden dims on non-overlapping actions do not raise errors."""
+        current = CmabBernoulli.cold_start(
+            action_ids={_ACTION_ID}, n_features=_N_FEATURES, hidden_dim_list=current_hidden, strategy=ClassicBandit()
+        )
+        template = CmabBernoulli.cold_start(
+            action_ids={"a2"}, n_features=_N_FEATURES, hidden_dim_list=new_hidden, strategy=ClassicBandit()
         )
         result = edit_model_on_the_fly(current, template)
         assert set(result.actions.keys()) == {"a2"}


### PR DESCRIPTION
### Changes:

* Update pybandits/model.py
  - Add hidden_dim_list property to BaseBayesianNeuralNetwork derived from layer weight shapes

* Update pybandits/transfer.py
  - Replace _append_template_bnn_features with _expand_bnn_weights: block-wise expansion of weights (2D) and biases (1D) across all layers, preserving the top-left learned block and filling new connections from the template
  - Add _validate_hidden_dims helper to enforce same number of layers and no dimension reduction
  - Always route CMABs through _expand_with_template_weights (no-op when dims match), enabling hidden-dim-only expansion
  - Support simultaneous input-feature + hidden-dim expansion in one pass

* Update tests/test_transfer.py
  - Add TestHiddenDimExpansion with hypothesis and parametrize tests covering: hidden-dim-only SO/MO, combined features+hidden SO/MO, learned weight block preservation, and error cases (reduce dims, change layer count)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime support for expanding neural-network architectures during transfer while preserving learned parameters; stricter validation to prevent incompatible hidden-layer changes.
  * New public property to inspect hidden-layer output dimensions and a public bias identifier for models.

* **Tests**
  * Expanded tests for hidden-dimension expansion, parameter preservation, non-overlap scenarios, and expected error cases.

* **Chores**
  * Version bumped to 6.0.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->