### PR TITLE
Add VI training options: num_particles, gradient clipping

### DIFF
--- a/pybandits/model.py
+++ b/pybandits/model.py
@@ -20,8 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import inspect
 import warnings
 from abc import ABC, abstractmethod
+from contextlib import nullcontext
 from copy import deepcopy
 from math import ceil
 from random import betavariate
@@ -33,6 +35,7 @@ import numpy as np
 import numpyro
 import numpyro.distributions as npdist
 import numpyro.optim as noptim
+import optax
 from loguru import logger
 from numpy import sqrt
 from numpyro.distributions import Bernoulli as NumpyroBernoulli
@@ -67,6 +70,7 @@ from pybandits.pydantic_version_compatibility import (
 UpdateMethods = Literal["VI", "MCMC"]
 VIMethods = Literal["advi", "fullrank_advi"]
 ActivationFunctions = Literal["tanh", "relu", "sigmoid", "gelu"]
+OptaxKind = Literal["optimizer", "lr_scheduler"]
 
 
 def _numpy_relu(x: np.ndarray) -> np.ndarray:
@@ -1092,16 +1096,58 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         "batch_size",
         "early_stopping_kwargs",
         "epochs",
+        "lr_scheduler_type",
+        "lr_scheduler_kwargs",
+        "restore_best_weights",
+        "num_particles",
+        "gradient_clip_norm",
+        "kl_tau",
     ]
     _distribution_mapping: ClassVar[Dict[str, type]] = {"normal": NormalArray, "studentt": StudentTArray}
     _embedding_dim_divisor: ClassVar[int] = 4
-    _supported_optimizers: ClassVar[dict] = {
-        "sgd": noptim.SGD,
-        "momentum": noptim.Momentum,
-        "adagrad": noptim.Adagrad,
-        "adam": noptim.Adam,
-        "clipped_adam": noptim.ClippedAdam,
+    _optax_return_types: ClassVar[dict] = {
+        "optimizer": optax.GradientTransformation,
+        "lr_scheduler": optax.Schedule,
     }
+
+    def _resolve_optax_fn(self, name: str, kind: OptaxKind) -> Any:
+        """Look up an optax function by name using getattr and validate its return type annotation.
+
+        Parameters
+        ----------
+        name : str
+            Name of the optax attribute (e.g. ``"adam"``, ``"exponential_decay"``).
+        kind : OptaxKind
+            Key into ``_optax_return_types`` (``"optimizer"`` or ``"lr_scheduler"``).
+
+        Returns
+        -------
+        Any
+            The callable found on the ``optax`` module.
+
+        Raises
+        ------
+        ValueError
+            If ``name`` is not a callable attribute of ``optax``, or its return-type
+            annotation does not match the expected type for ``kind``.
+        """
+        fn = getattr(optax, name, None)
+        if fn is None or not callable(fn):
+            raise ValueError(f"Invalid {kind}: '{name}' is not a callable attribute of optax.")
+        expected = self._optax_return_types[kind]
+        return_annotation = inspect.signature(fn).return_annotation
+        if isinstance(expected, type):
+            # e.g. GradientTransformationExtraArgs — check via issubclass
+            valid = isinstance(return_annotation, type) and issubclass(return_annotation, expected)
+        else:
+            # e.g. optax.Schedule (a generic alias) — check for equality
+            valid = return_annotation == expected
+        if not valid:
+            raise ValueError(
+                f"Invalid {kind}: '{name}' does not return {expected} (got return annotation: {return_annotation})."
+            )
+        return fn
+
     _jax_activations: ClassVar[dict] = {
         "tanh": jax.nn.tanh,
         "relu": jax.nn.relu,
@@ -1131,6 +1177,11 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         optimizer_kwargs={"step_size": 0.01},
         batch_size=None,
         early_stopping_kwargs=None,
+        lr_scheduler_type=None,
+        lr_scheduler_kwargs=None,
+        num_particles=1,
+        gradient_clip_norm=None,
+        kl_tau=None,
     )
 
     _default_mcmc_kwargs: ClassVar[dict] = dict(
@@ -1212,19 +1263,35 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         return numerical_arr, cat_indices_dict
 
     def _get_obj_optimizer(self) -> Any:
-        """Build the optimizer from update_kwargs. Always returns an optimizer (uses default if not specified)."""
+        """Build an optax optimizer from update_kwargs, wrapped via ``optax_to_numpyro``.
+
+        Optionally chains a learning-rate schedule and/or gradient clipping.
+        """
         optimizer_type = self.update_kwargs["optimizer_type"]
-        if optimizer_type not in self._supported_optimizers:
-            raise ValueError(
-                f"Invalid optimizer type: {optimizer_type}. "
-                f"Supported optimizers are: {list(self._supported_optimizers.keys())}"
-            )
-        cls_ = self._supported_optimizers[optimizer_type]
-        optimizer_kwargs = self.update_kwargs.get("optimizer_kwargs", {})
+        optimizer_kwargs = dict(self.update_kwargs.get("optimizer_kwargs", {}))
+        lr_scheduler_type = self.update_kwargs.get("lr_scheduler_type")
+        lr_scheduler_kwargs = self.update_kwargs.get("lr_scheduler_kwargs") or {}
+        gradient_clip_norm = self.update_kwargs.get("gradient_clip_norm")
+
+        optimizer_fn = self._resolve_optax_fn(optimizer_type, "optimizer")
+
+        # Resolve learning rate (possibly a schedule)
+        learning_rate = optimizer_kwargs.pop("step_size", 0.01)
+        if lr_scheduler_type is not None:
+            scheduler_fn = self._resolve_optax_fn(lr_scheduler_type, "lr_scheduler")
+            try:
+                learning_rate = scheduler_fn(init_value=learning_rate, **lr_scheduler_kwargs)
+            except (TypeError, ValueError) as e:
+                raise e.__class__(f"Invalid lr_scheduler_kwargs: {lr_scheduler_kwargs}.\n{e}") from e
+
         try:
-            return cls_(**optimizer_kwargs)
+            base_optimizer = optimizer_fn(learning_rate=learning_rate, **optimizer_kwargs)
         except (TypeError, ValueError, KeyError) as e:
-            raise e.__class__(f"Invalid optimizer kwargs: {optimizer_kwargs}.\n{e}")
+            raise e.__class__(f"Invalid optimizer kwargs: {optimizer_kwargs}.\n{e}") from e
+
+        if gradient_clip_norm is not None:
+            return noptim.optax_to_numpyro(optax.chain(optax.clip_by_global_norm(gradient_clip_norm), base_optimizer))
+        return noptim.optax_to_numpyro(base_optimizer)
 
     def _get_early_stopping_callback(self) -> Optional[EarlyStopping]:
         early_stopping_kwargs = self.update_kwargs.get("early_stopping_kwargs", None)
@@ -1454,7 +1521,42 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         self.__dict__.update(state)
         self._init_private_attrs()
 
-    def create_update_model(self, batch_size: Optional[PositiveInt] = None) -> Callable:
+    def _kl_scale_ctx(self, n_samples: PositiveInt):
+        """Return a context manager that scales sample-site log-probs for KL temperature.
+
+        When kl_tau is set in update_kwargs, this returns a
+        numpyro.handlers.scale context manager with factor
+        beta = kl_tau * n_samples / n_neurons, where *n_neurons* is the
+        total number of hidden units across all layers except the output layer.
+        Wrapping both the model prior and the guide with this handler scales the
+        full KL divergence term in the ELBO by *beta*.
+
+        When kl_tau is None (the default), returns a plain
+        contextlib.nullcontext (no-op).
+
+        References
+        ----------
+        Variational Inference of overparameterized Bayesian Neural Networks
+        (Huix et al., 2022) - https://arxiv.org/abs/2207.03859
+
+        Parameters
+        ----------
+        n_samples : PositiveInt
+            Number of data points in the current batch. Used to
+            compute the data-dependent part of the scale factor.
+
+        Returns
+        -------
+        contextlib.AbstractContextManager
+            Either numpyro.handlers.scale(scale=beta) or nullcontext().
+        """
+        kl_tau = self._update_kwargs.get("kl_tau")
+        if kl_tau is not None:
+            n_neurons = max(sum(lp.weight.shape[1] for lp in self.model_params.bnn_layer_params[:-1]), 1)
+            return numpyro.handlers.scale(scale=kl_tau * n_samples / n_neurons)
+        return nullcontext()
+
+    def _create_update_model(self) -> Callable:
         """
         Create a NumPyro model function for Bayesian Neural Network.
 
@@ -1463,13 +1565,8 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         with subsample_size.
 
         Numerical columns are passed through as-is. Categorical columns (identified by their
-        ``column_index`` in ``feature_config``) are modelled with Bayesian embedding matrices
+        ``column_index`` in ``feature_config``) are modeled with Bayesian embedding matrices
         sampled as NumPyro random variables.
-
-        Parameters
-        ----------
-        batch_size : Optional[PositiveInt]
-            If provided, use minibatching with this batch size via numpyro.plate.
 
         Returns
         -------
@@ -1486,31 +1583,36 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         5. Use Bernoulli likelihood for binary classification
         """
 
+        batch_size = self._update_kwargs.get("batch_size")
+        kl_scale = self._kl_scale_ctx
+
         n_layers = len(self.model_params.bnn_layer_params)
         numerical_indices = self.feature_config.numerical_indices
         cat_configs = self.feature_config.categorical_features_configs
         has_embeddings = self.model_params.embedding_params is not None and len(cat_configs) > 0
 
         def model(x: jax.Array, y: jax.Array):
-            N = x.shape[0]
+            n_samples = x.shape[0]
 
             # Sample all weights (global parameters, outside plate)
             weights_biases = []
-            for layer_ind, layer_params in enumerate(self.model_params.bnn_layer_params):
-                weight_name, bias_name = self.get_layer_params_name(layer_ind)
-                w = numpyro.sample(weight_name, layer_params.weight.to_numpyro_distribution())
-                b = numpyro.sample(bias_name, layer_params.bias.to_numpyro_distribution())
-                weights_biases.append((w, b, layer_params.weight.shape))
+            with kl_scale(n_samples):
+                for layer_ind, layer_params in enumerate(self.model_params.bnn_layer_params):
+                    weight_name, bias_name = self.get_layer_params_name(layer_ind)
+                    w = numpyro.sample(weight_name, layer_params.weight.to_numpyro_distribution())
+                    b = numpyro.sample(bias_name, layer_params.bias.to_numpyro_distribution())
+                    weights_biases.append((w, b, layer_params.weight.shape))
 
             # Sample embedding matrices (global parameters, outside plate)
             embedding_matrices = []
             if has_embeddings:
-                for i, emb_dist in enumerate(self.model_params.embedding_params.embeddings):
-                    emb = numpyro.sample(self.get_embedding_var_name(i), emb_dist.to_numpyro_distribution())
-                    embedding_matrices.append(emb)
+                with kl_scale(n_samples):
+                    for i, emb_dist in enumerate(self.model_params.embedding_params.embeddings):
+                        emb = numpyro.sample(self.get_embedding_var_name(i), emb_dist.to_numpyro_distribution())
+                        embedding_matrices.append(emb)
 
             # Data plate with optional minibatching
-            with numpyro.plate("data", N, subsample_size=batch_size) as idx:
+            with numpyro.plate("data", n_samples, subsample_size=batch_size) as idx:
                 x_batch = x[idx] if batch_size is not None else x
                 y_batch = y[idx] if batch_size is not None else y
 
@@ -1867,10 +1969,9 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         """
         if self._early_stopping_callback is not None:
             self._early_stopping_callback.reset()
-        batch_size = self._update_kwargs["batch_size"]
-        _model = self.create_update_model(batch_size=batch_size)
+        _model = self._create_update_model()
 
-        effective_batch_size = batch_size if batch_size is not None else n_samples
+        effective_batch_size = self._update_kwargs.get("batch_size") or n_samples
         steps_per_epoch = max(1, n_samples // effective_batch_size)
 
         if self._update_kwargs.get("epochs") is not None:
@@ -1887,8 +1988,22 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         # Set up VI method (guide + loss) dynamically
         vi_method = self._update_kwargs["method"]
         method_config = self._vi_method_config[vi_method]
-        guide = method_config["guide"](_model, init_loc_fn=init_to_median)
-        loss = method_config["loss"]()
+        raw_guide = method_config["guide"](_model, init_loc_fn=init_to_median)
+
+        # When kl_tau is active, wrap the guide with the same scale handler so
+        # both log p(z) and log q(z) are scaled equally → the KL term as a
+        # whole is multiplied by beta = tau * N / n_neurons.
+        if self._update_kwargs.get("kl_tau") is not None:
+            kl_scale = self._kl_scale_ctx
+
+            def guide(x, y, *args, **kwargs):
+                with kl_scale(x.shape[0]):
+                    return raw_guide(x, y, *args, **kwargs)
+        else:
+            guide = raw_guide
+
+        num_particles = self._update_kwargs["num_particles"]
+        loss = method_config["loss"](num_particles=num_particles)
         svi = SVI(_model, guide, self._obj_optimizer, loss=loss)
 
         # Run the SVI loop via jax.lax.scan to keep the iteration inside XLA.
@@ -1915,12 +2030,13 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             svi_state, epoch_losses = _run_epoch(svi_state, epoch_steps)
 
             epoch_np = np.array(epoch_losses)
+            epoch_end_loss = float(epoch_np[-1])
             all_losses.append(epoch_np)
             pbar.update(1)
-            pbar.set_postfix(loss=f"{float(epoch_np[-1]):.4f}")
+            pbar.set_postfix(loss=f"{epoch_end_loss:.4f}")
 
             if self._early_stopping_callback is not None:
-                if self._early_stopping_callback.should_stop(float(epoch_np[-1])):
+                if self._early_stopping_callback.should_stop(epoch_end_loss):
                     logger.info(
                         f"Early stopping at epoch {epoch_idx + 1}/{len(epoch_steps_list)}: "
                         f"loss change below {self._early_stopping_callback.tolerance} "
@@ -1933,7 +2049,9 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         pbar.close()
         self._approx_history = np.concatenate(all_losses) if all_losses else np.array([])
         params = svi.get_params(svi_state)
-        return svi, guide, params
+        # Return the raw AutoGuide (not the scaled wrapper) so downstream
+        # param extraction (median, scale_tril, etc.) works correctly.
+        return svi, raw_guide, params
 
     def _extract_advi_params(self, params: dict) -> tuple:
         """
@@ -2062,7 +2180,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         List
             Updated ``BnnLayerParams`` list (embeddings are updated in-place as a side-effect).
         """
-        _model = self.create_update_model()
+        _model = self._create_update_model()
         nuts_kwargs = self._update_kwargs["nuts"]
         # All top-level keys except 'nuts' are MCMC kwargs
         mcmc_kwargs = {k: v for k, v in self._update_kwargs.items() if k != "nuts"}

--- a/pybandits/model.py
+++ b/pybandits/model.py
@@ -19,7 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
+import inspect
 import warnings
 from abc import ABC, abstractmethod
 from contextlib import ExitStack, nullcontext
@@ -34,6 +34,7 @@ import numpy as np
 import numpyro
 import numpyro.distributions as npdist
 import numpyro.optim as noptim
+import optax
 from loguru import logger
 from numpy import sqrt
 from numpyro.distributions import Bernoulli as NumpyroBernoulli
@@ -70,6 +71,7 @@ _Array = Union[np.ndarray, jax.Array]
 UpdateMethods = Literal["VI", "MCMC"]
 VIMethods = Literal["advi", "fullrank_advi"]
 ActivationFunctions = Literal["tanh", "relu", "sigmoid", "gelu"]
+OptaxKind = Literal["optimizer", "lr_scheduler"]
 
 _LOGIT_CLIPPING_THRESHOLD = 15
 
@@ -1017,12 +1019,12 @@ class EarlyStopping(PyBanditsBaseModel):
         """Check if training should stop based on loss convergence."""
         if self._previous_loss is not None:
             if self.diff_type == "relative":
-                change = (self._previous_loss - loss) / (abs(self._previous_loss) + self._epsilon)
+                change = abs((loss - self._previous_loss) / (abs(self._previous_loss) + self._epsilon))
             elif self.diff_type == "absolute":
-                change = self._previous_loss - loss
+                change = abs(loss - self._previous_loss)
             else:
                 raise ValueError(f"Unknown diff {self.diff_type}")
-            logger.info(str((loss, change, self._no_improvement_count)))
+
             if change < self.tolerance:
                 self._no_improvement_count += 1
             else:
@@ -1278,17 +1280,72 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         "batch_size",
         "early_stopping_kwargs",
         "epochs",
+        "lr_scheduler_type",
+        "lr_scheduler_kwargs",
+        "restore_best_svi_state",
+        "num_particles",
+        "gradient_clip_norm",
     ]
     _distribution_mapping: ClassVar[Dict[str, type]] = {"normal": NormalArray, "studentt": StudentTArray}
     _embedding_dim_divisor: ClassVar[int] = 4
     _numerical_eps: ClassVar[float] = 1e-6
-    _supported_optimizers: ClassVar[dict] = {
-        "sgd": noptim.SGD,
-        "momentum": noptim.Momentum,
-        "adagrad": noptim.Adagrad,
-        "adam": noptim.Adam,
-        "clipped_adam": noptim.ClippedAdam,
+    _optax_return_types: ClassVar[dict] = {
+        "optimizer": optax.GradientTransformation,
+        "lr_scheduler": optax.Schedule,
     }
+    _optax_required_kwargs: ClassVar[dict] = {
+        "optimizer": "learning_rate",
+        "lr_scheduler": "init_value",
+    }
+
+    def _resolve_optax_fn(self, name: str, kind: OptaxKind) -> Any:
+        """Look up an optax function by name using getattr and validate its return type annotation
+        and required keyword argument.
+
+        Parameters
+        ----------
+        name : str
+            Name of the optax attribute (e.g. ``"adam"``, ``"exponential_decay"``).
+        kind : OptaxKind
+            Key into ``_optax_return_types`` (``"optimizer"`` or ``"lr_scheduler"``).
+
+        Returns
+        -------
+        Any
+            The callable found on the ``optax`` module.
+
+        Raises
+        ------
+        ValueError
+            If ``name`` is not a callable attribute of ``optax``, its return-type
+            annotation does not match the expected type for ``kind``, or its signature
+            does not accept the required keyword argument for ``kind``.
+        """
+        fn = getattr(optax, name, None)
+        if fn is None or not callable(fn):
+            raise ValueError(f"Invalid {kind}: '{name}' is not a callable attribute of optax.")
+        expected = self._optax_return_types[kind]
+        sig = inspect.signature(fn)
+        return_annotation = sig.return_annotation
+        if isinstance(expected, type) and not hasattr(expected, "__origin__"):
+            # e.g. GradientTransformation (plain class) — check via issubclass
+            valid = isinstance(return_annotation, type) and issubclass(return_annotation, expected)
+        else:
+            # e.g. optax.Schedule (parameterized generic) — check for equality
+            valid = return_annotation == expected
+        if not valid:
+            raise ValueError(
+                f"Invalid {kind}: '{name}' does not return {expected} (got return annotation: {return_annotation})."
+            )
+        required_kwarg = self._optax_required_kwargs[kind]
+        params = sig.parameters
+        has_required = required_kwarg in params or any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
+        if not has_required:
+            raise ValueError(
+                f"Invalid {kind}: '{name}' does not accept the required keyword argument '{required_kwarg}'."
+            )
+        return fn
+
     _jax_activations: ClassVar[dict] = {
         "tanh": jax.nn.tanh,
         "relu": jax.nn.relu,
@@ -1320,7 +1377,11 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         optimizer_kwargs={"step_size": 0.01},
         batch_size=None,
         early_stopping_kwargs=None,
+        lr_scheduler_type=None,
+        lr_scheduler_kwargs=None,
         restore_best_svi_state=True,
+        num_particles=1,
+        gradient_clip_norm=None,
     )
 
     _default_mcmc_kwargs: ClassVar[dict] = dict(
@@ -1407,19 +1468,35 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         return numerical_arr, cat_indices_dict
 
     def _get_obj_optimizer(self) -> Any:
-        """Build the optimizer from update_kwargs. Always returns an optimizer (uses default if not specified)."""
+        """Build an optax optimizer from update_kwargs, wrapped via ``optax_to_numpyro``.
+
+        Optionally chains a learning-rate schedule and/or gradient clipping.
+        """
         optimizer_type = self.update_kwargs["optimizer_type"]
-        if optimizer_type not in self._supported_optimizers:
-            raise ValueError(
-                f"Invalid optimizer type: {optimizer_type}. "
-                f"Supported optimizers are: {list(self._supported_optimizers.keys())}"
-            )
-        cls_ = self._supported_optimizers[optimizer_type]
-        optimizer_kwargs = self.update_kwargs.get("optimizer_kwargs", {})
+        optimizer_kwargs = dict(self.update_kwargs.get("optimizer_kwargs", {}))
+        lr_scheduler_type = self.update_kwargs.get("lr_scheduler_type")
+        lr_scheduler_kwargs = self.update_kwargs.get("lr_scheduler_kwargs") or {}
+        gradient_clip_norm = self.update_kwargs.get("gradient_clip_norm")
+
+        optimizer_fn = self._resolve_optax_fn(optimizer_type, "optimizer")
+
+        # Resolve learning rate (possibly a schedule)
+        learning_rate = optimizer_kwargs.pop("step_size", 0.01)
+        if lr_scheduler_type is not None:
+            scheduler_fn = self._resolve_optax_fn(lr_scheduler_type, "lr_scheduler")
+            try:
+                learning_rate = scheduler_fn(init_value=learning_rate, **lr_scheduler_kwargs)
+            except (TypeError, ValueError) as e:
+                raise e.__class__(f"Invalid lr_scheduler_kwargs: {lr_scheduler_kwargs}.\n{e}") from e
+
         try:
-            return cls_(**optimizer_kwargs)
+            base_optimizer = optimizer_fn(learning_rate=learning_rate, **optimizer_kwargs)
         except (TypeError, ValueError, KeyError) as e:
-            raise e.__class__(f"Invalid optimizer kwargs: {optimizer_kwargs}.\n{e}")
+            raise e.__class__(f"Invalid optimizer kwargs: {optimizer_kwargs}.\n{e}") from e
+
+        if gradient_clip_norm is not None:
+            return noptim.optax_to_numpyro(optax.chain(optax.clip_by_global_norm(gradient_clip_norm), base_optimizer))
+        return noptim.optax_to_numpyro(base_optimizer)
 
     def _get_early_stopping_callback(self) -> Optional[EarlyStopping]:
         early_stopping_kwargs = self.update_kwargs.get("early_stopping_kwargs", None)
@@ -1703,7 +1780,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
 
         return linear_transform
 
-    def create_update_model(self, batch_size: Optional[PositiveInt] = None) -> Callable:
+    def _create_update_model(self) -> Callable:
         """
         Create a NumPyro model function for Bayesian Neural Network.
 
@@ -1712,13 +1789,8 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         with subsample_size.
 
         Numerical columns are passed through as-is. Categorical columns (identified by their
-        ``column_index`` in ``feature_config``) are modelled with Bayesian embedding matrices
+        ``column_index`` in ``feature_config``) are modeled with Bayesian embedding matrices
         sampled as NumPyro random variables.
-
-        Parameters
-        ----------
-        batch_size : Optional[PositiveInt]
-            If provided, use minibatching with this batch size via numpyro.plate.
 
         Returns
         -------
@@ -1735,12 +1807,13 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         5. Use Bernoulli likelihood for binary classification
         """
 
+        batch_size = self._update_kwargs.get("batch_size")
         numerical_indices = self.feature_config.numerical_indices
         cat_configs = self.feature_config.categorical_features_configs
         has_embeddings = self.model_params.embedding_params is not None and len(cat_configs) > 0
 
         def model(x: jax.Array, y: jax.Array):
-            N = x.shape[0]
+            n_samples = x.shape[0]
 
             # Sample all weights (global parameters, outside plate)
             weights_biases = []
@@ -1758,8 +1831,8 @@ class BaseBayesianNeuralNetwork(Model, ABC):
                     embedding_matrices.append(emb)
 
             # Data plate with optional minibatching
-            if batch_size is not None and batch_size < N:
-                plate_ctx = numpyro.plate("data", size=N, subsample_size=batch_size)
+            if batch_size is not None and batch_size < n_samples:
+                plate_ctx = numpyro.plate("data", size=n_samples, subsample_size=batch_size)
             else:
                 plate_ctx = nullcontext()
 
@@ -2141,10 +2214,9 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         """
         if self._early_stopping_callback is not None:
             self._early_stopping_callback.reset()
-        batch_size = self._update_kwargs["batch_size"]
-        _model = self.create_update_model(batch_size=batch_size)
+        _model = self._create_update_model()
 
-        effective_batch_size = batch_size if batch_size is not None else n_samples
+        effective_batch_size = self._update_kwargs.get("batch_size") or n_samples
         steps_per_epoch = max(1, n_samples // effective_batch_size)
 
         if self._update_kwargs.get("epochs") is not None:
@@ -2171,7 +2243,9 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         else:
             # fullrank_advi needs a scalar; use the avg sigma via the unknown-site fallback
             guide = method_config["guide"](_model, init_loc_fn=init_loc_fn, init_scale=init_scale_fn(""))
-        loss = method_config["loss"]()
+
+        num_particles = self._update_kwargs["num_particles"]
+        loss = method_config["loss"](num_particles=num_particles)
         svi = SVI(_model, guide, self._obj_optimizer, loss=loss)
 
         # Run the SVI loop via jax.lax.scan to keep the iteration inside XLA.
@@ -2182,14 +2256,18 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         self._rng_key, subkey = jax.random.split(self._rng_key)
         svi_state = svi.init(subkey, x_jnp, y_jnp)
 
-        def _svi_body(state, _):
-            state, loss = svi.update(state, x_jnp, y_jnp)
-            return state, loss
+        # Pass x/y as explicit JIT arguments (not closure captures) so JAX treats
+        # them as abstract buffers rather than embedding them as XLA constants.
+        # Closing over large arrays causes "Failed to allocate N bytes for new constant"
+        # at compile time when the dataset is large.
+        def _run_epoch(state, x, y, n):
+            def _svi_body(s, _):
+                s, loss = svi.update(s, x, y)
+                return s, loss
 
-        _run_epoch = jax.jit(
-            lambda state, n: jax.lax.scan(_svi_body, state, None, length=n),
-            static_argnums=(1,),
-        )
+            return jax.lax.scan(_svi_body, state, None, length=n)
+
+        _run_epoch = jax.jit(_run_epoch, static_argnums=(3,))
 
         restore_best = self._update_kwargs.get("restore_best_svi_state", True)
         all_losses = []
@@ -2197,38 +2275,38 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         best_svi_state = svi_state
         pbar = trange(len(epoch_steps_list), desc="SVI", leave=False)
 
-        for epoch_idx, epoch_steps in enumerate(epoch_steps_list):
-            svi_state, epoch_losses = _run_epoch(svi_state, epoch_steps)
+        try:
+            for epoch_idx, epoch_steps in enumerate(epoch_steps_list):
+                svi_state, epoch_losses = _run_epoch(svi_state, x_jnp, y_jnp, epoch_steps)
 
-            epoch_np = np.array(epoch_losses)
-            epoch_loss = float(np.mean(epoch_np))
-            all_losses.append(epoch_np)
-            pbar.update(1)
-            pbar.set_postfix(loss=f"{epoch_loss:.4f}")
+                epoch_np = np.array(epoch_losses)
+                epoch_loss = float(np.mean(epoch_np))
+                all_losses.append(epoch_np)
+                pbar.update(1)
+                pbar.set_postfix(loss=f"{epoch_loss:.4f}")
 
-            if np.isnan(epoch_loss):
-                pbar.close()
-                raise ValueError(
-                    f"SVI training diverged: loss is NaN at epoch {epoch_idx + 1}/{len(epoch_steps_list)}. "
-                    "Consider reducing the learning rate or checking your data for invalid values."
-                )
-
-            if restore_best and epoch_loss < best_loss:
-                best_loss = epoch_loss
-                best_svi_state = svi_state
-
-            if self._early_stopping_callback is not None:
-                if self._early_stopping_callback.should_stop(epoch_loss):
-                    logger.info(
-                        f"Early stopping at epoch {epoch_idx + 1}/{len(epoch_steps_list)}: "
-                        f"loss change below {self._early_stopping_callback.tolerance} "
-                        f"({self._early_stopping_callback.diff_type}) for "
-                        f"{self._early_stopping_callback.patience} consecutive epochs. "
-                        f"Best loss: {best_loss:.6f}, last loss: {epoch_loss:.6f}."
+                if np.isnan(epoch_loss):
+                    raise ValueError(
+                        f"SVI training diverged: loss is NaN at epoch {epoch_idx + 1}/{len(epoch_steps_list)}. "
+                        "Consider reducing the learning rate or checking your data for invalid values."
                     )
-                    break
 
-        pbar.close()
+                if restore_best and epoch_loss < best_loss:
+                    best_loss = epoch_loss
+                    best_svi_state = svi_state
+
+                if self._early_stopping_callback is not None:
+                    if self._early_stopping_callback.should_stop(epoch_loss):
+                        logger.info(
+                            f"Early stopping at epoch {epoch_idx + 1}/{len(epoch_steps_list)}: "
+                            f"loss change below {self._early_stopping_callback.tolerance} "
+                            f"({self._early_stopping_callback.diff_type}) for "
+                            f"{self._early_stopping_callback.patience} consecutive epochs. "
+                            f"Best loss: {best_loss:.6f}, last loss: {epoch_loss:.6f}."
+                        )
+                        break
+        finally:
+            pbar.close()
         self._approx_history = np.concatenate(all_losses) if all_losses else np.array([])
         final_state = best_svi_state if restore_best else svi_state
         params = svi.get_params(final_state)
@@ -2365,7 +2443,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         List
             Updated ``BnnLayerParams`` list (embeddings are updated in-place as a side-effect).
         """
-        _model = self.create_update_model()
+        _model = self._create_update_model()
         nuts_kwargs = self._update_kwargs["nuts"]
         # All top-level keys except 'nuts' are MCMC kwargs
         mcmc_kwargs = {k: v for k, v in self._update_kwargs.items() if k != "nuts"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybandits"
-version = "6.0.1"
+version = "6.1.0"
 description = "Python Multi-Armed Bandit Library"
 authors = [
     "Dario d'Andrea <dariod@playtika.com>",
@@ -41,6 +41,7 @@ numpyro = [
     { version = "^0.16", python = ">=3.9,<3.11" },
     { version = "^0.20", python = ">=3.11" },
 ]
+optax = "^0.1"
 scikit-learn = "^1.1"
 optuna = "^3.6"
 tqdm = "^4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybandits"
-version = "7.2.0"
+version = "7.2.1"
 description = "Python Multi-Armed Bandit Library"
 authors = [
     "Dario d'Andrea <dariod@playtika.com>",
@@ -46,6 +46,7 @@ numpyro = [
     { version = "^0.16", python = ">=3.9,<3.11" },
     { version = "^0.20", python = ">=3.11" },
 ]
+optax = "^0.1"
 scikit-learn = "^1.1"
 optuna = "^3.6"
 tqdm = "^4"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -46,6 +46,7 @@ from pybandits.model import (
     EmbeddingParams,
     FeaturesConfig,
     NormalArray,
+    OptaxKind,
     StudentTArray,
     UpdateMethods,
 )
@@ -503,7 +504,7 @@ def test_bnn_vi_update(
             assert isinstance(bnn.model_params.bnn_layer_params[layer_ind].weight, expected_array)
             assert isinstance(bnn.model_params.bnn_layer_params[layer_ind].bias, expected_array)
 
-    rewards = np.random.choice([0, 1], size=n_samples).tolist()
+    rewards = _make_random_rewards(n_samples)
 
     # context is numpy array
     context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
@@ -591,7 +592,7 @@ def test_bnn_vi_update_parameters(
         update_kwargs=update_kwargs,
     )
 
-    model_fn = bnn.create_update_model()
+    model_fn = bnn._create_update_model()
     assert callable(model_fn)
 
     # Optimizer is always set for VI (built from defaults or user override)
@@ -607,13 +608,11 @@ def test_bnn_vi_update_parameters(
 @given(
     n_features=st.just(2),
     hidden_dim_list=st.just([1]),
-    n_samples=st.just(5),
     update_method=st.just("MCMC"),
 )
 def test_bnn_mcmc_update_parameters(
     n_features: int,
     hidden_dim_list: list[int],
-    n_samples: int,
     update_method: UpdateMethods,
 ) -> None:
     """Test BNN MCMC update with valid parameters (no batch_size, optimizer, or early_stopping)."""
@@ -625,7 +624,7 @@ def test_bnn_mcmc_update_parameters(
         update_kwargs={},
     )
 
-    model_fn = bnn.create_update_model()
+    model_fn = bnn._create_update_model()
     assert callable(model_fn)
 
 
@@ -737,6 +736,17 @@ def test_invalid_optimizer_kwargs(
         )
 
 
+def test_optax_kind_literal_matches_optax_return_types_keys() -> None:
+    """Verify that OptaxKind Literal values exactly match _optax_return_types keys."""
+    from typing import get_args
+
+    literal_values = set(get_args(OptaxKind))
+    classvar_keys = set(BayesianNeuralNetwork._optax_return_types.keys())
+    assert literal_values == classvar_keys, (
+        f"OptaxKind Literal {literal_values} does not match _optax_return_types keys {classvar_keys}"
+    )
+
+
 @pytest.mark.parametrize(
     "early_stopping_kwargs",
     [
@@ -759,6 +769,132 @@ def test_invalid_early_stopping_kwargs(
         )
 
 
+@pytest.mark.parametrize(
+    "optimizer_type,optimizer_kwargs,lr_scheduler_type,lr_scheduler_kwargs",
+    [
+        ("sgd", {"step_size": 0.01}, "exponential_decay", {"transition_steps": 100, "decay_rate": 0.9}),
+        ("adam", {"step_size": 0.01}, "exponential_decay", {"transition_steps": 50, "decay_rate": 0.95}),
+        ("sgd", {"step_size": 0.01, "momentum": 0.9}, "cosine_decay_schedule", {"decay_steps": 100}),
+        (
+            "adam",
+            {"step_size": 0.01},
+            "exponential_decay",
+            {"transition_steps": 100, "decay_rate": 0.9, "staircase": True},
+        ),
+        (
+            "sgd",
+            {"step_size": 0.01},
+            "warmup_cosine_decay_schedule",
+            {"peak_value": 0.05, "warmup_steps": 10, "decay_steps": 100},
+        ),
+        ("adam", {"step_size": 0.01}, "linear_schedule", {"end_value": 1e-5, "transition_steps": 200}),
+    ],
+)
+def test_lr_scheduler_valid(
+    optimizer_type: str,
+    optimizer_kwargs: dict,
+    lr_scheduler_type: str,
+    lr_scheduler_kwargs: dict,
+    n_features: int = 2,
+) -> None:
+    """Test that valid lr_scheduler_type/lr_scheduler_kwargs build an optimizer successfully."""
+    bnn = BayesianNeuralNetwork.cold_start(
+        n_features=n_features,
+        update_method="VI",
+        update_kwargs={
+            "optimizer_type": optimizer_type,
+            "optimizer_kwargs": optimizer_kwargs,
+            "lr_scheduler_type": lr_scheduler_type,
+            "lr_scheduler_kwargs": lr_scheduler_kwargs,
+        },
+    )
+    assert bnn._obj_optimizer is not None
+
+
+@pytest.mark.parametrize(
+    "lr_scheduler_type,lr_scheduler_kwargs",
+    [
+        (
+            "dummy_scheduler",
+            {},
+        ),
+        ("exponential_decay", {"invalid_kwarg": 1}),
+    ],
+)
+def test_lr_scheduler_invalid_type_or_kwargs(
+    lr_scheduler_type: str,
+    lr_scheduler_kwargs: dict,
+    n_features: int = 2,
+) -> None:
+    """Test that invalid lr_scheduler_type or lr_scheduler_kwargs raise ValueError."""
+    with pytest.raises((TypeError, ValueError)):
+        BayesianNeuralNetwork.cold_start(
+            n_features=n_features,
+            update_method="VI",
+            update_kwargs={
+                "lr_scheduler_type": lr_scheduler_type,
+                "lr_scheduler_kwargs": lr_scheduler_kwargs,
+            },
+        )
+
+
+@given(
+    optimizer_type=st.sampled_from(("sgd", "adam")),
+    num_particles=st.sampled_from((1, 3)),
+    gradient_clip_norm=st.one_of(st.none(), st.floats(min_value=0.1, max_value=10.0)),
+    kl_tau=st.one_of(st.none(), st.floats(min_value=0.01, max_value=1.0)),
+    lr_scheduler_type=st.sampled_from((None, "exponential_decay")),
+    num_steps=st.just(4),
+    n_features=st.just(2),
+    update_method=st.just("VI"),
+    n_samples=st.just(5),
+    decay_rate=st.just(0.9),
+    transition_steps_factor=st.just(2),
+)
+def test_vi_training_options(
+    optimizer_type: str,
+    num_particles: int,
+    gradient_clip_norm: Optional[float],
+    kl_tau: Optional[float],
+    lr_scheduler_type: Optional[str],
+    num_steps: int,
+    n_features: int,
+    update_method: UpdateMethods,
+    n_samples: int,
+    decay_rate: float,
+    transition_steps_factor: int,
+) -> None:
+    """Test that VI training options (num_particles, gradient_clip_norm, kl_tau, lr_scheduler) compose correctly."""
+    update_kwargs: dict = {
+        "num_steps": num_steps,
+        "optimizer_type": optimizer_type,
+        "num_particles": num_particles,
+    }
+    if gradient_clip_norm is not None:
+        update_kwargs["gradient_clip_norm"] = gradient_clip_norm
+    if kl_tau is not None:
+        update_kwargs["kl_tau"] = kl_tau
+    if lr_scheduler_type is not None:
+        update_kwargs["lr_scheduler_type"] = lr_scheduler_type
+        update_kwargs["lr_scheduler_kwargs"] = {
+            "transition_steps": num_steps // transition_steps_factor,
+            "decay_rate": decay_rate,
+        }
+
+    bnn = BayesianNeuralNetwork.cold_start(
+        n_features=n_features,
+        update_method=update_method,
+        update_kwargs=update_kwargs,
+    )
+    context = np.random.rand(n_samples, n_features).astype(np.float32)
+    rewards = _make_random_rewards(n_samples)
+    bnn.update(context=context, rewards=rewards)
+    result = bnn.sample_proba(context=context)
+    assert len(result) == n_samples
+    assert all(0 <= p[0] <= 1 for p in result), f"Probabilities out of [0,1]: {result}"
+    assert all(np.isfinite(p[1]) for p in result), f"Non-finite weights: {result}"
+
+
 @given(
     n_features=st.just(2),
     update_method=st.just("VI"),
@@ -777,13 +913,10 @@ def test_epochs_and_num_steps_warns(n_features: int, update_method: UpdateMethod
 
 @pytest.mark.parametrize("n_features", [1, 2])
 def test_bnn_mcmc_update(
-    n_features,
-    hidden_dim_list=(1,),
-    n_samples=3,
-    update_method="MCMC",
-    update_kwargs={"num_warmup": 2, "num_samples": 2, "num_chains": 1},
+    n_features, hidden_dim_list=(1,), n_samples=3, update_method="MCMC", num_warmup=1, mcmc_num_samples=2, num_chains=1
 ):
     hidden_dim_list = list(hidden_dim_list)
+    update_kwargs = {"num_warmup": num_warmup, "num_samples": mcmc_num_samples, "num_chains": num_chains}
 
     def update(context: np.ndarray, rewards: list):
         bnn = BayesianNeuralNetwork.cold_start(
@@ -813,7 +946,7 @@ def test_bnn_mcmc_update(
                 assert np.all(layer_w[param] != layer_w_init[param])
                 assert np.all(layer_b[param] != layer_b_init[param])
 
-    rewards = np.random.choice([0, 1], size=n_samples).tolist()
+    rewards = _make_random_rewards(n_samples)
     context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
     update(context=context, rewards=rewards)
 
@@ -860,7 +993,7 @@ def test_bnn_fullrank_advi_update(n_features, hidden_dim_list=(1,), n_samples=5,
                 assert np.all(layer_w[param] != layer_w_init[param])
                 assert np.all(layer_b[param] != layer_b_init[param])
 
-    rewards = np.random.choice([0, 1], size=n_samples).tolist()
+    rewards = _make_random_rewards(n_samples)
     context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
     update(context=context, rewards=rewards)
 
@@ -1429,13 +1562,18 @@ def test_embedding_params_init_is_frozen_copy(n_features, cardinality, embedding
 # ---------------------------------------------------------------------------
 
 
-def _make_bnn_with_categoricals(n_features=2, categorical_features=None, dist_type="studentt", hidden_dim_list=None):
+def _make_bnn_with_categoricals(
+    n_features=2, categorical_features=None, dist_type="studentt", hidden_dim_list=None, update_kwargs=None
+):
+    kwargs = {"epochs": 1}
+    if update_kwargs:
+        kwargs.update(update_kwargs)
     return BayesianNeuralNetwork.cold_start(
         n_features=n_features,
         categorical_features=categorical_features or {1: 3},
         hidden_dim_list=hidden_dim_list or [8],
         dist_type=dist_type,
-        update_kwargs={"epochs": 1},
+        update_kwargs=kwargs,
     )
 
 
@@ -1571,7 +1709,7 @@ def test_create_update_model_contains_embedding_variable(n_features, cardinality
     cat_col = n_features - 1
     categorical_features = {cat_col: cardinality}
     bnn = _make_bnn_with_categoricals(n_features=n_features, categorical_features=categorical_features)
-    model_fn = bnn.create_update_model()
+    model_fn = bnn._create_update_model()
     context = jnp.array(_make_categorical_context(n_samples, n_features, categorical_features), dtype=jnp.float32)
     rewards = jnp.array(_make_random_rewards(n_samples), dtype=jnp.int32)
     trace = numpyro.handlers.trace(numpyro.handlers.seed(model_fn, rng_seed=0)).get_trace(context, rewards)
@@ -1591,8 +1729,10 @@ def test_create_update_model_minibatch_with_categoricals(n_features, cardinality
 
     cat_col = n_features - 1
     categorical_features = {cat_col: cardinality}
-    bnn = _make_bnn_with_categoricals(n_features=n_features, categorical_features=categorical_features)
-    model_fn = bnn.create_update_model(batch_size=batch_size)
+    bnn = _make_bnn_with_categoricals(
+        n_features=n_features, categorical_features=categorical_features, update_kwargs={"batch_size": batch_size}
+    )
+    model_fn = bnn._create_update_model()
     context = jnp.array(_make_categorical_context(n_samples, n_features, categorical_features), dtype=jnp.float32)
     rewards = jnp.array(_make_random_rewards(n_samples), dtype=jnp.int32)
     trace = numpyro.handlers.trace(numpyro.handlers.seed(model_fn, rng_seed=0)).get_trace(context, rewards)
@@ -1633,16 +1773,16 @@ def test_reset_restores_embedding_params(n_features, cardinality):
 # ---------------------------------------------------------------------------
 
 
-@settings(deadline=None, max_examples=5)
 @given(
     dist_type=st.sampled_from(["studentt", "normal"]),
     n_features=st.integers(min_value=2, max_value=4),
     cardinality=st.integers(min_value=2, max_value=6),
     hidden_dim_list=st.lists(st.integers(min_value=4, max_value=8), min_size=1, max_size=1),
     n_samples=st.integers(min_value=4, max_value=10),
+    num_steps=st.just(5),
 )
 def test_bnn_vi_update_with_categorical_features_updates_embeddings(
-    dist_type, n_features, cardinality, hidden_dim_list, n_samples
+    dist_type, n_features, cardinality, hidden_dim_list, n_samples, num_steps
 ):
     cat_col = n_features - 1
     categorical_features = {cat_col: cardinality}
@@ -1651,7 +1791,7 @@ def test_bnn_vi_update_with_categorical_features_updates_embeddings(
         categorical_features=categorical_features,
         hidden_dim_list=hidden_dim_list,
         dist_type=dist_type,
-        update_kwargs={"num_steps": 10},
+        update_kwargs={"num_steps": num_steps},
     )
     context = _make_categorical_context(n_samples, n_features, categorical_features)
     rewards = _make_random_rewards(n_samples)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Literal, Optional
+from typing import Literal, Optional, get_args
 from unittest.mock import patch
 
 import jax
@@ -54,6 +54,7 @@ from pybandits.model import (
     EmbeddingParams,
     FeaturesConfig,
     NormalArray,
+    OptaxKind,
     StudentTArray,
     UpdateMethods,
 )
@@ -815,7 +816,7 @@ def test_bnn_vi_update(
             assert isinstance(bnn.model_params.bnn_layer_params[layer_ind].weight, expected_array)
             assert isinstance(bnn.model_params.bnn_layer_params[layer_ind].bias, expected_array)
 
-    rewards = np.random.choice([0, 1], size=n_samples).tolist()
+    rewards = _make_random_rewards(n_samples)
 
     # context is numpy array
     context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
@@ -905,7 +906,7 @@ def test_bnn_vi_update_parameters(
         update_kwargs=update_kwargs,
     )
 
-    model_fn = bnn.create_update_model()
+    model_fn = bnn._create_update_model()
     assert callable(model_fn)
 
     # Optimizer is always set for VI (built from defaults or user override)
@@ -925,13 +926,11 @@ def test_bnn_vi_update_parameters(
 @given(
     n_features=st.just(2),
     hidden_dim_list=st.just([1]),
-    n_samples=st.just(5),
     update_method=st.just("MCMC"),
 )
 def test_bnn_mcmc_update_parameters(
     n_features: int,
     hidden_dim_list: list[int],
-    n_samples: int,
     update_method: UpdateMethods,
 ) -> None:
     """Test BNN MCMC update with valid parameters (no batch_size, optimizer, or early_stopping)."""
@@ -943,7 +942,7 @@ def test_bnn_mcmc_update_parameters(
         update_kwargs={},
     )
 
-    model_fn = bnn.create_update_model()
+    model_fn = bnn._create_update_model()
     assert callable(model_fn)
 
 
@@ -1055,6 +1054,46 @@ def test_invalid_optimizer_kwargs(
         )
 
 
+def test_optax_kind_literal_matches_optax_return_types_keys() -> None:
+    """Verify that OptaxKind Literal values exactly match _optax_return_types keys."""
+
+    literal_values = set(get_args(OptaxKind))
+    classvar_keys = set(BayesianNeuralNetwork._optax_return_types.keys())
+    assert literal_values == classvar_keys, (
+        f"OptaxKind Literal {literal_values} does not match _optax_return_types keys {classvar_keys}"
+    )
+
+
+def test_optax_kind_literal_matches_optax_required_kwargs_keys() -> None:
+    """Verify that OptaxKind Literal values exactly match _optax_required_kwargs keys."""
+
+    literal_values = set(get_args(OptaxKind))
+    classvar_keys = set(BayesianNeuralNetwork._optax_required_kwargs.keys())
+    assert literal_values == classvar_keys, (
+        f"OptaxKind Literal {literal_values} does not match _optax_required_kwargs keys {classvar_keys}"
+    )
+
+
+@pytest.mark.parametrize(
+    "kind,fn_name",
+    [
+        # optax.scale returns GradientTransformation but accepts step_size, not learning_rate
+        ("optimizer", "scale"),
+        # optax.constant_schedule returns Schedule but accepts value, not init_value
+        ("lr_scheduler", "constant_schedule"),
+    ],
+)
+def test_resolve_optax_fn_rejects_missing_required_kwarg(
+    kind: str,
+    fn_name: str,
+    n_features: int = 2,
+) -> None:
+    """Test that _resolve_optax_fn raises ValueError when the required kwarg is absent."""
+    bnn = BayesianNeuralNetwork.cold_start(n_features=n_features)
+    with pytest.raises(ValueError, match="does not accept the required keyword argument"):
+        bnn._resolve_optax_fn(fn_name, kind)
+
+
 @pytest.mark.parametrize(
     "early_stopping_kwargs",
     [
@@ -1077,6 +1116,130 @@ def test_invalid_early_stopping_kwargs(
         )
 
 
+@pytest.mark.parametrize(
+    "optimizer_type,optimizer_kwargs,lr_scheduler_type,lr_scheduler_kwargs",
+    [
+        ("sgd", {"step_size": 0.01}, "exponential_decay", {"transition_steps": 100, "decay_rate": 0.9}),
+        ("adam", {"step_size": 0.01}, "exponential_decay", {"transition_steps": 50, "decay_rate": 0.95}),
+        ("sgd", {"step_size": 0.01, "momentum": 0.9}, "cosine_decay_schedule", {"decay_steps": 100}),
+        (
+            "adam",
+            {"step_size": 0.01},
+            "exponential_decay",
+            {"transition_steps": 100, "decay_rate": 0.9, "staircase": True},
+        ),
+        (
+            "sgd",
+            {"step_size": 0.01},
+            "warmup_cosine_decay_schedule",
+            {"peak_value": 0.05, "warmup_steps": 10, "decay_steps": 100},
+        ),
+        ("adam", {"step_size": 0.01}, "linear_schedule", {"end_value": 1e-5, "transition_steps": 200}),
+    ],
+)
+def test_lr_scheduler_valid(
+    optimizer_type: str,
+    optimizer_kwargs: dict,
+    lr_scheduler_type: str,
+    lr_scheduler_kwargs: dict,
+    n_features: int = 2,
+) -> None:
+    """Test that valid lr_scheduler_type/lr_scheduler_kwargs build an optimizer successfully."""
+    bnn = BayesianNeuralNetwork.cold_start(
+        n_features=n_features,
+        update_method="VI",
+        update_kwargs={
+            "optimizer_type": optimizer_type,
+            "optimizer_kwargs": optimizer_kwargs,
+            "lr_scheduler_type": lr_scheduler_type,
+            "lr_scheduler_kwargs": lr_scheduler_kwargs,
+        },
+    )
+    assert bnn._obj_optimizer is not None
+
+
+@pytest.mark.parametrize(
+    "lr_scheduler_type,lr_scheduler_kwargs",
+    [
+        (
+            "dummy_scheduler",
+            {},
+        ),
+        ("exponential_decay", {"invalid_kwarg": 1}),
+    ],
+)
+def test_lr_scheduler_invalid_type_or_kwargs(
+    lr_scheduler_type: str,
+    lr_scheduler_kwargs: dict,
+    n_features: int = 2,
+) -> None:
+    """Test that invalid lr_scheduler_type or lr_scheduler_kwargs raise ValueError."""
+    with pytest.raises((TypeError, ValueError)):
+        BayesianNeuralNetwork.cold_start(
+            n_features=n_features,
+            update_method="VI",
+            update_kwargs={
+                "lr_scheduler_type": lr_scheduler_type,
+                "lr_scheduler_kwargs": lr_scheduler_kwargs,
+            },
+        )
+
+
+@settings(max_examples=20)
+@given(
+    optimizer_type=st.sampled_from(("sgd", "adam")),
+    num_particles=st.sampled_from((1, 2)),
+    gradient_clip_norm=st.one_of(st.none(), st.floats(min_value=0.1, max_value=10.0)),
+    lr_scheduler_type=st.sampled_from((None, "exponential_decay")),
+    num_steps=st.just(5),
+    n_features=st.just(2),
+    update_method=st.just("VI"),
+    n_samples=st.just(5),
+    decay_rate=st.just(0.9),
+    transition_steps_factor=st.just(2),
+)
+def test_vi_training_options(
+    rng,
+    optimizer_type: str,
+    num_particles: int,
+    gradient_clip_norm: Optional[float],
+    lr_scheduler_type: Optional[str],
+    num_steps: int,
+    n_features: int,
+    update_method: UpdateMethods,
+    n_samples: int,
+    decay_rate: float,
+    transition_steps_factor: int,
+) -> None:
+    """Test that VI training options (num_particles, gradient_clip_norm, lr_scheduler) compose correctly."""
+    update_kwargs: dict = {
+        "num_steps": num_steps,
+        "optimizer_type": optimizer_type,
+        "num_particles": num_particles,
+    }
+    if gradient_clip_norm is not None:
+        update_kwargs["gradient_clip_norm"] = gradient_clip_norm
+    if lr_scheduler_type is not None:
+        update_kwargs["lr_scheduler_type"] = lr_scheduler_type
+        update_kwargs["lr_scheduler_kwargs"] = {
+            "transition_steps": num_steps // transition_steps_factor,
+            "decay_rate": decay_rate,
+        }
+
+    bnn = BayesianNeuralNetwork.cold_start(
+        n_features=n_features,
+        update_method=update_method,
+        update_kwargs=update_kwargs,
+    )
+    context = np.random.rand(n_samples, n_features).astype(np.float32)
+    rewards = _make_random_rewards(n_samples)
+    bnn.update(context=context, rewards=rewards)
+    result = bnn.sample_proba(context=context, rng=rng)
+    assert len(result) == n_samples
+    assert all(0 <= p[0] <= 1 for p in result), f"Probabilities out of [0,1]: {result}"
+    assert all(np.isfinite(p[1]) for p in result), f"Non-finite weights: {result}"
+
+
 @given(
     n_features=st.just(2),
     update_method=st.just("VI"),
@@ -1095,13 +1258,10 @@ def test_epochs_and_num_steps_warns(n_features: int, update_method: UpdateMethod
 
 @pytest.mark.parametrize("n_features", [1, 2])
 def test_bnn_mcmc_update(
-    n_features,
-    hidden_dim_list=(1,),
-    n_samples=3,
-    update_method="MCMC",
-    update_kwargs={"num_warmup": 2, "num_samples": 2, "num_chains": 1},
+    n_features, hidden_dim_list=(1,), n_samples=3, update_method="MCMC", num_warmup=1, mcmc_num_samples=2, num_chains=1
 ):
     hidden_dim_list = list(hidden_dim_list)
+    update_kwargs = {"num_warmup": num_warmup, "num_samples": mcmc_num_samples, "num_chains": num_chains}
 
     def update(context: np.ndarray, rewards: list):
         bnn = BayesianNeuralNetwork.cold_start(
@@ -1135,7 +1295,7 @@ def test_bnn_mcmc_update(
                 assert layer_w.params[param].tolist() == getattr(layer_w, param)
                 assert layer_b.params[param].tolist() == getattr(layer_b, param)
 
-    rewards = np.random.choice([0, 1], size=n_samples).tolist()
+    rewards = _make_random_rewards(n_samples)
     context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
     update(context=context, rewards=rewards)
 
@@ -1186,7 +1346,7 @@ def test_bnn_fullrank_advi_update(n_features, hidden_dim_list=(1,), n_samples=5,
                 assert layer_w.params[param].tolist() == getattr(layer_w, param)
                 assert layer_b.params[param].tolist() == getattr(layer_b, param)
 
-    rewards = np.random.choice([0, 1], size=n_samples).tolist()
+    rewards = _make_random_rewards(n_samples)
     context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
     update(context=context, rewards=rewards)
 
@@ -1853,13 +2013,18 @@ def test_embedding_params_init_is_frozen_copy(n_features, cardinality, embedding
 # ---------------------------------------------------------------------------
 
 
-def _make_bnn_with_categoricals(n_features=2, categorical_features=None, dist_type="studentt", hidden_dim_list=None):
+def _make_bnn_with_categoricals(
+    n_features=2, categorical_features=None, dist_type="studentt", hidden_dim_list=None, update_kwargs=None
+):
+    kwargs = {"epochs": 1}
+    if update_kwargs:
+        kwargs.update(update_kwargs)
     return BayesianNeuralNetwork.cold_start(
         n_features=n_features,
         categorical_features=categorical_features or {1: 3},
         hidden_dim_list=hidden_dim_list or [8],
         dist_type=dist_type,
-        update_kwargs={"epochs": 1},
+        update_kwargs=kwargs,
     )
 
 
@@ -1990,12 +2155,11 @@ def test_sample_proba_with_feature_config(rng, dist_type, n_samples, n_features,
 )
 def test_create_update_model_contains_embedding_variable(n_features, cardinality, n_samples):
     """Verify the NumPyro model function samples embedding variables."""
-    import jax.numpy as jnp
 
     cat_col = n_features - 1
     categorical_features = {cat_col: cardinality}
     bnn = _make_bnn_with_categoricals(n_features=n_features, categorical_features=categorical_features)
-    model_fn = bnn.create_update_model()
+    model_fn = bnn._create_update_model()
     context = jnp.array(_make_categorical_context(n_samples, n_features, categorical_features), dtype=jnp.float32)
     rewards = jnp.array(_make_random_rewards(n_samples), dtype=jnp.int32)
     trace = numpyro.handlers.trace(numpyro.handlers.seed(model_fn, rng_seed=0)).get_trace(context, rewards)
@@ -2011,12 +2175,13 @@ def test_create_update_model_contains_embedding_variable(n_features, cardinality
 )
 def test_create_update_model_minibatch_with_categoricals(n_features, cardinality, n_samples, batch_size):
     """Verify the NumPyro model function with minibatching samples embedding variables."""
-    import jax.numpy as jnp
 
     cat_col = n_features - 1
     categorical_features = {cat_col: cardinality}
-    bnn = _make_bnn_with_categoricals(n_features=n_features, categorical_features=categorical_features)
-    model_fn = bnn.create_update_model(batch_size=batch_size)
+    bnn = _make_bnn_with_categoricals(
+        n_features=n_features, categorical_features=categorical_features, update_kwargs={"batch_size": batch_size}
+    )
+    model_fn = bnn._create_update_model()
     context = jnp.array(_make_categorical_context(n_samples, n_features, categorical_features), dtype=jnp.float32)
     rewards = jnp.array(_make_random_rewards(n_samples), dtype=jnp.int32)
     trace = numpyro.handlers.trace(numpyro.handlers.seed(model_fn, rng_seed=0)).get_trace(context, rewards)
@@ -2057,7 +2222,7 @@ def test_reset_restores_embedding_params(n_features, cardinality):
 # ---------------------------------------------------------------------------
 
 
-@settings(deadline=None, max_examples=5)
+@settings(max_examples=20)
 @given(
     dist_type=st.sampled_from(["studentt", "normal"]),
     n_features=st.integers(min_value=2, max_value=4),


### PR DESCRIPTION
### Changes:
* Add `num_particles`, `gradient_clip_norm` to VI `update_kwargs`
  - `num_particles` is passed to `TraceMeanField_ELBO`/`Trace_ELBO` for multi-particle gradient estimates
  - `gradient_clip_norm` chains `optax.clip_by_global_norm` before the base optimizer
* Switch all optimizers from numpyro-native to optax via `optax_to_numpyro`, removing the dual-path logic
* Remove `clipped_adam`, `momentum`, and `reduce_on_plateau` scheduler
* Remove `batch_size` parameter from `create_update_model`; read from `_update_kwargs` instead
* Add `optax` to `pyproject.toml` dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optax optimizers with selectable LR schedulers, optional global‑norm gradient clipping, and VI support for multiple particles; learning-rate and scheduler configurable via update options.

* **Breaking Changes**
  * Batch size is provided via update/training options; public model-construction API changed. Early stopping now uses absolute loss-change magnitude for convergence.

* **Tests**
  * Added/expanded tests for LR schedulers, VI options (particles, gradient clipping), categorical-feature updates, and Optax-kind consistency.

* **Chores**
  * Version bumped to 7.1.1; Optax added as a runtime dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->