### PR TITLE
Backyard clean: remove BLR, flatten Zooming hierarchy

### DIFF
--- a/docs/src/tutorials/bnn.ipynb
+++ b/docs/src/tutorials/bnn.ipynb
@@ -35,7 +35,6 @@
     "from sklearn.preprocessing import scale\n",
     "\n",
     "from pybandits.model import (\n",
-    "    BayesianLogisticRegression,\n",
     "    BayesianNeuralNetwork,\n",
     "    CategoricalFeatureConfig,\n",
     "    FeaturesConfig,\n",
@@ -118,7 +117,7 @@
    "id": "8",
    "metadata": {},
    "source": [
-    "Using `BayesianLogisticRegression.cold_start` we create a probabilistic linear classifier with Student-T weight priors (default: mu=0, sigma=10, nu=5).\n",
+    "Using `BayesianNeuralNetwork.cold_start` we create a probabilistic linear classifier with Student-T weight priors (default: mu=0, sigma=10, nu=5).\n",
     "\n",
     "We fit it with Variational Inference using Adam and minibatches of 256."
    ]
@@ -130,7 +129,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "blr = BayesianLogisticRegression.cold_start(\n",
+    "blr = BayesianNeuralNetwork.cold_start(\n",
     "    n_features=2,\n",
     "    update_method=\"VI\",\n",
     "    update_kwargs={\"num_steps\": 4000, \"batch_size\": 256, \"optimizer_type\": \"adam\"},\n",

--- a/docs/src/tutorials/cmab.ipynb
+++ b/docs/src/tutorials/cmab.ipynb
@@ -45,7 +45,7 @@
     "import numpy as np\n",
     "\n",
     "from pybandits.cmab import CmabBernoulli\n",
-    "from pybandits.model import BayesianLogisticRegression, BnnLayerParams, BnnParams, FeaturesConfig, StudentTArray"
+    "from pybandits.model import BayesianNeuralNetwork, BnnLayerParams, BnnParams, FeaturesConfig, StudentTArray"
    ]
   },
   {
@@ -98,13 +98,13 @@
     "update_kwargs = {\"num_steps\": 100, \"batch_size\": 128, \"optimizer_type\": \"adam\"}\n",
     "\n",
     "actions = {\n",
-    "    \"a1\": BayesianLogisticRegression(\n",
+    "    \"a1\": BayesianNeuralNetwork(\n",
     "        model_params=model_params,\n",
     "        feature_config=feature_config,\n",
     "        update_method=update_method,\n",
     "        update_kwargs=update_kwargs,\n",
     "    ),\n",
-    "    \"a2\": BayesianLogisticRegression(\n",
+    "    \"a2\": BayesianNeuralNetwork(\n",
     "        model_params=model_params,\n",
     "        feature_config=feature_config,\n",
     "        update_method=update_method,\n",

--- a/docs/src/tutorials/cmab_simulator.ipynb
+++ b/docs/src/tutorials/cmab_simulator.ipynb
@@ -24,7 +24,7 @@
     "\n",
     "from pybandits.cmab import CmabBernoulli\n",
     "from pybandits.cmab_simulator import CmabSimulator\n",
-    "from pybandits.model import BayesianLogisticRegression, BnnLayerParams, BnnParams, FeaturesConfig, StudentTArray"
+    "from pybandits.model import BayesianNeuralNetwork, BnnLayerParams, BnnParams, FeaturesConfig, StudentTArray"
    ]
   },
   {
@@ -101,14 +101,14 @@
     "# define action model\n",
     "\n",
     "\n",
-    "def create_blr(n_features, bias_mu, bias_sigma, update_method, update_kwargs):\n",
-    "    \"\"\"Create a BayesianLogisticRegression with given parameters.\"\"\"\n",
+    "def create_bnn(n_features, bias_mu, bias_sigma, update_method, update_kwargs):\n",
+    "    \"\"\"Create a BayesianNeuralNetwork with given parameters.\"\"\"\n",
     "    bias = StudentTArray.cold_start(mu=bias_mu, sigma=bias_sigma, shape=1)\n",
     "    weight = StudentTArray.cold_start(shape=(n_features, 1))\n",
     "    layer_params = BnnLayerParams(weight=weight, bias=bias)\n",
     "    model_params = BnnParams(bnn_layer_params=[layer_params])\n",
     "    feature_config = FeaturesConfig(n_features=n_features)\n",
-    "    return BayesianLogisticRegression(\n",
+    "    return BayesianNeuralNetwork(\n",
     "        model_params=model_params,\n",
     "        feature_config=feature_config,\n",
     "        update_method=update_method,\n",
@@ -122,9 +122,9 @@
     "    n_features=n_features, bias_mu=1, bias_sigma=2, update_method=update_method, update_kwargs=update_kwargs\n",
     ")\n",
     "actions = {\n",
-    "    \"a1\": create_blr(**blr_kwargs),\n",
-    "    \"a2\": create_blr(**blr_kwargs),\n",
-    "    \"a3\": create_blr(**blr_kwargs),\n",
+    "    \"a1\": create_bnn(**blr_kwargs),\n",
+    "    \"a2\": create_bnn(**blr_kwargs),\n",
+    "    \"a3\": create_bnn(**blr_kwargs),\n",
     "}\n",
     "# init contextual Multi-Armed Bandit model\n",
     "cmab = CmabBernoulli(actions=actions)"

--- a/docs/src/tutorials/smab_zooming.ipynb
+++ b/docs/src/tutorials/smab_zooming.ipynb
@@ -28,7 +28,7 @@
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
-    "from pybandits.quantitative_model import SmabZoomingModel\n",
+    "from pybandits.quantitative_model import Zooming\n",
     "from pybandits.smab import SmabBernoulli"
    ]
   },
@@ -51,7 +51,7 @@
     "np.random.seed(42)\n",
     "\n",
     "# Define actions with zooming models\n",
-    "actions = {\"action_1\": SmabZoomingModel.cold_start(dimension=1), \"action_2\": SmabZoomingModel.cold_start(dimension=1)}"
+    "actions = {\"action_1\": Zooming.cold_start(dimension=1), \"action_2\": Zooming.cold_start(dimension=1)}"
    ]
   },
   {

--- a/pybandits/actions_manager.py
+++ b/pybandits/actions_manager.py
@@ -66,12 +66,12 @@ from pybandits.pydantic_version_compatibility import (
 )
 from pybandits.quantitative_model import (
     BaseQuantitativeBayesianNeuralNetwork,
-    BaseSmabZoomingModel,
+    BaseZooming,
     QuantitativeBayesianNeuralNetwork,
     QuantitativeBayesianNeuralNetworkCC,
     QuantitativeModel,
-    SmabZoomingModel,
-    SmabZoomingModelCC,
+    Zooming,
+    ZoomingCC,
 )
 from pybandits.utils import classproperty, extract_argument_names_from_function
 
@@ -826,7 +826,7 @@ class ActionsManager(PyBanditsBaseModel, ABC):
         return action_model_classes
 
 
-SmabModelType = TypeVar("SmabModelType", bound=Union[BaseBeta, BaseBetaMO, BaseSmabZoomingModel])
+SmabModelType = TypeVar("SmabModelType", bound=Union[BaseBeta, BaseBetaMO, BaseZooming])
 
 
 class SmabActionsManager(ActionsManager, GenericModel, Generic[SmabModelType]):
@@ -1116,8 +1116,8 @@ class CmabActionsManager(ActionsManager, GenericModel, Generic[CmabModelType]):
 
 
 # For pickling purposes
-SmabActionsManagerSO = SmabActionsManager[Union[Beta, SmabZoomingModel]]
-SmabActionsManagerCC = SmabActionsManager[Union[BetaCC, SmabZoomingModelCC]]
+SmabActionsManagerSO = SmabActionsManager[Union[Beta, Zooming]]
+SmabActionsManagerCC = SmabActionsManager[Union[BetaCC, ZoomingCC]]
 SmabActionsManagerMO = SmabActionsManager[BetaMO]
 SmabActionsManagerMOCC = SmabActionsManager[BetaMOCC]
 

--- a/pybandits/cmab.py
+++ b/pybandits/cmab.py
@@ -64,7 +64,7 @@ class BaseCmabBernoulli(BaseMab, ABC):
 
     Parameters
     ----------
-    actions : Dict[ActionId, Union[BaseBayesianLogisticRegression, BaseQuantitativeBayesianNeuralNetwork]]
+    actions : Dict[ActionId, Union[BaseBayesianNeuralNetwork, BaseQuantitativeBayesianNeuralNetwork]]
         The list of possible actions, and their associated Model.
     strategy : Strategy
         The strategy used to select actions.

--- a/pybandits/model.py
+++ b/pybandits/model.py
@@ -210,7 +210,7 @@ class BetaCC(BaseBeta, ModelCC):
 
 class BaseBetaMO(ModelMO, ABC):
     """
-    Base beta Distribution model for Bernoulli multi-armed bandits with multi-objectives.
+    Base Beta Distribution model for Bernoulli multi-armed bandits with multi-objectives.
 
     Parameters
     ----------
@@ -226,24 +226,17 @@ class BaseBetaMO(ModelMO, ABC):
         raise ValueError(f"Unsupported pydantic version: {pydantic_version}")
 
     @classmethod
-    def cold_start(cls, n_objectives: PositiveInt, **kwargs) -> "BetaMO":
+    def cold_start(cls, n_objectives: PositiveInt, **kwargs) -> "BaseBetaMO":
         """
-        Utility function to create a Bayesian Logistic Regression model  or child model with cost control,
+        Utility function to create a BetaMO or child model with cost control,
         with default parameters.
-
-        It is modeled as:
-
-            y = sigmoid(alpha + beta1 * x1 + beta2 * x2 + ... + betaN * xN)
-
-        where the alpha and betas coefficients are Student's t-distributions.
 
         Parameters
         ----------
-        n_betas : PositiveInt
-            The number of betas of the Bayesian Logistic Regression model. This is also the number of features expected
-            after in the context matrix.
+        n_objectives : PositiveInt
+            Number of objectives (models) to create.
         kwargs: Dict[str, Any]
-            Additional arguments for the Bayesian Logistic Regression child model.
+            Additional arguments for the BaseBetaMO child model.
 
         Returns
         -------
@@ -1005,12 +998,12 @@ class EarlyStopping(PyBanditsBaseModel):
         """Check if training should stop based on loss convergence."""
         if self._previous_loss is not None:
             if self.diff_type == "relative":
-                change = abs((loss - self._previous_loss) / (abs(self._previous_loss) + self._epsilon))
+                change = (self._previous_loss - loss) / (abs(self._previous_loss) + self._epsilon)
             elif self.diff_type == "absolute":
-                change = abs(loss - self._previous_loss)
+                change = self._previous_loss - loss
             else:
                 raise ValueError(f"Unknown diff {self.diff_type}")
-
+            logger.info(str((loss, change, self._no_improvement_count)))
             if change < self.tolerance:
                 self._no_improvement_count += 1
             else:
@@ -1131,6 +1124,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         optimizer_kwargs={"step_size": 0.01},
         batch_size=None,
         early_stopping_kwargs=None,
+        restore_best_svi_state=True,
     )
 
     _default_mcmc_kwargs: ClassVar[dict] = dict(
@@ -1908,31 +1902,47 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             static_argnums=(1,),
         )
 
+        restore_best = self._update_kwargs.get("restore_best_svi_state", True)
         all_losses = []
+        best_loss = float("inf")
+        best_svi_state = svi_state
         pbar = trange(len(epoch_steps_list), desc="SVI", leave=False)
 
         for epoch_idx, epoch_steps in enumerate(epoch_steps_list):
             svi_state, epoch_losses = _run_epoch(svi_state, epoch_steps)
 
             epoch_np = np.array(epoch_losses)
+            epoch_loss = float(np.mean(epoch_np))
             all_losses.append(epoch_np)
             pbar.update(1)
-            pbar.set_postfix(loss=f"{float(epoch_np[-1]):.4f}")
+            pbar.set_postfix(loss=f"{epoch_loss:.4f}")
+
+            if np.isnan(epoch_loss):
+                pbar.close()
+                raise ValueError(
+                    f"SVI training diverged: loss is NaN at epoch {epoch_idx + 1}/{len(epoch_steps_list)}. "
+                    "Consider reducing the learning rate or checking your data for invalid values."
+                )
+
+            if restore_best and epoch_loss < best_loss:
+                best_loss = epoch_loss
+                best_svi_state = svi_state
 
             if self._early_stopping_callback is not None:
-                if self._early_stopping_callback.should_stop(float(epoch_np[-1])):
+                if self._early_stopping_callback.should_stop(epoch_loss):
                     logger.info(
                         f"Early stopping at epoch {epoch_idx + 1}/{len(epoch_steps_list)}: "
                         f"loss change below {self._early_stopping_callback.tolerance} "
                         f"({self._early_stopping_callback.diff_type}) for "
                         f"{self._early_stopping_callback.patience} consecutive epochs. "
-                        f"Last loss: {float(epoch_np[-1]):.6f}."
+                        f"Best loss: {best_loss:.6f}, last loss: {epoch_loss:.6f}."
                     )
                     break
 
         pbar.close()
         self._approx_history = np.concatenate(all_losses) if all_losses else np.array([])
-        params = svi.get_params(svi_state)
+        final_state = best_svi_state if restore_best else svi_state
+        params = svi.get_params(final_state)
         return svi, guide, params
 
     def _extract_advi_params(self, params: dict) -> tuple:
@@ -2413,25 +2423,4 @@ class BayesianNeuralNetworkMOCC(BaseBayesianNeuralNetworkMO, ModelMO, ModelCC):
         The list of Bayesian Neural Network models for each objective.
     cost : NonNegativeFloat
         Cost associated to the Bayesian Neural Network model.
-    """
-
-
-class BayesianLogisticRegression(BayesianNeuralNetwork):
-    """
-    A Bayesian Logistic Regression model that inherits from BayesianNeuralNetwork.
-    This model is a specialized version of a Bayesian Neural Network with a single layer,
-    designed specifically for logistic regression tasks. The model parameters are
-    validated to ensure that the model adheres to this single-layer constraint.
-    """
-
-    @field_validator("model_params")
-    def validate_model_params(cls, model_params):
-        if (len(model_params.bnn_layer_params_init) != 1) or (len(model_params.bnn_layer_params) != 1):
-            raise ValueError("The Bayesian Logistic Regression model should have only one layer.")
-        return model_params
-
-
-class BayesianLogisticRegressionCC(BayesianLogisticRegression, ModelCC):
-    """
-    A Bayesian Logistic Regression model with cost control.
     """

--- a/pybandits/quantitative_model.py
+++ b/pybandits/quantitative_model.py
@@ -24,7 +24,7 @@ import functools
 import inspect
 import json
 from abc import ABC, abstractmethod
-from collections import Counter
+from collections import Counter, defaultdict
 from itertools import product
 from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple, Union, get_args, get_type_hints
 
@@ -38,7 +38,6 @@ from pybandits.base import (
     BinaryReward,
     Float01,
     Probability,
-    ProbabilityWeight,
     PyBanditsBaseModel,
     QuantitativeProbability,
     QuantitativeProbabilityWeight,
@@ -373,10 +372,10 @@ class Segment(PyBanditsBaseModel):
             return False
 
 
-class ZoomingModel(QuantitativeModel, ABC):
+class BaseZooming(QuantitativeModel, ABC):
     """
-    This class is used to implement the zooming method. The approach is based on adaptive discretization of the
-    quantitative action space. The space is represented s a hyper cube with a dimension number of dimensions.
+    Zooming model for sMAB. The approach is based on adaptive discretization of the
+    quantitative action space. The space is represented as a hyper cube with a dimension number of dimensions.
     After each update step, the model checks if the segments are interesting or nuisance based on segment_update_factor.
     If a segment is interesting, it can be split to two segments.
     In contrast, adjacent nuisance segments can be merged based on comparison_threshold.
@@ -402,8 +401,8 @@ class ZoomingModel(QuantitativeModel, ABC):
         Number of comparison points.
     n_max_segments: PositiveInt
         Maximum number of segments.
-    sub_actions: Dict[Tuple[Tuple[Float01, Float01], ...], Optional[Model]]
-        Mapping of segments to models.
+    sub_actions: Dict[Tuple[Tuple[Float01, Float01], ...], Optional[Beta]]
+        Mapping of segments to Beta models.
     """
 
     dimension: PositiveInt
@@ -411,7 +410,7 @@ class ZoomingModel(QuantitativeModel, ABC):
     segment_update_factor: Float01 = 0.1
     n_comparison_points: PositiveInt = 1000
     n_max_segments: Optional[PositiveInt] = 32
-    sub_actions: Dict[Tuple[Tuple[Float01, Float01], ...], Optional[Model]]
+    sub_actions: Dict[Tuple[Tuple[Float01, Float01], ...], Optional[Beta]]
     _base_model: Model = PrivateAttr()
     _n_initial_segments: ClassVar = 4
     _transfer_learned_keys: ClassVar[Tuple[str, ...]] = ("sub_actions",)
@@ -477,14 +476,14 @@ class ZoomingModel(QuantitativeModel, ABC):
             )
 
     @property
-    def segmented_actions(self) -> Dict[Segment, Optional[Model]]:
+    def segmented_actions(self) -> Dict[Segment, Optional[Beta]]:
         return {Segment(intervals=segment): model for segment, model in self.sub_actions.items()}
 
-    @abstractmethod
     def _init_base_model(self):
         """
         Initialize the base model.
         """
+        self._base_model = Beta()
 
     @classmethod
     @validate_call
@@ -501,7 +500,7 @@ class ZoomingModel(QuantitativeModel, ABC):
 
         Returns
         -------
-        ZoomingModel
+        Zooming
             Cold start model.
         """
         sub_actions = dict(zip(cls._generate_initial_segments(dimension), [None] * cls._n_initial_segments**dimension))
@@ -520,7 +519,7 @@ class ZoomingModel(QuantitativeModel, ABC):
         intervals = [(interval_points[i], interval_points[i + 1]) for i in range(cls._n_initial_segments)]
         return [tuple(segment) for segment in product(intervals, repeat=dimension)]
 
-    def sample_proba(self, **kwargs) -> List[QuantitativeProbability]:
+    def sample_proba(self, n_samples: PositiveInt) -> List[QuantitativeProbability]:
         """
         Sample probability functions from the model.
 
@@ -532,315 +531,8 @@ class ZoomingModel(QuantitativeModel, ABC):
         # Get sampled probabilities from each segment model
         segment_probabilities = {}
         for segment, model in self.segmented_actions.items():
-            segment_probabilities[segment] = model.sample_proba(**kwargs)
+            segment_probabilities[segment] = model.sample_proba(n_samples)
         return self._to_quantitative_probabilities(segment_probabilities)
-
-    @abstractmethod
-    def _to_quantitative_probabilities(
-        self, segment_probabilities: Dict[Segment, Union[List[Probability], List[ProbabilityWeight]]]
-    ) -> Union[List[QuantitativeProbability], List[QuantitativeProbabilityWeight]]:
-        """
-        Convert the segment probabilities to quantitative probabilities.
-
-        Parameters
-        ----------
-        segment_probabilities : Dict[Segment, Union[List[Probability], List[ProbabilityWeight]]]
-            The probabilities of each segment.
-
-        Returns
-        -------
-        Union[List[QuantitativeProbability], List[QuantitativeProbabilityWeight]]
-            The quantitative probabilities.
-        """
-
-    def _quantitative_update(
-        self, quantities: List[Union[float, List[float], None]], rewards: List[BinaryReward], **kwargs
-    ):
-        """
-        Update the model parameters.
-
-        Parameters
-        ----------
-        quantities : List[Union[float, List[float], None]],
-            The value associated with each action.
-        rewards: List[BinaryReward]
-            The reward for each sample.
-        context : Optional[ArrayLike]
-            Context for each sample.
-        """
-
-        segments = self._map_and_update_segment_models(quantities, rewards, **kwargs)
-        self._update_segmentation(quantities, segments, rewards, **kwargs)
-
-    def _map_and_update_segment_models(
-        self, quantities: List[Union[float, List[float], None]], rewards: List[BinaryReward], **kwargs
-    ) -> List[Segment]:
-        """
-        Map and update the segment models.
-
-        Parameters
-        ----------
-        quantities : List[Union[float, List[float], None]]
-            The value associated with each action.
-        rewards: List[BinaryReward]
-            The reward for each sample.
-
-        Returns
-        -------
-        List[Segment]
-            Segments to update.
-        """
-        segments = self._map_values_to_segments(quantities)
-        self._inner_update(segments, rewards, **kwargs)
-        return segments
-
-    @abstractmethod
-    def _inner_update(self, segments: List[Segment], rewards: List[BinaryReward], **kwargs):
-        """
-        Update the segments models.
-
-        Parameters
-        ----------
-        segments : List[Segment]
-            Segments to update.
-        rewards : List[BinaryReward]
-            Rewards for update.
-        context : Optional[ArrayLike]
-            Context for update.
-        """
-
-    def _map_values_to_segments(
-        self,
-        quantities: List[Union[float, List[float], None]],
-    ) -> List[Segment]:
-        segments = [segment for value in quantities for segment in self.segmented_actions.keys() if value in segment]
-        return segments
-
-    def _update_segmentation(
-        self,
-        quantities: List[Union[float, List[float], None]],
-        segments: List[Segment],
-        rewards: List[BinaryReward],
-        **kwargs,
-    ):
-        """
-        Sort segments into three categories: interest (good), nuisance (bad), and all others (neutral).
-        Segments of interest are to be splitted; adjucent nuisance segments to be merged; and reminder remain untouched.
-        The segment classification is based on the rate of exploitation using self.segment_update_factor.
-
-        Parameters
-        ----------
-        quantities : List[Union[float, List[float], None]]
-            The value associated with each action.
-        segments : List[Segment]
-            All segments in the model.
-        rewards : List[BinaryReward]
-            Rewards for update.
-        kwargs : Dict[str, Any]
-            Keyword arguments for update.
-        """
-        segments_counts = Counter(segments)
-        num_segments = len(self.sub_actions)
-        interest_segments = []
-        nuisance_segments = []
-        for segment in segments_counts:
-            if segments_counts[segment] > (len(segments) / num_segments) * (1 + self.segment_update_factor):
-                interest_segments.append(segment)
-            elif segments_counts[segment] < (len(segments) / num_segments) * (1 - self.segment_update_factor):
-                nuisance_segments.append(segment)
-        interest_segments = sorted(interest_segments, key=lambda x: segments_counts[x], reverse=True)
-
-        self._merge_adjacent_nuisance_segments(nuisance_segments, quantities, segments, rewards, **kwargs)
-        self._split_segments_of_interest(interest_segments, quantities, segments, rewards, **kwargs)
-
-    def _merge_adjacent_nuisance_segments(
-        self,
-        nuisance_segments: List[Segment],
-        quantities: List[Union[float, List[float], None]],
-        segments: List[Segment],
-        rewards: List[BinaryReward],
-        **kwargs,
-    ):
-        """
-        Merge adjacent segments that have similar performance.
-
-        Parameters
-        ----------
-        nuisance_segments : List[Segment]
-            List of segments to consider for merging.
-        quantities : List[Union[float, List[float], None]]
-            The value associated with each action.
-        segments : List[Segment]
-            All segments in the model.
-        rewards : List[BinaryReward]
-            The reward for each sample.
-        """
-        i = 0
-        while i < len(nuisance_segments) - 1:
-            segment = nuisance_segments[i]
-            j = i + 1
-            while j < len(nuisance_segments):
-                other_segment = nuisance_segments[j]
-                if segment.is_adjacent(other_segment) and self.is_similar_performance(segment, other_segment):
-                    del self.sub_actions[segment.intervals]
-                    del self.sub_actions[other_segment.intervals]
-                    nuisance_segments.remove(segment)
-                    nuisance_segments.remove(other_segment)
-                    merged_segment = segment + other_segment
-                    self.sub_actions[merged_segment.intervals] = self._base_model.model_copy(deep=True)
-                    filtered_quantities, filtered_rewards, filtered_kwargs = self._filter_by_segment(
-                        merged_segment, quantities, segments, rewards, **kwargs
-                    )
-                    self._map_and_update_segment_models(filtered_quantities, filtered_rewards, **filtered_kwargs)
-                    break
-                j += 1
-            i += 1
-
-    def _split_segments_of_interest(
-        self,
-        interest_segments: List[Segment],
-        quantities: List[Union[float, List[float], None]],
-        segments: List[Segment],
-        rewards: List[BinaryReward],
-        **kwargs,
-    ):
-        """
-        Split segments of interest into two sub-segments if possible.
-
-        Parameters
-        ----------
-        interest_segments : List[Segment]
-            List of segments to consider for splitting.
-        quantities : List[Union[float, List[float], None]]
-            The value associated with each action.
-        segments : List[Segment]
-            All segments in the model.
-        rewards : List[BinaryReward]
-            The reward for each sample.
-        """
-        i = 0
-        while i < len(interest_segments) - 1 and (
-            self.n_max_segments is None or len(self.sub_actions) < self.n_max_segments
-        ):
-            best_segment = interest_segments[i]
-            del self.sub_actions[best_segment.intervals]
-            sub_best_segments = best_segment.split()
-            self.sub_actions[sub_best_segments[0].intervals] = self._base_model.model_copy(deep=True)
-            self.sub_actions[sub_best_segments[1].intervals] = self._base_model.model_copy(deep=True)
-            filtered_quantities, filtered_rewards, filtered_kwargs = self._filter_by_segment(
-                best_segment, quantities, segments, rewards, **kwargs
-            )
-            self._map_and_update_segment_models(filtered_quantities, filtered_rewards, **filtered_kwargs)
-            i += 1
-
-    def is_similar_performance(self, segment1: Segment, segment2: Segment) -> bool:
-        """
-        Check if two segments have similar performance.
-
-        Parameters
-        ----------
-        segment1 : Segment
-            First segment.
-        segment2 : Segment
-            Second segment.
-
-        Returns
-        -------
-        bool
-            Whether the segments have similar performance.
-        """
-        x = np.linspace(0, 1, self.n_comparison_points)
-        model1 = self.sub_actions[segment1.intervals]
-        model2 = self.sub_actions[segment2.intervals]
-        p1 = beta.pdf(x, model1.n_successes, model1.n_failures)
-        p2 = beta.pdf(x, model2.n_successes, model2.n_failures)
-        return jensenshannon(p1, p2) < self.comparison_threshold
-
-    def _filter_by_segment(
-        self,
-        reference_segment: Segment,
-        quantities: List[Union[float, List[float], None]],
-        segments: List[Segment],
-        rewards: List[BinaryReward],
-        **kwargs,
-    ) -> Tuple[List[Union[float, List[float], None]], List[BinaryReward], Dict[str, Any]]:
-        """
-        Filter and update the segments models.
-
-        Parameters
-        ----------
-        reference_segment : Segment
-            Reference segment to filter upon.
-        segments : List[Segment]
-            Segments to filter.
-        quantities : List[Union[float, List[float], None]]
-            Values to filter.
-        rewards : List[BinaryReward]
-            Rewards to filter.
-
-        Returns
-        -------
-        filtered_values : List[Union[float, List[float], None]]
-            Filtered quantities.
-        filtered_rewards : List[BinaryReward]
-            Filtered rewards.
-        filtered_kwargs : Dict[str, Any]
-            Filtered context.
-        """
-        filtered_values_rewards_kwargs = [
-            (value, reward, *[kwarg[i] for kwarg in kwargs.values()])
-            for i, (value, reward, segment) in enumerate(zip(quantities, rewards, segments))
-            if segment == reference_segment
-        ]
-        if filtered_values_rewards_kwargs:
-            filtered_values, filtered_rewards, *filtered_kwargs = zip(*filtered_values_rewards_kwargs)
-            filtered_kwargs = dict(zip(kwargs.keys(), filtered_kwargs))
-        else:
-            filtered_values, filtered_rewards, filtered_kwargs = [], [], {k: [] for k in kwargs.keys()}
-        filtered_kwargs = {
-            k: np.array(v) if isinstance(kwargs[k], np.ndarray) else v for k, v in filtered_kwargs.items()
-        }
-        return filtered_values, filtered_rewards, filtered_kwargs
-
-    def _reset(self):
-        self.sub_actions = dict(
-            zip(
-                self._generate_initial_segments(self.dimension),
-                [self._base_model.model_copy(deep=True) for _ in range(self._n_initial_segments**self.dimension)],
-            )
-        )
-
-
-class BaseSmabZoomingModel(ZoomingModel, ABC):
-    """
-    Zooming model for sMAB.
-
-    Parameters
-    ----------
-    dimension: PositiveInt
-        Number of parameters of the model.
-    comparison_threshold: Float01
-        Comparison threshold.
-    segment_update_factor: Float01
-        Segment update factor. If the number of samples in a segment is more than the average number of samples in all
-        segments by this factor, the segment is considered interesting. If the number of samples in a segment is less
-        than the average number of samples in all segments by this factor, the segment is considered a nuisance.
-        Interest segments can be split, while nuisance segments can be merged.
-    n_comparison_points: PositiveInt
-        Number of comparison points.
-    n_max_segments: PositiveInt
-        Maximum number of segments.
-    sub_actions: Dict[Tuple[Tuple[Float01, Float01], ...], Optional[Beta]]
-        Mapping of segments to Beta models.
-    """
-
-    sub_actions: Dict[Tuple[Tuple[Float01, Float01], ...], Optional[Beta]]
-
-    def _init_base_model(self):
-        """
-        Initialize the base model.
-        """
-        self._base_model = Beta()
 
     def _to_quantitative_probabilities(
         self, segment_probabilities: Dict[Segment, List[Probability]]
@@ -879,24 +571,43 @@ class BaseSmabZoomingModel(ZoomingModel, ABC):
         return result
 
     @validate_call
-    def _quantitative_update(
-        self,
-        quantities: List[Union[float, List[float], None]],
-        rewards: List[BinaryReward],
-    ):
+    def _quantitative_update(self, quantities: Union[List[float], List[List[float]]], rewards: List[BinaryReward]):
         """
         Update the model parameters.
 
         Parameters
         ----------
-        quantities : Optional[List[Union[float, List[float], None]]
-            The value associated with each action. If none, the value is not used, i.e. non-quantitative action.
+        quantities : Union[List[float], List[List[float]]],
+            The value associated with each action.
         rewards: List[BinaryReward]
             The reward for each sample.
         """
-        super()._quantitative_update(quantities, rewards)
 
-    @validate_call(config=dict(arbitrary_types_allowed=True))
+        segments = self._map_and_update_segment_models(quantities, rewards)
+        self._update_segmentation(quantities, segments, rewards)
+
+    def _map_and_update_segment_models(
+        self, quantities: Union[List[float], List[List[float]]], rewards: List[BinaryReward]
+    ) -> List[Segment]:
+        """
+        Map and update the segment models.
+
+        Parameters
+        ----------
+        quantities : Union[List[float], List[List[float]]]
+            The value associated with each action.
+        rewards: List[BinaryReward]
+            The reward for each sample.
+
+        Returns
+        -------
+        List[Segment]
+            Segments to update.
+        """
+        segments = self._map_values_to_segments(quantities)
+        self._inner_update(segments, rewards)
+        return segments
+
     def _inner_update(self, segments: List[Segment], rewards: List[BinaryReward]):
         """
         Update the segments models.
@@ -908,13 +619,203 @@ class BaseSmabZoomingModel(ZoomingModel, ABC):
         rewards : List[BinaryReward]
             Rewards for update.
         """
-        rewards = np.array(rewards)
-        for segment in set(segments):
-            rewards_of_segment = [r for r, s in zip(rewards, segments) if s == segment]
+        rewards_by_segment = defaultdict(list)
+        for segment, reward in zip(segments, rewards):
+            rewards_by_segment[segment].append(reward)
+
+        for segment, rewards_of_segment in rewards_by_segment.items():
             self.sub_actions[segment.intervals].update(rewards=rewards_of_segment)
 
+    def _map_values_to_segments(
+        self,
+        quantities: Union[List[float], List[List[float]]],
+    ) -> List[Segment]:
+        segments = [segment for value in quantities for segment in self.segmented_actions.keys() if value in segment]
+        return segments
 
-class SmabZoomingModel(BaseSmabZoomingModel):
+    def _update_segmentation(
+        self,
+        quantities: Union[List[float], List[List[float]]],
+        segments: List[Segment],
+        rewards: List[BinaryReward],
+    ):
+        """
+        Sort segments into three categories: interest (good), nuisance (bad), and all others (neutral).
+        Segments of interest are to be split; adjacent nuisance segments to be merged; and reminder remain untouched.
+        The segment classification is based on the rate of exploitation using self.segment_update_factor.
+
+        Parameters
+        ----------
+        quantities : Union[List[float], List[List[float]]]
+            The value associated with each action.
+        segments : List[Segment]
+            All segments in the model.
+        rewards : List[BinaryReward]
+            Rewards for update.
+        """
+        segments_counts = Counter(segments)
+        num_segments = len(self.sub_actions)
+        interest_segments = []
+        nuisance_segments = []
+        for segment in segments_counts:
+            if segments_counts[segment] > (len(segments) / num_segments) * (1 + self.segment_update_factor):
+                interest_segments.append(segment)
+            elif segments_counts[segment] < (len(segments) / num_segments) * (1 - self.segment_update_factor):
+                nuisance_segments.append(segment)
+        interest_segments = sorted(interest_segments, key=lambda x: segments_counts[x], reverse=True)
+
+        self._merge_adjacent_nuisance_segments(nuisance_segments, quantities, segments, rewards)
+        self._split_segments_of_interest(interest_segments, quantities, segments, rewards)
+
+    def _merge_adjacent_nuisance_segments(
+        self,
+        nuisance_segments: List[Segment],
+        quantities: Union[List[float], List[List[float]]],
+        segments: List[Segment],
+        rewards: List[BinaryReward],
+    ):
+        """
+        Merge adjacent segments that have similar performance.
+
+        Parameters
+        ----------
+        nuisance_segments : List[Segment]
+            List of segments to consider for merging.
+        quantities : Union[List[float], List[List[float]]]
+            The value associated with each action.
+        segments : List[Segment]
+            All segments in the model.
+        rewards : List[BinaryReward]
+            The reward for each sample.
+        """
+        i = 0
+        while i < len(nuisance_segments) - 1:
+            segment = nuisance_segments[i]
+            j = i + 1
+            while j < len(nuisance_segments):
+                other_segment = nuisance_segments[j]
+                if segment.is_adjacent(other_segment) and self.is_similar_performance(segment, other_segment):
+                    del self.sub_actions[segment.intervals]
+                    del self.sub_actions[other_segment.intervals]
+                    nuisance_segments.remove(segment)
+                    nuisance_segments.remove(other_segment)
+                    merged_segment = segment + other_segment
+                    self.sub_actions[merged_segment.intervals] = self._base_model.model_copy(deep=True)
+                    filtered_quantities, filtered_rewards = self._filter_by_segment(
+                        [segment, other_segment], quantities, segments, rewards
+                    )
+                    self._map_and_update_segment_models(filtered_quantities, filtered_rewards)
+                    break
+                j += 1
+            i += 1
+
+    def _split_segments_of_interest(
+        self,
+        interest_segments: List[Segment],
+        quantities: Union[List[float], List[List[float]]],
+        segments: List[Segment],
+        rewards: List[BinaryReward],
+    ):
+        """
+        Split segments of interest into two sub-segments if possible.
+
+        Parameters
+        ----------
+        interest_segments : List[Segment]
+            List of segments to consider for splitting.
+        quantities : Union[List[float], List[List[float]]]
+            The value associated with each action.
+        segments : List[Segment]
+            All segments in the model.
+        rewards : List[BinaryReward]
+            The reward for each sample.
+        """
+        i = 0
+        while i < len(interest_segments) - 1 and (
+            self.n_max_segments is None or len(self.sub_actions) < self.n_max_segments
+        ):
+            best_segment = interest_segments[i]
+            del self.sub_actions[best_segment.intervals]
+            sub_best_segments = best_segment.split()
+            self.sub_actions[sub_best_segments[0].intervals] = self._base_model.model_copy(deep=True)
+            self.sub_actions[sub_best_segments[1].intervals] = self._base_model.model_copy(deep=True)
+            filtered_quantities, filtered_rewards = self._filter_by_segment(best_segment, quantities, segments, rewards)
+            self._map_and_update_segment_models(filtered_quantities, filtered_rewards)
+            i += 1
+
+    def is_similar_performance(self, segment1: Segment, segment2: Segment) -> bool:
+        """
+        Check if two segments have similar performance.
+
+        Parameters
+        ----------
+        segment1 : Segment
+            First segment.
+        segment2 : Segment
+            Second segment.
+
+        Returns
+        -------
+        bool
+            Whether the segments have similar performance.
+        """
+        x = np.linspace(0, 1, self.n_comparison_points)
+        model1 = self.sub_actions[segment1.intervals]
+        model2 = self.sub_actions[segment2.intervals]
+        p1 = beta.pdf(x, model1.n_successes, model1.n_failures)
+        p2 = beta.pdf(x, model2.n_successes, model2.n_failures)
+        return jensenshannon(p1, p2) < self.comparison_threshold
+
+    def _filter_by_segment(
+        self,
+        reference_segment: Union[Segment, List[Segment]],
+        quantities: Union[List[float], List[List[float]]],
+        segments: List[Segment],
+        rewards: List[BinaryReward],
+    ) -> Tuple[Union[List[float], List[List[float]]], List[BinaryReward]]:
+        """
+        Filter and update the segments models.
+
+        Parameters
+        ----------
+        reference_segment : Union[Segment, List[Segment]]
+            Reference segment(s) to filter upon. Pass a list when multiple source
+            segments should be included (e.g. after a merge).
+        segments : List[Segment]
+            Segments to filter.
+        quantities : Union[List[float], List[List[float]]]
+            Values to filter.
+        rewards : List[BinaryReward]
+            Rewards to filter.
+
+        Returns
+        -------
+        filtered_values : Union[List[float], List[List[float]]]
+            Filtered quantities.
+        filtered_rewards : List[BinaryReward]
+            Filtered rewards.
+        """
+        reference_segments = reference_segment if isinstance(reference_segment, list) else [reference_segment]
+        filtered_values_rewards = [
+            (value, reward)
+            for value, reward, segment in zip(quantities, rewards, segments)
+            if segment in reference_segments
+        ]
+        if filtered_values_rewards:
+            filtered_values, filtered_rewards = zip(*filtered_values_rewards)
+            return list(filtered_values), list(filtered_rewards)
+        return [], []
+
+    def _reset(self):
+        self.sub_actions = dict(
+            zip(
+                self._generate_initial_segments(self.dimension),
+                [self._base_model.model_copy(deep=True) for _ in range(self._n_initial_segments**self.dimension)],
+            )
+        )
+
+
+class Zooming(BaseZooming):
     """
     Zooming model for sMAB.
 
@@ -938,7 +839,7 @@ class SmabZoomingModel(BaseSmabZoomingModel):
     """
 
 
-class SmabZoomingModelCC(BaseSmabZoomingModel, QuantitativeModelCC):
+class ZoomingCC(BaseZooming, QuantitativeModelCC):
     """
     Zooming model for sMAB with cost control.
 
@@ -959,192 +860,6 @@ class SmabZoomingModelCC(BaseSmabZoomingModel, QuantitativeModelCC):
         Maximum number of segments.
     sub_actions: Dict[Tuple[Tuple[Float01, Float01], ...], Optional[Beta]]
         Mapping of segments to Beta models.
-    cost: Callable[[Union[float, NonNegativeFloat]], NonNegativeFloat]
-        Cost associated to the Beta distribution.
-    """
-
-
-class BaseCmabZoomingModel(ZoomingModel, ABC):
-    """
-    Zooming model for CMAB.
-
-    Parameters
-    ----------
-    dimension: PositiveInt
-        Number of parameters of the model.
-    comparison_threshold: Float01
-        Comparison threshold.
-    segment_update_factor: Float01
-        Segment update factor. If the number of samples in a segment is more than the average number of samples in all
-        segments by this factor, the segment is considered interesting. If the number of samples in a segment is less
-        than the average number of samples in all segments by this factor, the segment is considered a nuisance.
-        Interest segments can be split, while nuisance segments can be merged.
-    n_comparison_points: PositiveInt
-        Number of comparison points.
-    n_max_segments: PositiveInt
-        Maximum number of segments.
-    sub_actions: Dict[Tuple[Tuple[Float01, Float01], ...], Optional[BayesianNeuralNetwork]]
-        Mapping of segments to Bayesian Logistic Regression models.
-    base_model_cold_start_kwargs: Dict[str, Any]
-        Keyword arguments for the base model cold start.
-    """
-
-    sub_actions: Dict[Tuple[Tuple[Float01, Float01], ...], Optional[BayesianNeuralNetwork]]
-    base_model_cold_start_kwargs: Dict[str, Any]
-
-    @field_validator("base_model_cold_start_kwargs", mode="before")
-    @classmethod
-    def validate_n_features(cls, value):
-        if "n_features" not in value:
-            raise KeyError("n_features must be in base_model_cold_start_kwargs.")
-        return value
-
-    @property
-    def input_dim(self) -> int:
-        """Returns the input feature dimension (number of context features)."""
-        return self.base_model_cold_start_kwargs["n_features"]
-
-    def _init_base_model(self):
-        """
-        Initialize the base model.
-        """
-        self._base_model = BayesianNeuralNetwork.cold_start(**self.base_model_cold_start_kwargs)
-
-    def _to_quantitative_probabilities(
-        self, segment_probabilities: Dict[Segment, List[ProbabilityWeight]]
-    ) -> List[QuantitativeProbabilityWeight]:
-        """
-        Convert the segment probabilities and weights to quantitative probabilities and weights.
-
-        Parameters
-        ----------
-        segment_probabilities : Dict[Segment, List[ProbabilityWeight]]
-            The probabilities and weights of each segment.
-
-        Returns
-        -------
-        List[QuantitativeProbabilityWeight]
-            The quantitative probabilities and weights.
-        """
-        result = []
-        max_samples = max(len(probas) for probas in segment_probabilities.values())
-        n_outputs = len(next(iter(segment_probabilities.values()))[0])
-        for sample_idx in range(max_samples):
-
-            def create_probability_or_weight_function(
-                sample_idx: NonNegativeInt, output_index: NonNegativeInt
-            ) -> Union[QuantitativeProbability, QuantitativeWeight]:
-                def output_function(quantity: np.ndarray) -> Union[Probability, float]:  # Probability or weight
-                    """
-                    Evaluate output at the given quantity.
-                    """
-                    for segment in segment_probabilities.keys():
-                        if quantity in segment:
-                            segment_probas_for_segment = segment_probabilities[segment]
-                            return segment_probas_for_segment[sample_idx][output_index]  # Probability or weight
-                    return 0.0
-
-                return output_function
-
-            result.append(
-                tuple(
-                    create_probability_or_weight_function(sample_idx, output_index) for output_index in range(n_outputs)
-                )
-            )
-        return result
-
-    @validate_call(config=dict(arbitrary_types_allowed=True))
-    def _quantitative_update(
-        self,
-        quantities: List[Union[float, List[float], None]],
-        rewards: List[BinaryReward],
-        context: np.ndarray,
-    ):
-        """
-        Update the model parameters.
-
-        Parameters
-        ----------
-        quantities : Optional[List[Union[float, List[float], None]]
-            The value associated with each action. If none, the value is not used, i.e. non-quantitative action.
-        rewards: List[BinaryReward]
-            The reward for each sample.
-        context : ArrayLike
-            Context for each sample
-        """
-        super()._quantitative_update(quantities, rewards, context=context)
-
-    @validate_call(config=dict(arbitrary_types_allowed=True))
-    def _inner_update(self, segments: List[Segment], rewards: List[BinaryReward], context: np.ndarray):
-        """
-        Update the segments models.
-
-        Parameters
-        ----------
-        segments : List[Segment]
-            Segments to update.
-        rewards : List[BinaryReward]
-            Rewards for update.
-        context : Optional[ArrayLike]
-            Context for update.
-        """
-        context = np.array(context)
-        for segment in set(segments):
-            rewards_of_segment = [r for r, s in zip(rewards, segments) if s == segment]
-            context_of_segment = context[[s == segment for s in segments]]
-            if rewards_of_segment:
-                self.sub_actions[segment.intervals].update(rewards=rewards_of_segment, context=context_of_segment)
-
-
-class CmabZoomingModel(BaseCmabZoomingModel):
-    """
-    Zooming model for CMAB.
-
-    Parameters
-    ----------
-    dimension: PositiveInt
-        Number of parameters of the model.
-    comparison_threshold: Float01
-        Comparison threshold.
-    segment_update_factor: Float01
-        Segment update factor. If the number of samples in a segment is more than the average number of samples in all
-        segments by this factor, the segment is considered interesting. If the number of samples in a segment is less
-        than the average number of samples in all segments by this factor, the segment is considered a nuisance.
-        Interest segments can be split, while nuisance segments can be merged.
-    n_comparison_points: PositiveInt
-        Number of comparison points.
-    n_max_segments: PositiveInt
-        Maximum number of segments.
-    sub_actions: Dict[Tuple[Tuple[Float01, Float01], ...], Optional[BayesianNeuralNetwork]]
-        Mapping of segments to Bayesian Logistic Regression models.
-    base_model_cold_start_kwargs: Dict[str, Any]
-        Keyword arguments for the base model cold start.
-    """
-
-
-class CmabZoomingModelCC(BaseCmabZoomingModel, QuantitativeModelCC):
-    """
-    Zooming model for CMAB with cost control.
-
-    Parameters
-    ----------
-    dimension: PositiveInt
-        Number of parameters of the model.
-    comparison_threshold: Float01
-        Comparison threshold.
-    segment_update_factor: Float01
-        Segment update factor. If the number of samples in a segment is more than the average number of samples in all
-        segments by this factor, the segment is considered interesting. If the number of samples in a segment is less
-        than the average number of samples in all segments by this factor, the segment is considered a nuisance.
-        Interest segments can be split, while nuisance segments can be merged.
-    n_comparison_points: PositiveInt
-        Number of comparison points.
-    n_max_segments: PositiveInt
-        Maximum number of segments.
-    sub_actions: Dict[Tuple[Tuple[Float01, Float01], ...], Optional[BayesianNeuralNetwork]]
-        Mapping of segments to Bayesian Logistic Regression models.
-    base_model_cold_start_kwargs: Dict[str, Any]
-        Keyword arguments for the base model cold start.
     cost: Callable[[Union[float, NonNegativeFloat]], NonNegativeFloat]
         Cost associated to the Beta distribution.
     """

--- a/pybandits/smab.py
+++ b/pybandits/smab.py
@@ -38,7 +38,7 @@ from pybandits.base import (
 from pybandits.mab import BaseMab
 from pybandits.model import BaseBeta
 from pybandits.pydantic_version_compatibility import PositiveInt, validate_call
-from pybandits.quantitative_model import BaseSmabZoomingModel
+from pybandits.quantitative_model import BaseZooming
 from pybandits.strategy import (
     BestActionIdentificationBandit,
     ClassicBandit,
@@ -54,13 +54,13 @@ class BaseSmabBernoulli(BaseMab, ABC):
 
     Parameters
     ----------
-    actions: Dict[ActionId, Union[BaseBeta, BaseSmabZoomingModel]]
+    actions: Dict[ActionId, Union[BaseBeta, BaseZooming]]
         The list of possible actions, and their associated Model.
     strategy: Strategy
         The strategy used to select actions.
     """
 
-    actions_manager: SmabActionsManager[Union[BaseBeta, BaseSmabZoomingModel]]
+    actions_manager: SmabActionsManager[Union[BaseBeta, BaseZooming]]
 
     @validate_call
     def predict(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybandits"
-version = "6.0.4"
+version = "6.0.5"
 description = "Python Multi-Armed Bandit Library"
 authors = [
     "Dario d'Andrea <dariod@playtika.com>",

--- a/tests/test_actions_manager.py
+++ b/tests/test_actions_manager.py
@@ -40,14 +40,14 @@ from pybandits.pydantic_version_compatibility import (
     ValidationError,
     pydantic_version,
 )
-from pybandits.quantitative_model import QuantitativeBayesianNeuralNetwork, SmabZoomingModel
+from pybandits.quantitative_model import QuantitativeBayesianNeuralNetwork, Zooming
 from tests.utils import mock_update
 
 REFERENCE_DELTA = 0.0001
 
 
 class DummyActionsManager(ActionsManager):
-    actions: Dict[ActionId, Union[Beta, BetaMO, SmabZoomingModel]]
+    actions: Dict[ActionId, Union[Beta, BetaMO, Zooming]]
 
     def _update_actions(
         self,
@@ -177,24 +177,24 @@ def test_mixed_action_types_error(n_features=1):
 
 def test_smab_mixed_action_types_error():
     beta_model = Beta()
-    zoom_model = SmabZoomingModel.cold_start()
+    zoom_model = Zooming.cold_start()
 
     actions = {"a1": beta_model, "a2": zoom_model}
     with pytest.raises(ValidationError):
-        SmabActionsManager[SmabZoomingModel](actions=actions)
+        SmabActionsManager[Zooming](actions=actions)
     with pytest.raises(ValidationError):
         SmabActionsManager[Beta](actions=actions)
 
-    SmabActionsManager[Union[Beta, SmabZoomingModel]](actions=actions)
+    SmabActionsManager[Union[Beta, Zooming]](actions=actions)
 
 
 def test_cmab_mixed_action_types_error(n_features=1):
-    blr_model = BayesianNeuralNetwork.cold_start(n_features=n_features)
-    blr_model2 = BayesianNeuralNetwork.cold_start(n_features=n_features + 1)
+    bnn_model = BayesianNeuralNetwork.cold_start(n_features=n_features)
+    bnn_model2 = BayesianNeuralNetwork.cold_start(n_features=n_features + 1)
     quant_model = QuantitativeBayesianNeuralNetwork.cold_start(n_features=n_features)
     quant_model2 = QuantitativeBayesianNeuralNetwork.cold_start(n_features=n_features + 1)
 
-    actions = {"a1": blr_model, "a2": blr_model2}
+    actions = {"a1": bnn_model, "a2": bnn_model2}
     with pytest.raises(AttributeError):
         CmabActionsManager[BayesianNeuralNetwork](actions=actions)
 
@@ -202,11 +202,11 @@ def test_cmab_mixed_action_types_error(n_features=1):
     with pytest.raises(AttributeError):
         CmabActionsManager[QuantitativeBayesianNeuralNetwork](actions=actions)
 
-    actions = {"a1": blr_model, "a2": quant_model2}
+    actions = {"a1": bnn_model, "a2": quant_model2}
     with pytest.raises(AttributeError):
         CmabActionsManager[Union[BayesianNeuralNetwork, QuantitativeBayesianNeuralNetwork]](actions=actions)
 
-    actions = {"a1": blr_model, "a2": quant_model}
+    actions = {"a1": bnn_model, "a2": quant_model}
     CmabActionsManager[Union[BayesianNeuralNetwork, QuantitativeBayesianNeuralNetwork]](actions=actions)
 
 

--- a/tests/test_cmab_simulator.py
+++ b/tests/test_cmab_simulator.py
@@ -37,7 +37,7 @@ import pybandits.strategy
 import pybandits.utils
 from pybandits.cmab import CmabBernoulli
 from pybandits.cmab_simulator import CmabSimulator
-from pybandits.model import BayesianLogisticRegression
+from pybandits.model import BayesianNeuralNetwork
 from pybandits.quantitative_model import QuantitativeBayesianNeuralNetwork
 from tests.utils import apply_mock_update, sample_with_replacement, to_unified_action_id
 
@@ -200,7 +200,7 @@ def test_cmab_simulator_with_explicit_probs_reward(
     models=st.lists(
         st.sampled_from(
             [
-                BayesianLogisticRegression.cold_start(n_features=2, update_method="VI"),
+                BayesianNeuralNetwork.cold_start(n_features=2, update_method="VI"),
                 QuantitativeBayesianNeuralNetwork.cold_start(
                     n_features=2, base_model_cold_start_kwargs={"update_method": "VI"}
                 ),
@@ -264,7 +264,7 @@ def mock_mab_update(self, actions, rewards, quantities=None, **kwargs):
     st.lists(
         st.sampled_from(
             [
-                BayesianLogisticRegression.cold_start(n_features=2, update_method="VI"),
+                BayesianNeuralNetwork.cold_start(n_features=2, update_method="VI"),
                 QuantitativeBayesianNeuralNetwork.cold_start(
                     n_features=2, base_model_cold_start_kwargs={"update_method": "VI"}
                 ),
@@ -319,7 +319,7 @@ def test_cmab_e2e_simulation_with_default_arguments(monkeymodule, action_ids, mo
     models=st.lists(
         st.sampled_from(
             [
-                BayesianLogisticRegression.cold_start(n_features=3, update_method="VI"),
+                BayesianNeuralNetwork.cold_start(n_features=3, update_method="VI"),
                 QuantitativeBayesianNeuralNetwork.cold_start(
                     n_features=3, base_model_cold_start_kwargs={"update_method": "VI"}
                 ),

--- a/tests/test_mab.py
+++ b/tests/test_mab.py
@@ -230,10 +230,10 @@ def test_mab_model_post_init_quantitative_default_action_validation(epsilon=0.1)
 
 def test_mab_model_post_init_standard_default_action_validation(epsilon=0.1):
     """Test model_post_init validation for standard default action requirements."""
-    from pybandits.quantitative_model import SmabZoomingModel
+    from pybandits.quantitative_model import Zooming
 
     # Create quantitative actions
-    actions = {"action1": SmabZoomingModel.cold_start(), "action2": SmabZoomingModel.cold_start()}
+    actions = {"action1": Zooming.cold_start(), "action2": Zooming.cold_start()}
 
     # Test case: standard default action (string) with quantitative model - should raise AttributeError
     with pytest.raises(AttributeError, match="Standard default action requires a standard action model."):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 from typing import Literal, Optional
+from unittest.mock import patch
 
 import numpy as np
 import numpyro
@@ -32,7 +33,6 @@ from numpyro.distributions import StudentT as NumpyroStudentT
 
 from pybandits.model import (
     BaseLocationScaleArray,
-    BayesianLogisticRegression,
     BayesianNeuralNetwork,
     BayesianNeuralNetworkCC,
     BayesianNeuralNetworkMO,
@@ -293,7 +293,7 @@ def test_location_scale_array_to_numpyro_distribution(array_class, expected_nump
 ########################################################################################################################
 
 
-# BayesianNeuralNetwork and BayesianLogisticRegression
+# BayesianNeuralNetwork
 @settings(deadline=500)
 @given(
     n_features=st.integers(min_value=1, max_value=3),
@@ -436,7 +436,7 @@ def test_bnn_sample_proba(
     assert is_all_different
 
 
-@settings(deadline=None, max_examples=25)
+@settings(deadline=None, max_examples=20)
 @given(
     activation=st.sampled_from(["tanh", "relu", "sigmoid", "gelu"]),
     use_residual_connections=st.booleans(),
@@ -444,7 +444,7 @@ def test_bnn_sample_proba(
     dist_type=st.sampled_from(["studentt", "normal"]),
     n_features=st.integers(min_value=1, max_value=2),
     hidden_dim_list=st.lists(st.integers(min_value=1, max_value=2), min_size=0, max_size=1),
-    n_samples=st.just(3),
+    n_samples=st.just(2),
     update_method=st.just("VI"),
     epochs=st.just(1),
 )
@@ -558,7 +558,6 @@ def _create_update_kwargs(
 @given(
     n_features=st.just(2),
     hidden_dim_list=st.just([1]),
-    n_samples=st.just(5),
     batch_size=st.sampled_from((None, 2, 4)),
     optimizer_type=st.sampled_from((None, "adam")),
     lr=st.floats(min_value=0.0, max_value=1.0, exclude_min=True, exclude_max=True),
@@ -566,11 +565,11 @@ def _create_update_kwargs(
     early_stopping_tol=st.one_of(st.none(), st.floats(min_value=1e-6, max_value=1e-1)),
     early_stopping_patience=st.one_of(st.none(), st.integers(min_value=1, max_value=10)),
     update_method=st.just("VI"),
+    restore_best_svi_state=st.one_of(st.none(), st.booleans()),
 )
 def test_bnn_vi_update_parameters(
     n_features: int,
     hidden_dim_list: list[int],
-    n_samples: int,
     batch_size: Optional[int],
     optimizer_type: Optional[str],
     lr: Optional[float],
@@ -578,11 +577,14 @@ def test_bnn_vi_update_parameters(
     early_stopping_tol: Optional[float],
     early_stopping_patience: Optional[int],
     update_method: UpdateMethods,
+    restore_best_svi_state: Optional[bool],
 ) -> None:
     """Test BNN VI update with various valid parameters."""
     update_kwargs = _create_update_kwargs(
         batch_size, optimizer_type, lr, early_stopping_diff, early_stopping_tol, early_stopping_patience
     )
+    if restore_best_svi_state is not None:
+        update_kwargs["restore_best_svi_state"] = restore_best_svi_state
 
     bnn = BayesianNeuralNetwork.cold_start(
         n_features=n_features,
@@ -602,6 +604,10 @@ def test_bnn_vi_update_parameters(
         assert isinstance(bnn._get_early_stopping_callback(), EarlyStopping)
     else:
         assert bnn._get_early_stopping_callback() is None
+
+    # restore_best_svi_state defaults to True; explicit value is preserved
+    expected = restore_best_svi_state if restore_best_svi_state is not None else True
+    assert bnn._update_kwargs.get("restore_best_svi_state") is expected
 
 
 @given(
@@ -868,6 +874,47 @@ def test_bnn_fullrank_advi_update(n_features, hidden_dim_list=(1,), n_samples=5,
 ########################################################################################################################
 
 
+# BayesianNeuralNetwork - SVI NaN protection and restore_best_svi_state
+
+
+@given(
+    n_features=st.integers(min_value=1, max_value=3),
+    hidden_dim_list=st.lists(st.integers(min_value=1, max_value=2), min_size=0, max_size=1),
+    n_samples=st.just(2),
+    update_method=st.just("VI"),
+)
+def test_bnn_svi_nan_loss_raises_error(
+    n_features: int, hidden_dim_list: list[int], n_samples: int, update_method: UpdateMethods
+) -> None:
+    """Test that a NaN loss during SVI training raises a ValueError immediately."""
+
+    bnn = BayesianNeuralNetwork.cold_start(
+        n_features=n_features,
+        hidden_dim_list=hidden_dim_list,
+        update_method=update_method,
+    )
+
+    # Patch np.mean to return NaN on the first epoch to simulate divergence.
+    original_mean = np.mean
+    call_count = {"n": 0}
+
+    def nan_mean(a, *args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return float("nan")
+        return original_mean(a, *args, **kwargs)
+
+    context = np.random.uniform(size=(n_samples, n_features))
+    rewards = _make_random_rewards(n_samples)
+
+    with patch("pybandits.model.np.mean", nan_mean):
+        with pytest.raises(ValueError, match="SVI training diverged.*NaN"):
+            bnn.update(context=context, rewards=rewards)
+
+
+########################################################################################################################
+
+
 # BayesianNeuralNetwork - Activation Functions
 
 
@@ -885,14 +932,6 @@ def test_bnn_invalid_activation_raises_error(invalid_activation, n_features, hid
     assert "Invalid activation function" in error_str or "activation" in error_str.lower()
 
 
-@pytest.mark.parametrize("activation", ["tanh", "relu", "sigmoid", "gelu"])
-def test_bayesian_logistic_regression_with_different_activations(activation):
-    """Test that BayesianLogisticRegression works with different activation functions."""
-    blr = BayesianLogisticRegression.cold_start(n_features=3, hidden_dim_list=[], activation=activation)
-    assert blr.activation == activation
-    assert len(blr.model_params.bnn_layer_params) == 1
-
-
 def test_bnn_jax_and_numpy_activation_keys_match():
     """Test that the keys of _jax_activations and _numpy_activations dictionaries match."""
     jax_keys = set(BayesianNeuralNetwork._jax_activations.keys())
@@ -901,22 +940,6 @@ def test_bnn_jax_and_numpy_activation_keys_match():
     assert jax_keys == numpy_keys, (
         f"Keys mismatch between _jax_activations and _numpy_activations. JAX keys: {jax_keys}, NumPy keys: {numpy_keys}"
     )
-
-
-def test_bayesian_logistic_regression_with_residual_connections():
-    """Test that BayesianLogisticRegression works with residual connections."""
-    # Logistic regression has only one layer (input -> output), so no residual connections
-    # But it should still work without errors
-    blr = BayesianLogisticRegression.cold_start(n_features=3, hidden_dim_list=[], use_residual_connections=True)
-    assert blr.use_residual_connections is True
-    assert len(blr.model_params.bnn_layer_params) == 1
-
-    context = np.random.uniform(low=-1.0, high=1.0, size=(5, 3))
-    prob_and_weighted_sum = blr.sample_proba(context=context)
-    prob, weighted_sum = zip(*prob_and_weighted_sum)
-
-    assert len(prob) == 5
-    assert all([0 <= p <= 1 for p in prob])
 
 
 @settings(deadline=500)
@@ -1059,36 +1082,6 @@ def test_create_default_instance_bayesian_neural_network_cc(
         prob, weighted_sum = zip(*prob_and_weighted_sum)
         assert len(prob) == 5
         assert all([0 <= p <= 1 for p in prob])
-
-
-########################################################################################################################
-
-
-# BayesianLogisticRegression
-
-
-@given(
-    n_features=st.integers(min_value=1, max_value=10),
-)
-def test_bayesian_logistic_regression_valid_init(n_features: int) -> None:
-    """Test that BayesianLogisticRegression can be initialized with valid single-layer configurations."""
-
-    # Should not raise any validation errors
-    blr = BayesianLogisticRegression.cold_start(n_features=n_features, hidden_dim_list=[])
-    assert len(blr.model_params.bnn_layer_params) == 1
-    assert len(blr.model_params.bnn_layer_params_init) == 1
-
-
-@settings(deadline=500)
-@given(
-    n_features=st.integers(min_value=1, max_value=5),
-    hidden_dim_list=st.lists(st.integers(min_value=1, max_value=5), min_size=1, max_size=3),
-)
-def test_bayesian_logistic_regression_invalid_init(n_features: int, hidden_dim_list: list) -> None:
-    """Test that BayesianLogisticRegression raises ValueError for multi-layer configurations."""
-
-    with pytest.raises(ValueError, match="The Bayesian Logistic Regression model should have only one layer."):
-        BayesianLogisticRegression.cold_start(n_features=n_features, hidden_dim_list=hidden_dim_list)
 
 
 ########################################################################################################################
@@ -1638,11 +1631,13 @@ def test_reset_restores_embedding_params(n_features, cardinality):
     dist_type=st.sampled_from(["studentt", "normal"]),
     n_features=st.integers(min_value=2, max_value=4),
     cardinality=st.integers(min_value=2, max_value=6),
-    hidden_dim_list=st.lists(st.integers(min_value=4, max_value=8), min_size=1, max_size=1),
-    n_samples=st.integers(min_value=4, max_value=10),
+    hidden_dim_list=st.lists(st.integers(min_value=1, max_value=2), min_size=0, max_size=1),
+    n_samples=st.just(2),
+    update_method=st.just("VI"),
+    epochs=st.just(1),
 )
 def test_bnn_vi_update_with_categorical_features_updates_embeddings(
-    dist_type, n_features, cardinality, hidden_dim_list, n_samples
+    dist_type, n_features, cardinality, hidden_dim_list, n_samples, update_method, epochs
 ):
     cat_col = n_features - 1
     categorical_features = {cat_col: cardinality}
@@ -1651,7 +1646,8 @@ def test_bnn_vi_update_with_categorical_features_updates_embeddings(
         categorical_features=categorical_features,
         hidden_dim_list=hidden_dim_list,
         dist_type=dist_type,
-        update_kwargs={"num_steps": 10},
+        update_method=update_method,
+        update_kwargs={"epochs": epochs},
     )
     context = _make_categorical_context(n_samples, n_features, categorical_features)
     rewards = _make_random_rewards(n_samples)

--- a/tests/test_offline_policy_evaluator.py
+++ b/tests/test_offline_policy_evaluator.py
@@ -225,7 +225,7 @@ def generate_random_bool() -> bool:
 
 
 @pytest.mark.usefixtures("logged_data")
-@settings(deadline=None)
+@settings(deadline=None, max_examples=20)
 @given(
     split_prop=st.just(0.5),
     n_trials=st.just(2),

--- a/tests/test_quantitative_model.py
+++ b/tests/test_quantitative_model.py
@@ -36,11 +36,11 @@ from pybandits.base import BinaryReward, QuantitativeProbability, UnifiedProbabi
 from pybandits.model import Beta
 from pybandits.pydantic_version_compatibility import NonNegativeFloat
 from pybandits.quantitative_model import (
+    BaseZooming,
     QuantitativeBayesianNeuralNetwork,
     Segment,
-    SmabZoomingModel,
-    SmabZoomingModelCC,
-    ZoomingModel,
+    Zooming,
+    ZoomingCC,
 )
 from tests.utils import mock_update
 
@@ -90,7 +90,7 @@ def test_add_nonadjacent_segments():
         seg1 + seg2
 
 
-class DummyZoomingModel(ZoomingModel):
+class DummyZooming(BaseZooming):
     cost: Optional[Callable[[Union[float, NonNegativeFloat]], NonNegativeFloat]] = None
 
     def _init_base_model(self):
@@ -109,8 +109,8 @@ class DummyZoomingModel(ZoomingModel):
 # Model initialization with valid parameters creates correct number of segments
 @given(dimension=st.integers(min_value=1, max_value=3))
 def test_init_creates_correct_segments(dimension):
-    model = DummyZoomingModel.cold_start(dimension=dimension, n_max_segments=None)
-    expected_segments = DummyZoomingModel._n_initial_segments**dimension
+    model = DummyZooming.cold_start(dimension=dimension, n_max_segments=None)
+    expected_segments = DummyZooming._n_initial_segments**dimension
     assert len(model.sub_actions) == expected_segments
 
 
@@ -125,14 +125,14 @@ def test_init_creates_correct_segments(dimension):
 )
 def test_update_processes_rewards_correctly(data):
     rewards, quantities = data
-    model = DummyZoomingModel.cold_start(dimension=1)
+    model = DummyZooming.cold_start(dimension=1)
     model.update(quantities=quantities, rewards=rewards)
     assert model.n_successes != 1 or model.n_failures != 1
 
 
 # Best performing segment gets split when below max segments limit
 def test_best_segment_splits():
-    model = DummyZoomingModel.cold_start(dimension=1, n_max_segments=8)
+    model = DummyZooming.cold_start(dimension=1, n_max_segments=8)
     quantities = [0.25, 0.75]
     rewards = [1, 0]
     model.update(quantities=quantities, rewards=rewards)
@@ -143,7 +143,7 @@ def test_best_segment_splits():
 
 # Adjacent segments with similar performance get merged correctly
 def test_similar_segments_merge():
-    model = DummyZoomingModel.cold_start(dimension=1, comparison_threshold=0.5)
+    model = DummyZooming.cold_start(dimension=1, comparison_threshold=0.5)
     initial_segmented_actions = model.sub_actions.copy()
     quantities = [0.75, 0.75]
     rewards = [1, 1]
@@ -154,7 +154,7 @@ def test_similar_segments_merge():
 
 # Sample_proba returns valid probability functions
 def test_sample_proba_returns_valid_probabilities(n_samples=100, test_locations=((0.1,), (0.5,), (0.9,))):
-    model = DummyZoomingModel.cold_start(dimension=1)
+    model = DummyZooming.cold_start(dimension=1)
     prob_functions = model.sample_proba(n_samples=n_samples)
     assert len(prob_functions) == n_samples
 
@@ -169,7 +169,7 @@ def test_sample_proba_returns_valid_probabilities(n_samples=100, test_locations=
 
 # Update with empty rewards/quantities list
 def test_update_with_empty_lists():
-    model = DummyZoomingModel.cold_start(dimension=1)
+    model = DummyZooming.cold_start(dimension=1)
     initial_segments = len(model.sub_actions)
     model.update(quantities=[], rewards=[])
     assert len(model.sub_actions) == initial_segments
@@ -177,7 +177,7 @@ def test_update_with_empty_lists():
 
 # Update when at maximum number of segments
 def test_update_at_max_segments():
-    model = DummyZoomingModel.cold_start(dimension=1, n_max_segments=4)
+    model = DummyZooming.cold_start(dimension=1, n_max_segments=4)
     quantities = [0.5]
     rewards = [1]
     model.update(quantities=quantities, rewards=rewards)
@@ -186,7 +186,7 @@ def test_update_at_max_segments():
 
 # Merging segments when only 2 segments remain
 def test_merge_with_two_segments():
-    model = DummyZoomingModel.cold_start(dimension=1, comparison_threshold=1.0)
+    model = DummyZooming.cold_start(dimension=1, comparison_threshold=1.0)
     quantities = [0.25, 0.75]
     rewards = [1, 1]
     model.update(quantities=quantities, rewards=rewards)
@@ -195,7 +195,7 @@ def test_merge_with_two_segments():
 
 # Comparing non-adjacent segments for merging
 def test_non_adjacent_segments_comparison():
-    model = DummyZoomingModel.cold_start(dimension=1)
+    model = DummyZooming.cold_start(dimension=1)
     segments = list(model.segmented_actions.keys())
     non_adjacent = [segments[0], segments[2]]
     assert not non_adjacent[0].is_adjacent(non_adjacent[1])
@@ -260,7 +260,7 @@ def test_higher_dimension_adjacency(dimension, base_interval):
 # Values that fall on segment boundaries
 @given(st.integers(min_value=4, max_value=8))
 def test_boundary_values(n_segments):
-    model = DummyZoomingModel.cold_start(dimension=1, n_max_segments=n_segments)
+    model = DummyZooming.cold_start(dimension=1, n_max_segments=n_segments)
     boundary = 1.0 / n_segments
     quantities = [boundary]
     rewards = [1]
@@ -269,32 +269,32 @@ def test_boundary_values(n_segments):
     assert len(mapped_segments) >= 1
 
 
-# Test SmabZoomingModel initialization with valid parameters
+# Test Zooming initialization with valid parameters
 @given(dimension=st.integers(min_value=1, max_value=3), n_max_segments=st.just(None))
 def test_initializes_smab_zooming_model_correctly(dimension, n_max_segments):
-    model = SmabZoomingModel.cold_start(dimension=dimension, n_max_segments=n_max_segments)
-    expected_segments = SmabZoomingModel._n_initial_segments**dimension
+    model = Zooming.cold_start(dimension=dimension, n_max_segments=n_max_segments)
+    expected_segments = Zooming._n_initial_segments**dimension
     assert len(model.segmented_actions) == expected_segments
 
 
-# Test SmabZoomingModel update with valid rewards and quantities
+# Test Zooming update with valid rewards and quantities
 @given(
     rewards=st.lists(st.integers(min_value=0, max_value=1), min_size=1, max_size=5),
     dimension=st.just(1),
 )
 def test_updates_smab_zooming_model_correctly(rewards, dimension):
-    model = SmabZoomingModel.cold_start(dimension=dimension)
+    model = Zooming.cold_start(dimension=dimension)
     initial_segments = deepcopy(model.segmented_actions)
     quantities = np.random.uniform(0, 1, size=len(rewards)).tolist()
     model.update(quantities=quantities, rewards=rewards)
     assert model.segmented_actions != initial_segments
 
 
-# Test SmabZoomingModel sample_proba returns valid probability functions
+# Test Zooming sample_proba returns valid probability functions
 def test_sample_proba_returns_valid_probabilities_smab(
     dimension=1, n_samples=100, test_locations=((0.1,), (0.5,), (0.9,))
 ):
-    model = SmabZoomingModel.cold_start(dimension=dimension)
+    model = Zooming.cold_start(dimension=dimension)
     prob_functions = model.sample_proba(n_samples=n_samples)
     assert len(prob_functions) == n_samples
 
@@ -497,7 +497,7 @@ def test_quantitative_bnn_to_quantitative_probabilities_consistency_with_categor
 ########################################################################################################################
 
 
-# QuantitativeModelCC tests via SmabZoomingModelCC
+# QuantitativeModelCC tests via ZoomingCC
 
 
 def simple_cost(value: float) -> float:
@@ -523,14 +523,14 @@ def test_cost_serialization_deserialization(cost_function):
     """Test serialization and deserialization of cost field with different callables."""
 
     # Create model with the test callable as cost
-    model = SmabZoomingModelCC.cold_start(cost=cost_function)
+    model = ZoomingCC.cold_start(cost=cost_function)
     serialized = model.apply_version_adjusted_method("model_dump_json", "json")
     serialized_dict = json.loads(serialized)
 
     assert "cost" in serialized_dict
     assert isinstance(serialized_dict["cost"], str)
 
-    deserialized_model = SmabZoomingModelCC.model_validate_json(serialized)
+    deserialized_model = ZoomingCC.model_validate_json(serialized)
     # Check callable was properly restored
     assert callable(deserialized_model.cost)
 

--- a/tests/test_smab.py
+++ b/tests/test_smab.py
@@ -36,7 +36,7 @@ from pybandits.base import ActionId, Float01, PositiveProbability
 from pybandits.base_model import BaseModel
 from pybandits.model import Beta, BetaCC, BetaMO, BetaMOCC
 from pybandits.pydantic_version_compatibility import PositiveInt, ValidationError
-from pybandits.quantitative_model import QuantitativeModel, SmabZoomingModel, SmabZoomingModelCC
+from pybandits.quantitative_model import QuantitativeModel, Zooming, ZoomingCC
 from pybandits.smab import (
     BaseSmabBernoulli,
     SmabBernoulli,
@@ -92,7 +92,7 @@ class ModelTestConfig:
         if len(model_types) < len(action_ids):
             indices = np.random.randint(0, len(model_types), len(action_ids))
             model_types = [model_types[i] for i in indices]
-        if all(model in [BetaCC, SmabZoomingModelCC, BetaMOCC] for model in model_types):
+        if all(model in [BetaCC, ZoomingCC, BetaMOCC] for model in model_types):
             # Generate random costs
             costs = costs.draw(cost_strategy(n_actions=len(action_ids)))
             costs = [
@@ -107,14 +107,14 @@ class ModelTestConfig:
                 return {
                     action_id: model_type(cost=cost)
                     if issubclass(model_type, BetaCC)
-                    else model_type.cold_start(dimension=1, cost=cost)  # SmabZoomingModelCC
+                    else model_type.cold_start(dimension=1, cost=cost)  # ZoomingCC
                     for action_id, model_type, cost in zip(action_ids, model_types, costs)
                 }
             else:
                 return {
                     action_id: model_type()
                     if issubclass(model_type, Beta)
-                    else model_type.cold_start(dimension=1)  # SmabZoomingModel
+                    else model_type.cold_start(dimension=1)  # Zooming
                     for action_id, model_type in zip(action_ids, model_types)
                 }
         else:
@@ -175,12 +175,12 @@ class ModelTestConfig:
 
 
 TEST_CONFIGS = {
-    "smab": ModelTestConfig(SmabBernoulli, ClassicBandit, [Beta, SmabZoomingModel]),
-    "smab_bai": ModelTestConfig(SmabBernoulliBAI, BestActionIdentificationBandit, [Beta, SmabZoomingModel]),
+    "smab": ModelTestConfig(SmabBernoulli, ClassicBandit, [Beta, Zooming]),
+    "smab_bai": ModelTestConfig(SmabBernoulliBAI, BestActionIdentificationBandit, [Beta, Zooming]),
     "smab_cc": ModelTestConfig(
         SmabBernoulliCC,
         CostControlBandit,
-        [BetaCC, SmabZoomingModelCC],
+        [BetaCC, ZoomingCC],
     ),
     "smab_mo": ModelTestConfig(SmabBernoulliMO, MultiObjectiveBandit, [BetaMO]),
     "smab_mocc": ModelTestConfig(SmabBernoulliMOCC, MultiObjectiveCostControlBandit, [BetaMOCC]),
@@ -227,12 +227,12 @@ def test_cold_start(
             action for action, model in actions.items() if isinstance(model, QuantitativeModel)
         },
     }
-    if all(isinstance(model, (BetaCC, SmabZoomingModelCC, BetaMOCC)) for model in actions.values()):
+    if all(isinstance(model, (BetaCC, ZoomingCC, BetaMOCC)) for model in actions.values()):
         cold_start_kwargs["action_ids_cost"] = {
             action: model.cost for action, model in actions.items() if isinstance(model, (BetaCC, BetaMOCC))
         }
         cold_start_kwargs["quantitative_action_ids_cost"] = {
-            action: model.cost for action, model in actions.items() if isinstance(model, SmabZoomingModelCC)
+            action: model.cost for action, model in actions.items() if isinstance(model, ZoomingCC)
         }
     cold_start_kwargs.update(kwargs)  # Add exploit_p or subsidy_factor if needed
     cold_start_kwargs = {k: v for k, v in cold_start_kwargs.items() if v is not None}

--- a/tests/test_smab_simulator.py
+++ b/tests/test_smab_simulator.py
@@ -38,7 +38,7 @@ import pybandits.utils
 from pybandits.actions_manager import SmabModelType
 from pybandits.base_model import BaseModel
 from pybandits.model import Beta
-from pybandits.quantitative_model import QuantitativeModel, SmabZoomingModel
+from pybandits.quantitative_model import QuantitativeModel, Zooming
 from pybandits.smab import SmabBernoulli
 from pybandits.smab_simulator import SmabSimulator
 from tests.utils import sample_with_replacement, to_unified_action_id
@@ -196,7 +196,7 @@ def mock_predict(self, n_samples, *args, **kwargs):
 @settings(deadline=None)
 @given(
     action_ids=st.just(["a1", "a2"]),
-    models=st.lists(st.sampled_from([Beta(), SmabZoomingModel.cold_start()]), min_size=2, max_size=2),
+    models=st.lists(st.sampled_from([Beta(), Zooming.cold_start()]), min_size=2, max_size=2),
 )
 def test_smab_e2e_simulation_with_default_args(
     action_ids: List[str], models: List[BaseModel], monkeymodule: pytest.MonkeyPatch
@@ -237,7 +237,7 @@ def test_smab_e2e_simulation_with_default_args(
 @settings(deadline=None)
 @given(
     action_ids=st.just(["a1", "a2"]),
-    models=st.lists(st.sampled_from([Beta(), SmabZoomingModel.cold_start()]), min_size=2, max_size=2),
+    models=st.lists(st.sampled_from([Beta(), Zooming.cold_start()]), min_size=2, max_size=2),
     n_updates=st.integers(min_value=1, max_value=3),
     batch_size=st.integers(min_value=1, max_value=3),
     save=st.booleans(),

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -44,7 +44,7 @@ from pybandits.strategy import (
     MultiObjectiveStrategy,
     SingleObjectiveStrategy,
 )
-from tests.test_quantitative_model import DummyZoomingModel
+from tests.test_quantitative_model import DummyZooming
 
 ########################################################################################################################
 # Helper functions and fixtures
@@ -159,7 +159,7 @@ def action_probability_pairs(draw, min_actions: int = 2, max_actions: int = 10, 
         if allow_callables and draw(st.booleans()):
             # Create a callable probability
             probabilities[action_id] = lambda x, p=probability_value: p
-            models[action_id] = DummyZoomingModel.cold_start(dimension=DEFAULT_DIMENSION, cost=lambda x: cost_value)
+            models[action_id] = DummyZooming.cold_start(dimension=DEFAULT_DIMENSION, cost=lambda x, c=cost_value: c)
         else:
             # Create a fixed probability
             probabilities[action_id] = probability_value


### PR DESCRIPTION
### Changes
 * Remove `BayesianLogisticRegression` and `BayesianLogisticRegressionCC` from `model.py`
 * Flatten zooming hierarchy in `quantitative_model.py`:
   - `Zooming` (was `SmabZoomingModel`) absorbs `BaseSmabZoomingModel` — now the single concrete zooming model for sMAB
   - `ZoomingCC` (was `SmabZoomingModelCC`) retains cost-control variant
   - Remove `BaseCmabZoomingModel`, `CmabZoomingModel`, `CmabZoomingModelCC` — zooming is sMAB-only
 * Update imports and type annotations in `actions_manager.py`, `smab.py`, `cmab.py`
 * Remove `BayesianLogisticRegression` tests and update all zooming references across test suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved epoch loss reporting and early-stopping to use per-epoch mean loss.

* **Chores**
  * Bumped package version to 6.0.2.
  * Simplified quantitative model internals.

* **Breaking Changes**
  * Removed legacy logistic‑regression model types from the public API.
  * Renamed/consolidated zooming quantitative model names (public imports updated).

* **Documentation**
  * Tutorials/notebooks updated to use the neural‑network model.

* **Tests**
  * Test suite updated to reflect API and naming changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->