### PR TITLE
Add KL annealing to BNN VI training 

### DIFF
--- a/pybandits/model.py
+++ b/pybandits/model.py
@@ -20,8 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import inspect
 import warnings
 from abc import ABC, abstractmethod
+from contextlib import nullcontext
 from copy import deepcopy
 from math import ceil
 from random import betavariate
@@ -33,6 +35,7 @@ import numpy as np
 import numpyro
 import numpyro.distributions as npdist
 import numpyro.optim as noptim
+import optax
 from loguru import logger
 from numpy import sqrt
 from numpyro.distributions import Bernoulli as NumpyroBernoulli
@@ -67,6 +70,7 @@ from pybandits.pydantic_version_compatibility import (
 UpdateMethods = Literal["VI", "MCMC"]
 VIMethods = Literal["advi", "fullrank_advi"]
 ActivationFunctions = Literal["tanh", "relu", "sigmoid", "gelu"]
+OptaxKind = Literal["optimizer", "lr_scheduler"]
 
 
 def _numpy_relu(x: np.ndarray) -> np.ndarray:
@@ -1092,16 +1096,58 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         "batch_size",
         "early_stopping_kwargs",
         "epochs",
+        "lr_scheduler_type",
+        "lr_scheduler_kwargs",
+        "restore_best_weights",
+        "num_particles",
+        "gradient_clip_norm",
+        "kl_tau",
     ]
     _distribution_mapping: ClassVar[Dict[str, type]] = {"normal": NormalArray, "studentt": StudentTArray}
     _embedding_dim_divisor: ClassVar[int] = 4
-    _supported_optimizers: ClassVar[dict] = {
-        "sgd": noptim.SGD,
-        "momentum": noptim.Momentum,
-        "adagrad": noptim.Adagrad,
-        "adam": noptim.Adam,
-        "clipped_adam": noptim.ClippedAdam,
+    _optax_return_types: ClassVar[dict] = {
+        "optimizer": optax.GradientTransformation,
+        "lr_scheduler": optax.Schedule,
     }
+
+    def _resolve_optax_fn(self, name: str, kind: OptaxKind) -> Any:
+        """Look up an optax function by name using getattr and validate its return type annotation.
+
+        Parameters
+        ----------
+        name : str
+            Name of the optax attribute (e.g. ``"adam"``, ``"exponential_decay"``).
+        kind : OptaxKind
+            Key into ``_optax_return_types`` (``"optimizer"`` or ``"lr_scheduler"``).
+
+        Returns
+        -------
+        Any
+            The callable found on the ``optax`` module.
+
+        Raises
+        ------
+        ValueError
+            If ``name`` is not a callable attribute of ``optax``, or its return-type
+            annotation does not match the expected type for ``kind``.
+        """
+        fn = getattr(optax, name, None)
+        if fn is None or not callable(fn):
+            raise ValueError(f"Invalid {kind}: '{name}' is not a callable attribute of optax.")
+        expected = self._optax_return_types[kind]
+        return_annotation = inspect.signature(fn).return_annotation
+        if isinstance(expected, type):
+            # e.g. GradientTransformationExtraArgs — check via issubclass
+            valid = isinstance(return_annotation, type) and issubclass(return_annotation, expected)
+        else:
+            # e.g. optax.Schedule (a generic alias) — check for equality
+            valid = return_annotation == expected
+        if not valid:
+            raise ValueError(
+                f"Invalid {kind}: '{name}' does not return {expected} (got return annotation: {return_annotation})."
+            )
+        return fn
+
     _jax_activations: ClassVar[dict] = {
         "tanh": jax.nn.tanh,
         "relu": jax.nn.relu,
@@ -1131,6 +1177,11 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         optimizer_kwargs={"step_size": 0.01},
         batch_size=None,
         early_stopping_kwargs=None,
+        lr_scheduler_type=None,
+        lr_scheduler_kwargs=None,
+        num_particles=1,
+        gradient_clip_norm=None,
+        kl_tau=None,
     )
 
     _default_mcmc_kwargs: ClassVar[dict] = dict(
@@ -1212,19 +1263,35 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         return numerical_arr, cat_indices_dict
 
     def _get_obj_optimizer(self) -> Any:
-        """Build the optimizer from update_kwargs. Always returns an optimizer (uses default if not specified)."""
+        """Build an optax optimizer from update_kwargs, wrapped via ``optax_to_numpyro``.
+
+        Optionally chains a learning-rate schedule and/or gradient clipping.
+        """
         optimizer_type = self.update_kwargs["optimizer_type"]
-        if optimizer_type not in self._supported_optimizers:
-            raise ValueError(
-                f"Invalid optimizer type: {optimizer_type}. "
-                f"Supported optimizers are: {list(self._supported_optimizers.keys())}"
-            )
-        cls_ = self._supported_optimizers[optimizer_type]
-        optimizer_kwargs = self.update_kwargs.get("optimizer_kwargs", {})
+        optimizer_kwargs = dict(self.update_kwargs.get("optimizer_kwargs", {}))
+        lr_scheduler_type = self.update_kwargs.get("lr_scheduler_type")
+        lr_scheduler_kwargs = self.update_kwargs.get("lr_scheduler_kwargs") or {}
+        gradient_clip_norm = self.update_kwargs.get("gradient_clip_norm")
+
+        optimizer_fn = self._resolve_optax_fn(optimizer_type, "optimizer")
+
+        # Resolve learning rate (possibly a schedule)
+        learning_rate = optimizer_kwargs.pop("step_size", 0.01)
+        if lr_scheduler_type is not None:
+            scheduler_fn = self._resolve_optax_fn(lr_scheduler_type, "lr_scheduler")
+            try:
+                learning_rate = scheduler_fn(init_value=learning_rate, **lr_scheduler_kwargs)
+            except (TypeError, ValueError) as e:
+                raise e.__class__(f"Invalid lr_scheduler_kwargs: {lr_scheduler_kwargs}.\n{e}") from e
+
         try:
-            return cls_(**optimizer_kwargs)
+            base_optimizer = optimizer_fn(learning_rate=learning_rate, **optimizer_kwargs)
         except (TypeError, ValueError, KeyError) as e:
-            raise e.__class__(f"Invalid optimizer kwargs: {optimizer_kwargs}.\n{e}")
+            raise e.__class__(f"Invalid optimizer kwargs: {optimizer_kwargs}.\n{e}") from e
+
+        if gradient_clip_norm is not None:
+            return noptim.optax_to_numpyro(optax.chain(optax.clip_by_global_norm(gradient_clip_norm), base_optimizer))
+        return noptim.optax_to_numpyro(base_optimizer)
 
     def _get_early_stopping_callback(self) -> Optional[EarlyStopping]:
         early_stopping_kwargs = self.update_kwargs.get("early_stopping_kwargs", None)
@@ -1454,7 +1521,42 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         self.__dict__.update(state)
         self._init_private_attrs()
 
-    def create_update_model(self, batch_size: Optional[PositiveInt] = None) -> Callable:
+    def _kl_scale_ctx(self, n_samples: PositiveInt):
+        """Return a context manager that scales sample-site log-probs for KL temperature.
+
+        When kl_tau is set in update_kwargs, this returns a
+        numpyro.handlers.scale context manager with factor
+        beta = kl_tau * n_samples / n_neurons, where *n_neurons* is the
+        total number of hidden units across all layers except the output layer.
+        Wrapping both the model prior and the guide with this handler scales the
+        full KL divergence term in the ELBO by *beta*.
+
+        When kl_tau is None (the default), returns a plain
+        contextlib.nullcontext (no-op).
+
+        References
+        ----------
+        Variational Inference of overparameterized Bayesian Neural Networks
+        (Huix et al., 2022) - https://arxiv.org/abs/2207.03859
+
+        Parameters
+        ----------
+        n_samples : PositiveInt
+            Number of data points in the current batch. Used to
+            compute the data-dependent part of the scale factor.
+
+        Returns
+        -------
+        contextlib.AbstractContextManager
+            Either numpyro.handlers.scale(scale=beta) or nullcontext().
+        """
+        kl_tau = self._update_kwargs.get("kl_tau")
+        if kl_tau is not None:
+            n_neurons = max(sum(lp.weight.shape[1] for lp in self.model_params.bnn_layer_params[:-1]), 1)
+            return numpyro.handlers.scale(scale=kl_tau * n_samples / n_neurons)
+        return nullcontext()
+
+    def _create_update_model(self) -> Callable:
         """
         Create a NumPyro model function for Bayesian Neural Network.
 
@@ -1463,13 +1565,8 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         with subsample_size.
 
         Numerical columns are passed through as-is. Categorical columns (identified by their
-        ``column_index`` in ``feature_config``) are modelled with Bayesian embedding matrices
+        ``column_index`` in ``feature_config``) are modeled with Bayesian embedding matrices
         sampled as NumPyro random variables.
-
-        Parameters
-        ----------
-        batch_size : Optional[PositiveInt]
-            If provided, use minibatching with this batch size via numpyro.plate.
 
         Returns
         -------
@@ -1486,31 +1583,36 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         5. Use Bernoulli likelihood for binary classification
         """
 
+        batch_size = self._update_kwargs.get("batch_size")
+        kl_scale = self._kl_scale_ctx
+
         n_layers = len(self.model_params.bnn_layer_params)
         numerical_indices = self.feature_config.numerical_indices
         cat_configs = self.feature_config.categorical_features_configs
         has_embeddings = self.model_params.embedding_params is not None and len(cat_configs) > 0
 
         def model(x: jax.Array, y: jax.Array):
-            N = x.shape[0]
+            n_samples = x.shape[0]
 
             # Sample all weights (global parameters, outside plate)
             weights_biases = []
-            for layer_ind, layer_params in enumerate(self.model_params.bnn_layer_params):
-                weight_name, bias_name = self.get_layer_params_name(layer_ind)
-                w = numpyro.sample(weight_name, layer_params.weight.to_numpyro_distribution())
-                b = numpyro.sample(bias_name, layer_params.bias.to_numpyro_distribution())
-                weights_biases.append((w, b, layer_params.weight.shape))
+            with kl_scale(n_samples):
+                for layer_ind, layer_params in enumerate(self.model_params.bnn_layer_params):
+                    weight_name, bias_name = self.get_layer_params_name(layer_ind)
+                    w = numpyro.sample(weight_name, layer_params.weight.to_numpyro_distribution())
+                    b = numpyro.sample(bias_name, layer_params.bias.to_numpyro_distribution())
+                    weights_biases.append((w, b, layer_params.weight.shape))
 
             # Sample embedding matrices (global parameters, outside plate)
             embedding_matrices = []
             if has_embeddings:
-                for i, emb_dist in enumerate(self.model_params.embedding_params.embeddings):
-                    emb = numpyro.sample(self.get_embedding_var_name(i), emb_dist.to_numpyro_distribution())
-                    embedding_matrices.append(emb)
+                with kl_scale(n_samples):
+                    for i, emb_dist in enumerate(self.model_params.embedding_params.embeddings):
+                        emb = numpyro.sample(self.get_embedding_var_name(i), emb_dist.to_numpyro_distribution())
+                        embedding_matrices.append(emb)
 
             # Data plate with optional minibatching
-            with numpyro.plate("data", N, subsample_size=batch_size) as idx:
+            with numpyro.plate("data", n_samples, subsample_size=batch_size) as idx:
                 x_batch = x[idx] if batch_size is not None else x
                 y_batch = y[idx] if batch_size is not None else y
 
@@ -1867,10 +1969,9 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         """
         if self._early_stopping_callback is not None:
             self._early_stopping_callback.reset()
-        batch_size = self._update_kwargs["batch_size"]
-        _model = self.create_update_model(batch_size=batch_size)
+        _model = self._create_update_model()
 
-        effective_batch_size = batch_size if batch_size is not None else n_samples
+        effective_batch_size = self._update_kwargs.get("batch_size") or n_samples
         steps_per_epoch = max(1, n_samples // effective_batch_size)
 
         if self._update_kwargs.get("epochs") is not None:
@@ -1887,8 +1988,22 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         # Set up VI method (guide + loss) dynamically
         vi_method = self._update_kwargs["method"]
         method_config = self._vi_method_config[vi_method]
-        guide = method_config["guide"](_model, init_loc_fn=init_to_median)
-        loss = method_config["loss"]()
+        raw_guide = method_config["guide"](_model, init_loc_fn=init_to_median)
+
+        # When kl_tau is active, wrap the guide with the same scale handler so
+        # both log p(z) and log q(z) are scaled equally → the KL term as a
+        # whole is multiplied by beta = tau * N / n_neurons.
+        if self._update_kwargs.get("kl_tau") is not None:
+            kl_scale = self._kl_scale_ctx
+
+            def guide(x, y, *args, **kwargs):
+                with kl_scale(x.shape[0]):
+                    return raw_guide(x, y, *args, **kwargs)
+        else:
+            guide = raw_guide
+
+        num_particles = self._update_kwargs["num_particles"]
+        loss = method_config["loss"](num_particles=num_particles)
         svi = SVI(_model, guide, self._obj_optimizer, loss=loss)
 
         # Run the SVI loop via jax.lax.scan to keep the iteration inside XLA.
@@ -1915,12 +2030,13 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             svi_state, epoch_losses = _run_epoch(svi_state, epoch_steps)
 
             epoch_np = np.array(epoch_losses)
+            epoch_end_loss = float(epoch_np[-1])
             all_losses.append(epoch_np)
             pbar.update(1)
-            pbar.set_postfix(loss=f"{float(epoch_np[-1]):.4f}")
+            pbar.set_postfix(loss=f"{epoch_end_loss:.4f}")
 
             if self._early_stopping_callback is not None:
-                if self._early_stopping_callback.should_stop(float(epoch_np[-1])):
+                if self._early_stopping_callback.should_stop(epoch_end_loss):
                     logger.info(
                         f"Early stopping at epoch {epoch_idx + 1}/{len(epoch_steps_list)}: "
                         f"loss change below {self._early_stopping_callback.tolerance} "
@@ -1933,7 +2049,9 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         pbar.close()
         self._approx_history = np.concatenate(all_losses) if all_losses else np.array([])
         params = svi.get_params(svi_state)
-        return svi, guide, params
+        # Return the raw AutoGuide (not the scaled wrapper) so downstream
+        # param extraction (median, scale_tril, etc.) works correctly.
+        return svi, raw_guide, params
 
     def _extract_advi_params(self, params: dict) -> tuple:
         """
@@ -2062,7 +2180,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         List
             Updated ``BnnLayerParams`` list (embeddings are updated in-place as a side-effect).
         """
-        _model = self.create_update_model()
+        _model = self._create_update_model()
         nuts_kwargs = self._update_kwargs["nuts"]
         # All top-level keys except 'nuts' are MCMC kwargs
         mcmc_kwargs = {k: v for k, v in self._update_kwargs.items() if k != "nuts"}

--- a/pybandits/model.py
+++ b/pybandits/model.py
@@ -1102,6 +1102,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         "num_particles",
         "gradient_clip_norm",
         "kl_tau",
+        "kl_annealing_fraction",
     ]
     _distribution_mapping: ClassVar[Dict[str, type]] = {"normal": NormalArray, "studentt": StudentTArray}
     _embedding_dim_divisor: ClassVar[int] = 4
@@ -1182,6 +1183,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         num_particles=1,
         gradient_clip_norm=None,
         kl_tau=None,
+        kl_annealing_fraction=None,
     )
 
     _default_mcmc_kwargs: ClassVar[dict] = dict(
@@ -1457,6 +1459,10 @@ class BaseBayesianNeuralNetwork(Model, ABC):
 
             self.update_kwargs = {**self._default_vi_kwargs, **self.update_kwargs}
 
+            kl_annealing_fraction = self.update_kwargs.get("kl_annealing_fraction")
+            if kl_annealing_fraction is not None and not (0.0 <= kl_annealing_fraction <= 1.0):
+                raise ValueError(f"kl_annealing_fraction must be in [0, 1] or None, got {kl_annealing_fraction}")
+
             # Validate VI method
             vi_method = self.update_kwargs.get("method")
             if vi_method not in self._vi_method_config:
@@ -1521,18 +1527,16 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         self.__dict__.update(state)
         self._init_private_attrs()
 
-    def _kl_scale_ctx(self, n_samples: PositiveInt):
-        """Return a context manager that scales sample-site log-probs for KL temperature.
+    def _kl_scale_ctx(self, n_samples: PositiveInt, kl_annealing_factor=1.0):
+        """Return a context manager that scales sample-site log-probs for KL.
 
-        When kl_tau is set in update_kwargs, this returns a
-        numpyro.handlers.scale context manager with factor
-        beta = kl_tau * n_samples / n_neurons, where *n_neurons* is the
-        total number of hidden units across all layers except the output layer.
-        Wrapping both the model prior and the guide with this handler scales the
-        full KL divergence term in the ELBO by *beta*.
+        The effective scale is ``kl_base_factor * kl_annealing_factor`` where
+        ``kl_base_factor = kl_tau * n_samples / n_neurons`` if ``kl_tau`` is set,
+        else ``1.0``. Wrapping both the model prior and the guide with this
+        handler multiplies the full KL term in the ELBO by that product.
 
-        When kl_tau is None (the default), returns a plain
-        contextlib.nullcontext (no-op).
+        When neither ``kl_tau`` nor ``kl_annealing_fraction`` is active, returns
+        ``contextlib.nullcontext`` (no-op).
 
         References
         ----------
@@ -1542,19 +1546,31 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         Parameters
         ----------
         n_samples : PositiveInt
-            Number of data points in the current batch. Used to
-            compute the data-dependent part of the scale factor.
+            Number of data points in the current batch.
+        kl_annealing_factor : float or jax scalar, optional
+            Multiplicative factor in [0, 1]. Default 1.0 (no annealing).
+            May be a traced JAX scalar inside lax.scan - do not coerce to float.
 
         Returns
         -------
         contextlib.AbstractContextManager
-            Either numpyro.handlers.scale(scale=beta) or nullcontext().
+            Either numpyro.handlers.scale(scale=kl_base_factor * kl_annealing_factor) or nullcontext().
         """
         kl_tau = self._update_kwargs.get("kl_tau")
-        if kl_tau is not None:
+        kl_annealing_fraction = self._update_kwargs.get("kl_annealing_fraction")
+        kl_tau_active = kl_tau is not None
+        kl_annealing_active = kl_annealing_fraction not in (None, 0.0)
+
+        if not kl_tau_active and not kl_annealing_active:
+            return nullcontext()
+
+        if kl_tau_active:
             n_neurons = max(sum(lp.weight.shape[1] for lp in self.model_params.bnn_layer_params[:-1]), 1)
-            return numpyro.handlers.scale(scale=kl_tau * n_samples / n_neurons)
-        return nullcontext()
+            kl_base_factor = kl_tau * n_samples / n_neurons
+        else:
+            kl_base_factor = 1.0
+
+        return numpyro.handlers.scale(scale=kl_base_factor * kl_annealing_factor)
 
     def _create_update_model(self) -> Callable:
         """
@@ -1591,12 +1607,12 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         cat_configs = self.feature_config.categorical_features_configs
         has_embeddings = self.model_params.embedding_params is not None and len(cat_configs) > 0
 
-        def model(x: jax.Array, y: jax.Array):
+        def model(x: jax.Array, y: jax.Array, kl_annealing_factor=1.0):
             n_samples = x.shape[0]
 
             # Sample all weights (global parameters, outside plate)
             weights_biases = []
-            with kl_scale(n_samples):
+            with kl_scale(n_samples, kl_annealing_factor):
                 for layer_ind, layer_params in enumerate(self.model_params.bnn_layer_params):
                     weight_name, bias_name = self.get_layer_params_name(layer_ind)
                     w = numpyro.sample(weight_name, layer_params.weight.to_numpyro_distribution())
@@ -1606,7 +1622,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             # Sample embedding matrices (global parameters, outside plate)
             embedding_matrices = []
             if has_embeddings:
-                with kl_scale(n_samples):
+                with kl_scale(n_samples, kl_annealing_factor):
                     for i, emb_dist in enumerate(self.model_params.embedding_params.embeddings):
                         emb = numpyro.sample(self.get_embedding_var_name(i), emb_dist.to_numpyro_distribution())
                         embedding_matrices.append(emb)
@@ -1985,20 +2001,26 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             if not epoch_steps_list:
                 epoch_steps_list = [1]
 
+        total_steps = sum(epoch_steps_list)
+        kl_annealing_fraction = self._update_kwargs.get("kl_annealing_fraction")
+        kl_annealing_active = kl_annealing_fraction not in (None, 0.0)
+        kl_warmup_steps = max(1, int(np.ceil(kl_annealing_fraction * total_steps))) if kl_annealing_active else None
+
         # Set up VI method (guide + loss) dynamically
         vi_method = self._update_kwargs["method"]
         method_config = self._vi_method_config[vi_method]
         raw_guide = method_config["guide"](_model, init_loc_fn=init_to_median)
 
-        # When kl_tau is active, wrap the guide with the same scale handler so
+        # When kl_tau or KL annealing is active, wrap the guide with the same scale handler so
         # both log p(z) and log q(z) are scaled equally → the KL term as a
-        # whole is multiplied by beta = tau * N / n_neurons.
-        if self._update_kwargs.get("kl_tau") is not None:
+        # whole is multiplied by kl_base_factor * kl_annealing_factor.
+        kl_tau_active = self._update_kwargs.get("kl_tau") is not None
+        if kl_tau_active or kl_annealing_active:
             kl_scale = self._kl_scale_ctx
 
-            def guide(x, y, *args, **kwargs):
-                with kl_scale(x.shape[0]):
-                    return raw_guide(x, y, *args, **kwargs)
+            def guide(x, y, kl_annealing_factor, *args, **kwargs):
+                with kl_scale(x.shape[0], kl_annealing_factor):
+                    return raw_guide(x, y, kl_annealing_factor, *args, **kwargs)
         else:
             guide = raw_guide
 
@@ -2012,22 +2034,46 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         # a fixed step count regardless of batch size or FP precision.
         # lax.scan compiles the loop body once and runs it entirely in XLA.
         self._rng_key, subkey = jax.random.split(self._rng_key)
-        svi_state = svi.init(subkey, x_jnp, y_jnp)
+        svi_state = svi.init(subkey, x_jnp, y_jnp, 1.0)
+        if kl_annealing_active:
+            kl_warmup_f = jnp.float32(kl_warmup_steps)
 
-        def _svi_body(state, _):
-            state, loss = svi.update(state, x_jnp, y_jnp)
-            return state, loss
+            def _svi_body(state, step):  # step is a traced int32 scalar (global index)
+                kl_annealing_factor = jnp.minimum(1.0, (step.astype(jnp.float32) + 1.0) / kl_warmup_f)
+                state, loss = svi.update(state, x_jnp, y_jnp, kl_annealing_factor)
+                return state, loss
 
-        _run_epoch = jax.jit(
-            lambda state, n: jax.lax.scan(_svi_body, state, None, length=n),
-            static_argnums=(1,),
-        )
+            _run_epoch = jax.jit(
+                lambda state, steps: jax.lax.scan(_svi_body, state, steps),
+            )  # steps is a 1-D int32 array; scan feeds each element as xs to _svi_body
+        else:
+
+            def _svi_body(state, _):
+                # kl_annealing_factor = 1.0 is safe: _kl_scale_ctx returns nullcontext
+                # if kl_tau is also None; otherwise kl_base_factor * 1.0 == kl_base_factor.
+                state, loss = svi.update(state, x_jnp, y_jnp, 1.0)
+                return state, loss
+
+            _run_epoch = jax.jit(
+                lambda state, n: jax.lax.scan(_svi_body, state, None, length=n),
+                static_argnums=(1,),
+            )
 
         all_losses = []
         pbar = trange(len(epoch_steps_list), desc="SVI", leave=False)
 
+        global_step_offset = 0
         for epoch_idx, epoch_steps in enumerate(epoch_steps_list):
-            svi_state, epoch_losses = _run_epoch(svi_state, epoch_steps)
+            if kl_annealing_active:
+                steps_arr = jnp.arange(
+                    global_step_offset,
+                    global_step_offset + epoch_steps,
+                    dtype=jnp.int32,
+                )
+                svi_state, epoch_losses = _run_epoch(svi_state, steps_arr)
+            else:
+                svi_state, epoch_losses = _run_epoch(svi_state, epoch_steps)
+            global_step_offset += epoch_steps
 
             epoch_np = np.array(epoch_losses)
             epoch_end_loss = float(epoch_np[-1])

--- a/pybandits/model.py
+++ b/pybandits/model.py
@@ -49,7 +49,7 @@ from scipy.stats import norm, t
 from tqdm import trange
 from typing_extensions import Self
 
-from pybandits.base import BinaryReward, MOProbability, Probability, ProbabilityWeight, PyBanditsBaseModel
+from pybandits.base import BinaryReward, Float01, MOProbability, Probability, ProbabilityWeight, PyBanditsBaseModel
 from pybandits.base_model import BaseModelCC, BaseModelMO, BaseModelSO
 from pybandits.pydantic_version_compatibility import (
     PYDANTIC_VERSION_1,
@@ -1527,7 +1527,11 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         self.__dict__.update(state)
         self._init_private_attrs()
 
-    def _kl_scale_ctx(self, n_samples: PositiveInt, kl_annealing_factor=1.0):
+    def _kl_scale_ctx(
+        self,
+        n_samples: Union[PositiveInt, jax.Array],
+        kl_annealing_factor: Union[Float01, jax.Array] = 1.0,
+    ):
         """Return a context manager that scales sample-site log-probs for KL.
 
         The effective scale is ``kl_base_factor * kl_annealing_factor`` where
@@ -1545,11 +1549,12 @@ class BaseBayesianNeuralNetwork(Model, ABC):
 
         Parameters
         ----------
-        n_samples : PositiveInt
+        n_samples : PositiveInt or jax.Array
             Number of data points in the current batch.
-        kl_annealing_factor : float or jax scalar, optional
-            Multiplicative factor in [0, 1]. Default 1.0 (no annealing).
-            May be a traced JAX scalar inside lax.scan - do not coerce to float.
+            May be a traced JAX integer scalar (``x.shape[0]`` inside ``lax.scan``).
+        kl_annealing_factor : Float01 or jax.Array, optional
+            Multiplicative factor in (0, 1]. Default 1.0 (no annealing).
+            May be a traced JAX scalar inside ``lax.scan`` - do not coerce to a Python float.
 
         Returns
         -------
@@ -1607,7 +1612,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         cat_configs = self.feature_config.categorical_features_configs
         has_embeddings = self.model_params.embedding_params is not None and len(cat_configs) > 0
 
-        def model(x: jax.Array, y: jax.Array, kl_annealing_factor=1.0):
+        def model(x: jax.Array, y: jax.Array, kl_annealing_factor: Union[Float01, jax.Array] = 1.0):
             n_samples = x.shape[0]
 
             # Sample all weights (global parameters, outside plate)
@@ -2004,25 +2009,40 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         total_steps = sum(epoch_steps_list)
         kl_annealing_fraction = self._update_kwargs.get("kl_annealing_fraction")
         kl_annealing_active = kl_annealing_fraction not in (None, 0.0)
-        kl_warmup_steps = max(1, int(np.ceil(kl_annealing_fraction * total_steps))) if kl_annealing_active else None
+
+        # Per-step KL annealing schedule, fed as the xs runtime array to lax.scan
+        # below. Inactive: a constant-1.0 array (no-op multiplier; nullcontext when
+        # kl_tau is also off). Active: linear ramp `min(1, (step+1) / warmup_steps)`
+        # over global step indices.
+        if kl_annealing_active:
+            kl_warmup_steps = max(1, int(np.ceil(kl_annealing_fraction * total_steps)))
+            all_steps = jnp.arange(total_steps, dtype=jnp.float32)
+            kl_factors_full = jnp.minimum(1.0, (all_steps + 1.0) / jnp.float32(kl_warmup_steps))
+        else:
+            kl_factors_full = jnp.ones(total_steps, dtype=jnp.float32)
 
         # Set up VI method (guide + loss) dynamically
         vi_method = self._update_kwargs["method"]
         method_config = self._vi_method_config[vi_method]
         raw_guide = method_config["guide"](_model, init_loc_fn=init_to_median)
 
-        # When kl_tau or KL annealing is active, wrap the guide with the same scale handler so
-        # both log p(z) and log q(z) are scaled equally → the KL term as a
-        # whole is multiplied by kl_base_factor * kl_annealing_factor.
-        kl_tau_active = self._update_kwargs.get("kl_tau") is not None
-        if kl_tau_active or kl_annealing_active:
-            kl_scale = self._kl_scale_ctx
+        # Wrap raw_guide so its signature matches the model's (svi.update forwards
+        # kl_annealing_factor into both). Wrapping both with the same kl_scale
+        # handler scales log p(z) and log q(z) equally, so the full KL term is
+        # multiplied by kl_base_factor * kl_annealing_factor. The wrapper is a
+        # no-op when both kl_tau and kl_annealing are inactive (kl_scale returns
+        # nullcontext()).
+        kl_scale = self._kl_scale_ctx
 
-            def guide(x, y, kl_annealing_factor, *args, **kwargs):
-                with kl_scale(x.shape[0], kl_annealing_factor):
-                    return raw_guide(x, y, kl_annealing_factor, *args, **kwargs)
-        else:
-            guide = raw_guide
+        def guide(
+            x: jax.Array,
+            y: jax.Array,
+            kl_annealing_factor: Union[Float01, jax.Array],
+            *args,
+            **kwargs,
+        ):
+            with kl_scale(x.shape[0], kl_annealing_factor):
+                return raw_guide(x, y, kl_annealing_factor, *args, **kwargs)
 
         num_particles = self._update_kwargs["num_particles"]
         loss = method_config["loss"](num_particles=num_particles)
@@ -2035,44 +2055,22 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         # lax.scan compiles the loop body once and runs it entirely in XLA.
         self._rng_key, subkey = jax.random.split(self._rng_key)
         svi_state = svi.init(subkey, x_jnp, y_jnp, 1.0)
-        if kl_annealing_active:
-            kl_warmup_f = jnp.float32(kl_warmup_steps)
 
-            def _svi_body(state, step):  # step is a traced int32 scalar (global index)
-                kl_annealing_factor = jnp.minimum(1.0, (step.astype(jnp.float32) + 1.0) / kl_warmup_f)
-                state, loss = svi.update(state, x_jnp, y_jnp, kl_annealing_factor)
-                return state, loss
+        def _svi_body(state, kl_annealing_factor: jax.Array):
+            # kl_annealing_factor is a traced float32 scalar from kl_factors_full
+            # (1.0 on the inactive path).
+            state, loss = svi.update(state, x_jnp, y_jnp, kl_annealing_factor)
+            return state, loss
 
-            _run_epoch = jax.jit(
-                lambda state, steps: jax.lax.scan(_svi_body, state, steps),
-            )  # steps is a 1-D int32 array; scan feeds each element as xs to _svi_body
-        else:
-
-            def _svi_body(state, _):
-                # kl_annealing_factor = 1.0 is safe: _kl_scale_ctx returns nullcontext
-                # if kl_tau is also None; otherwise kl_base_factor * 1.0 == kl_base_factor.
-                state, loss = svi.update(state, x_jnp, y_jnp, 1.0)
-                return state, loss
-
-            _run_epoch = jax.jit(
-                lambda state, n: jax.lax.scan(_svi_body, state, None, length=n),
-                static_argnums=(1,),
-            )
+        _run_epoch = jax.jit(lambda state, factors: jax.lax.scan(_svi_body, state, factors))
 
         all_losses = []
         pbar = trange(len(epoch_steps_list), desc="SVI", leave=False)
 
         global_step_offset = 0
         for epoch_idx, epoch_steps in enumerate(epoch_steps_list):
-            if kl_annealing_active:
-                steps_arr = jnp.arange(
-                    global_step_offset,
-                    global_step_offset + epoch_steps,
-                    dtype=jnp.int32,
-                )
-                svi_state, epoch_losses = _run_epoch(svi_state, steps_arr)
-            else:
-                svi_state, epoch_losses = _run_epoch(svi_state, epoch_steps)
+            factors_slice = kl_factors_full[global_step_offset : global_step_offset + epoch_steps]
+            svi_state, epoch_losses = _run_epoch(svi_state, factors_slice)
             global_step_offset += epoch_steps
 
             epoch_np = np.array(epoch_losses)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybandits"
-version = "6.0.1"
+version = "6.1.0"
 description = "Python Multi-Armed Bandit Library"
 authors = [
     "Dario d'Andrea <dariod@playtika.com>",
@@ -41,6 +41,7 @@ numpyro = [
     { version = "^0.16", python = ">=3.9,<3.11" },
     { version = "^0.20", python = ">=3.11" },
 ]
+optax = "^0.1"
 scikit-learn = "^1.1"
 optuna = "^3.6"
 tqdm = "^4"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1818,77 +1818,125 @@ def test_bnn_vi_update_with_categorical_features_updates_embeddings(
 # KL annealing
 # ---------------------------------------------------------------------------
 
+# Boundary-derived invalid fractions covering both sides of the (0, 1] range.
+_INVALID_KL_ANNEALING_FRACTIONS = (-1e-6, -0.1, -1.0, 1.0 + 1e-6, 1.5, 2.0)
 
-@pytest.mark.parametrize("bad_value", [-0.1, 1.5, 2.0, -1.0])
-def test_kl_annealing_fraction_range_validation(bad_value: float):
-    """Out-of-range kl_annealing_fraction raises ValueError at construction time."""
-    with pytest.raises(ValueError, match="kl_annealing_fraction"):
-        BayesianNeuralNetwork.cold_start(
-            n_features=2,
-            update_kwargs={"kl_annealing_fraction": bad_value},
+
+class TestKLAnnealing:
+    """Tests for the kl_annealing_fraction VI knob on BayesianNeuralNetwork."""
+
+    N_FEATURES = 2
+
+    @pytest.mark.parametrize("bad_value", _INVALID_KL_ANNEALING_FRACTIONS)
+    def test_kl_annealing_fraction_range_validation(self, bad_value: float):
+        """Out-of-range kl_annealing_fraction raises ValueError at construction time."""
+        with pytest.raises(ValueError, match="kl_annealing_fraction"):
+            BayesianNeuralNetwork.cold_start(
+                n_features=self.N_FEATURES,
+                update_kwargs={"kl_annealing_fraction": bad_value},
+            )
+
+    @pytest.mark.parametrize("kl_annealing_fraction", [None, 0.0])
+    def test_kl_annealing_inactive_no_scale_on_prior_sites(self, kl_annealing_fraction):
+        """Inactive values (None, 0.0) gate _kl_scale_ctx to nullcontext, so prior
+        sample sites carry no scale annotation in the model trace."""
+        import jax.numpy as jnp
+
+        n_samples = 10
+        context = jnp.asarray(np.random.rand(n_samples, self.N_FEATURES).astype(np.float32))
+        rewards = jnp.asarray(np.random.randint(0, 2, size=n_samples))
+
+        bnn = BayesianNeuralNetwork.cold_start(
+            n_features=self.N_FEATURES,
+            update_kwargs={"kl_annealing_fraction": kl_annealing_fraction},
+        )
+        model_fn = bnn._create_update_model()
+        trace = numpyro.handlers.trace(numpyro.handlers.seed(model_fn, rng_seed=0)).get_trace(context, rewards, 1.0)
+
+        # Prior sample sites = type 'sample' minus the likelihood site 'out'
+        # (which lives inside the data plate, outside the kl_scale ctx).
+        prior_sites = {n: s for n, s in trace.items() if s.get("type") == "sample" and n != "out"}
+        assert prior_sites, "expected at least one prior sample site in the trace"
+        for name, site in prior_sites.items():
+            assert site.get("scale") is None, (
+                f"kl_annealing_fraction={kl_annealing_fraction!r}: site {name!r} "
+                f"has unexpected scale={site.get('scale')!r}; expected None."
+            )
+
+    @pytest.mark.parametrize("factor", [0.1, 1.0])
+    def test_kl_annealing_active_scales_prior_sites(self, factor: float):
+        """When annealing is active, prior sample sites carry the factor passed
+        to model_fn as their cumulative scale (with kl_tau off, base = 1.0 so the
+        site scale equals the factor exactly)."""
+        import jax.numpy as jnp
+
+        n_samples = 10
+        context = jnp.asarray(np.random.rand(n_samples, self.N_FEATURES).astype(np.float32))
+        rewards = jnp.asarray(np.random.randint(0, 2, size=n_samples))
+
+        # Construction-time fraction only gates the active branch; the per-site
+        # scale comes from the runtime `factor` arg passed to model_fn below.
+        bnn = BayesianNeuralNetwork.cold_start(
+            n_features=self.N_FEATURES,
+            update_kwargs={"kl_annealing_fraction": float(np.random.uniform(0.01, 1.0))},
+        )
+        model_fn = bnn._create_update_model()
+        trace = numpyro.handlers.trace(numpyro.handlers.seed(model_fn, rng_seed=0)).get_trace(context, rewards, factor)
+
+        prior_sites = {n: s for n, s in trace.items() if s.get("type") == "sample" and n != "out"}
+        assert prior_sites, "expected at least one prior sample site in the trace"
+        for name, site in prior_sites.items():
+            assert site.get("scale") == pytest.approx(factor), (
+                f"factor={factor}: site {name!r} has scale={site.get('scale')!r}, expected {factor}."
+            )
+
+    def test_kl_annealing_interacts_with_kl_tau(self):
+        """kl_tau alone vs kl_tau + annealing produce distinct loss trajectories."""
+        random_seed = int(np.random.randint(0, 2**31 - 1))
+        kl_tau = float(np.random.uniform(0.01, 1.0))
+        # Lower bound 0.3: at num_steps=10, smaller fractions ramp the warmup
+        # window in too few steps to produce a divergent trajectory.
+        kl_annealing_fraction = float(np.random.uniform(0.3, 1.0))
+
+        n_samples = 20
+        context = np.random.rand(n_samples, self.N_FEATURES).astype(np.float32)
+        rewards = np.random.randint(0, 2, size=n_samples).tolist()
+
+        bnn_tau_only = BayesianNeuralNetwork.cold_start(
+            n_features=self.N_FEATURES,
+            update_kwargs={"num_steps": 10, "kl_tau": kl_tau},
+            random_seed=random_seed,
+        )
+        bnn_tau_anneal = BayesianNeuralNetwork.cold_start(
+            n_features=self.N_FEATURES,
+            update_kwargs={
+                "num_steps": 10,
+                "kl_tau": kl_tau,
+                "kl_annealing_fraction": kl_annealing_fraction,
+            },
+            random_seed=random_seed,
         )
 
+        bnn_tau_only.update(context=context, rewards=rewards)
+        bnn_tau_anneal.update(context=context, rewards=rewards)
 
-def test_kl_annealing_none_and_zero_equivalent():
-    """kl_annealing_fraction=None and =0.0 produce identical approx_history (both inactive)."""
-    np.random.seed(42)
-    context = np.random.rand(10, 2).astype(np.float32)
-    rewards = [1, 0, 1, 1, 0, 0, 1, 0, 1, 1]
+        # Both should complete without error and produce valid histories
+        assert bnn_tau_only._approx_history is not None
+        assert bnn_tau_anneal._approx_history is not None
+        # The KL weighting differs during warmup, so losses should diverge
+        assert not np.allclose(bnn_tau_only._approx_history, bnn_tau_anneal._approx_history)
 
-    bnn_none = BayesianNeuralNetwork.cold_start(
-        n_features=2,
-        update_kwargs={"num_steps": 6, "kl_annealing_fraction": None},
-        random_seed=7,
-    )
-    bnn_zero = BayesianNeuralNetwork.cold_start(
-        n_features=2,
-        update_kwargs={"num_steps": 6, "kl_annealing_fraction": 0.0},
-        random_seed=7,
-    )
+    def test_kl_annealing_fraction_serialization_round_trip(self):
+        """kl_annealing_fraction survives a model_dump / reconstruction round-trip."""
+        kl_annealing_fraction = float(np.random.uniform(0.01, 1.0))
+        bnn = BayesianNeuralNetwork.cold_start(
+            n_features=self.N_FEATURES,
+            update_kwargs={"num_steps": 4, "kl_annealing_fraction": kl_annealing_fraction},
+        )
+        dumped = bnn.apply_version_adjusted_method("model_dump", "dict")
+        # The value must be preserved in the serialised update_kwargs
+        assert dumped["update_kwargs"]["kl_annealing_fraction"] == kl_annealing_fraction
 
-    bnn_none.update(context=context, rewards=rewards)
-    bnn_zero.update(context=context, rewards=rewards)
-
-    np.testing.assert_array_equal(bnn_none._approx_history, bnn_zero._approx_history)
-
-
-def test_kl_annealing_interacts_with_kl_tau():
-    """kl_tau alone vs kl_tau + annealing produce distinct early-step loss trajectories."""
-    np.random.seed(0)
-    context = np.random.rand(20, 2).astype(np.float32)
-    rewards = [1, 0] * 10
-
-    bnn_tau_only = BayesianNeuralNetwork.cold_start(
-        n_features=2,
-        update_kwargs={"num_steps": 10, "kl_tau": 1.0},
-        random_seed=99,
-    )
-    bnn_tau_anneal = BayesianNeuralNetwork.cold_start(
-        n_features=2,
-        update_kwargs={"num_steps": 10, "kl_tau": 1.0, "kl_annealing_fraction": 0.5},
-        random_seed=99,
-    )
-
-    bnn_tau_only.update(context=context, rewards=rewards)
-    bnn_tau_anneal.update(context=context, rewards=rewards)
-
-    # Both should complete without error and produce valid histories
-    assert bnn_tau_only._approx_history is not None
-    assert bnn_tau_anneal._approx_history is not None
-    # The KL weighting differs during warmup, so losses should diverge
-    assert not np.allclose(bnn_tau_only._approx_history, bnn_tau_anneal._approx_history)
-
-
-def test_kl_annealing_fraction_serialization_round_trip():
-    """kl_annealing_fraction survives a model_dump / reconstruction round-trip."""
-    bnn = BayesianNeuralNetwork.cold_start(
-        n_features=2,
-        update_kwargs={"num_steps": 4, "kl_annealing_fraction": 0.3},
-    )
-    dumped = bnn.apply_version_adjusted_method("model_dump", "dict")
-    # The value must be preserved in the serialised update_kwargs
-    assert dumped["update_kwargs"]["kl_annealing_fraction"] == 0.3
-
-    # Reconstruct from the dump and verify the field is still present
-    bnn2 = BayesianNeuralNetwork(**dumped)
-    assert bnn2._update_kwargs["kl_annealing_fraction"] == 0.3
+        # Reconstruct from the dump and verify the field is still present
+        bnn2 = BayesianNeuralNetwork(**dumped)
+        assert bnn2._update_kwargs["kl_annealing_fraction"] == kl_annealing_fraction

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -843,6 +843,10 @@ def test_lr_scheduler_invalid_type_or_kwargs(
     num_particles=st.sampled_from((1, 3)),
     gradient_clip_norm=st.one_of(st.none(), st.floats(min_value=0.1, max_value=10.0)),
     kl_tau=st.one_of(st.none(), st.floats(min_value=0.01, max_value=1.0)),
+    kl_annealing_fraction=st.one_of(
+        st.none(),
+        st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+    ),
     lr_scheduler_type=st.sampled_from((None, "exponential_decay")),
     num_steps=st.just(4),
     n_features=st.just(2),
@@ -856,6 +860,7 @@ def test_vi_training_options(
     num_particles: int,
     gradient_clip_norm: Optional[float],
     kl_tau: Optional[float],
+    kl_annealing_fraction: Optional[float],
     lr_scheduler_type: Optional[str],
     num_steps: int,
     n_features: int,
@@ -864,7 +869,7 @@ def test_vi_training_options(
     decay_rate: float,
     transition_steps_factor: int,
 ) -> None:
-    """Test that VI training options (num_particles, gradient_clip_norm, kl_tau, lr_scheduler) compose correctly."""
+    """Test that VI training options (num_particles, gradient_clip_norm, kl_tau, kl_annealing_fraction, lr_scheduler) compose correctly."""
     update_kwargs: dict = {
         "num_steps": num_steps,
         "optimizer_type": optimizer_type,
@@ -874,6 +879,8 @@ def test_vi_training_options(
         update_kwargs["gradient_clip_norm"] = gradient_clip_norm
     if kl_tau is not None:
         update_kwargs["kl_tau"] = kl_tau
+    if kl_annealing_fraction is not None:
+        update_kwargs["kl_annealing_fraction"] = kl_annealing_fraction
     if lr_scheduler_type is not None:
         update_kwargs["lr_scheduler_type"] = lr_scheduler_type
         update_kwargs["lr_scheduler_kwargs"] = {
@@ -1805,3 +1812,83 @@ def test_bnn_vi_update_with_categorical_features_updates_embeddings(
     # Reset should restore initial embeddings
     bnn._reset()
     assert bnn.model_params.embedding_params.embeddings[0].mu == init_mu
+
+
+# ---------------------------------------------------------------------------
+# KL annealing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_value", [-0.1, 1.5, 2.0, -1.0])
+def test_kl_annealing_fraction_range_validation(bad_value: float):
+    """Out-of-range kl_annealing_fraction raises ValueError at construction time."""
+    with pytest.raises(ValueError, match="kl_annealing_fraction"):
+        BayesianNeuralNetwork.cold_start(
+            n_features=2,
+            update_kwargs={"kl_annealing_fraction": bad_value},
+        )
+
+
+def test_kl_annealing_none_and_zero_equivalent():
+    """kl_annealing_fraction=None and =0.0 produce identical approx_history (both inactive)."""
+    np.random.seed(42)
+    context = np.random.rand(10, 2).astype(np.float32)
+    rewards = [1, 0, 1, 1, 0, 0, 1, 0, 1, 1]
+
+    bnn_none = BayesianNeuralNetwork.cold_start(
+        n_features=2,
+        update_kwargs={"num_steps": 6, "kl_annealing_fraction": None},
+        random_seed=7,
+    )
+    bnn_zero = BayesianNeuralNetwork.cold_start(
+        n_features=2,
+        update_kwargs={"num_steps": 6, "kl_annealing_fraction": 0.0},
+        random_seed=7,
+    )
+
+    bnn_none.update(context=context, rewards=rewards)
+    bnn_zero.update(context=context, rewards=rewards)
+
+    np.testing.assert_array_equal(bnn_none._approx_history, bnn_zero._approx_history)
+
+
+def test_kl_annealing_interacts_with_kl_tau():
+    """kl_tau alone vs kl_tau + annealing produce distinct early-step loss trajectories."""
+    np.random.seed(0)
+    context = np.random.rand(20, 2).astype(np.float32)
+    rewards = [1, 0] * 10
+
+    bnn_tau_only = BayesianNeuralNetwork.cold_start(
+        n_features=2,
+        update_kwargs={"num_steps": 10, "kl_tau": 1.0},
+        random_seed=99,
+    )
+    bnn_tau_anneal = BayesianNeuralNetwork.cold_start(
+        n_features=2,
+        update_kwargs={"num_steps": 10, "kl_tau": 1.0, "kl_annealing_fraction": 0.5},
+        random_seed=99,
+    )
+
+    bnn_tau_only.update(context=context, rewards=rewards)
+    bnn_tau_anneal.update(context=context, rewards=rewards)
+
+    # Both should complete without error and produce valid histories
+    assert bnn_tau_only._approx_history is not None
+    assert bnn_tau_anneal._approx_history is not None
+    # The KL weighting differs during warmup, so losses should diverge
+    assert not np.allclose(bnn_tau_only._approx_history, bnn_tau_anneal._approx_history)
+
+
+def test_kl_annealing_fraction_serialization_round_trip():
+    """kl_annealing_fraction survives a model_dump / reconstruction round-trip."""
+    bnn = BayesianNeuralNetwork.cold_start(
+        n_features=2,
+        update_kwargs={"num_steps": 4, "kl_annealing_fraction": 0.3},
+    )
+    dumped = bnn.apply_version_adjusted_method("model_dump", "dict")
+    # The value must be preserved in the serialised update_kwargs
+    assert dumped["update_kwargs"]["kl_annealing_fraction"] == 0.3
+
+    # Reconstruct from the dump and verify the field is still present
+    bnn2 = BayesianNeuralNetwork(**dumped)
+    assert bnn2._update_kwargs["kl_annealing_fraction"] == 0.3

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -46,6 +46,7 @@ from pybandits.model import (
     EmbeddingParams,
     FeaturesConfig,
     NormalArray,
+    OptaxKind,
     StudentTArray,
     UpdateMethods,
 )
@@ -503,7 +504,7 @@ def test_bnn_vi_update(
             assert isinstance(bnn.model_params.bnn_layer_params[layer_ind].weight, expected_array)
             assert isinstance(bnn.model_params.bnn_layer_params[layer_ind].bias, expected_array)
 
-    rewards = np.random.choice([0, 1], size=n_samples).tolist()
+    rewards = _make_random_rewards(n_samples)
 
     # context is numpy array
     context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
@@ -591,7 +592,7 @@ def test_bnn_vi_update_parameters(
         update_kwargs=update_kwargs,
     )
 
-    model_fn = bnn.create_update_model()
+    model_fn = bnn._create_update_model()
     assert callable(model_fn)
 
     # Optimizer is always set for VI (built from defaults or user override)
@@ -607,13 +608,11 @@ def test_bnn_vi_update_parameters(
 @given(
     n_features=st.just(2),
     hidden_dim_list=st.just([1]),
-    n_samples=st.just(5),
     update_method=st.just("MCMC"),
 )
 def test_bnn_mcmc_update_parameters(
     n_features: int,
     hidden_dim_list: list[int],
-    n_samples: int,
     update_method: UpdateMethods,
 ) -> None:
     """Test BNN MCMC update with valid parameters (no batch_size, optimizer, or early_stopping)."""
@@ -625,7 +624,7 @@ def test_bnn_mcmc_update_parameters(
         update_kwargs={},
     )
 
-    model_fn = bnn.create_update_model()
+    model_fn = bnn._create_update_model()
     assert callable(model_fn)
 
 
@@ -737,6 +736,17 @@ def test_invalid_optimizer_kwargs(
         )
 
 
+def test_optax_kind_literal_matches_optax_return_types_keys() -> None:
+    """Verify that OptaxKind Literal values exactly match _optax_return_types keys."""
+    from typing import get_args
+
+    literal_values = set(get_args(OptaxKind))
+    classvar_keys = set(BayesianNeuralNetwork._optax_return_types.keys())
+    assert literal_values == classvar_keys, (
+        f"OptaxKind Literal {literal_values} does not match _optax_return_types keys {classvar_keys}"
+    )
+
+
 @pytest.mark.parametrize(
     "early_stopping_kwargs",
     [
@@ -759,6 +769,132 @@ def test_invalid_early_stopping_kwargs(
         )
 
 
+@pytest.mark.parametrize(
+    "optimizer_type,optimizer_kwargs,lr_scheduler_type,lr_scheduler_kwargs",
+    [
+        ("sgd", {"step_size": 0.01}, "exponential_decay", {"transition_steps": 100, "decay_rate": 0.9}),
+        ("adam", {"step_size": 0.01}, "exponential_decay", {"transition_steps": 50, "decay_rate": 0.95}),
+        ("sgd", {"step_size": 0.01, "momentum": 0.9}, "cosine_decay_schedule", {"decay_steps": 100}),
+        (
+            "adam",
+            {"step_size": 0.01},
+            "exponential_decay",
+            {"transition_steps": 100, "decay_rate": 0.9, "staircase": True},
+        ),
+        (
+            "sgd",
+            {"step_size": 0.01},
+            "warmup_cosine_decay_schedule",
+            {"peak_value": 0.05, "warmup_steps": 10, "decay_steps": 100},
+        ),
+        ("adam", {"step_size": 0.01}, "linear_schedule", {"end_value": 1e-5, "transition_steps": 200}),
+    ],
+)
+def test_lr_scheduler_valid(
+    optimizer_type: str,
+    optimizer_kwargs: dict,
+    lr_scheduler_type: str,
+    lr_scheduler_kwargs: dict,
+    n_features: int = 2,
+) -> None:
+    """Test that valid lr_scheduler_type/lr_scheduler_kwargs build an optimizer successfully."""
+    bnn = BayesianNeuralNetwork.cold_start(
+        n_features=n_features,
+        update_method="VI",
+        update_kwargs={
+            "optimizer_type": optimizer_type,
+            "optimizer_kwargs": optimizer_kwargs,
+            "lr_scheduler_type": lr_scheduler_type,
+            "lr_scheduler_kwargs": lr_scheduler_kwargs,
+        },
+    )
+    assert bnn._obj_optimizer is not None
+
+
+@pytest.mark.parametrize(
+    "lr_scheduler_type,lr_scheduler_kwargs",
+    [
+        (
+            "dummy_scheduler",
+            {},
+        ),
+        ("exponential_decay", {"invalid_kwarg": 1}),
+    ],
+)
+def test_lr_scheduler_invalid_type_or_kwargs(
+    lr_scheduler_type: str,
+    lr_scheduler_kwargs: dict,
+    n_features: int = 2,
+) -> None:
+    """Test that invalid lr_scheduler_type or lr_scheduler_kwargs raise ValueError."""
+    with pytest.raises((TypeError, ValueError)):
+        BayesianNeuralNetwork.cold_start(
+            n_features=n_features,
+            update_method="VI",
+            update_kwargs={
+                "lr_scheduler_type": lr_scheduler_type,
+                "lr_scheduler_kwargs": lr_scheduler_kwargs,
+            },
+        )
+
+
+@given(
+    optimizer_type=st.sampled_from(("sgd", "adam")),
+    num_particles=st.sampled_from((1, 3)),
+    gradient_clip_norm=st.one_of(st.none(), st.floats(min_value=0.1, max_value=10.0)),
+    kl_tau=st.one_of(st.none(), st.floats(min_value=0.01, max_value=1.0)),
+    lr_scheduler_type=st.sampled_from((None, "exponential_decay")),
+    num_steps=st.just(4),
+    n_features=st.just(2),
+    update_method=st.just("VI"),
+    n_samples=st.just(5),
+    decay_rate=st.just(0.9),
+    transition_steps_factor=st.just(2),
+)
+def test_vi_training_options(
+    optimizer_type: str,
+    num_particles: int,
+    gradient_clip_norm: Optional[float],
+    kl_tau: Optional[float],
+    lr_scheduler_type: Optional[str],
+    num_steps: int,
+    n_features: int,
+    update_method: UpdateMethods,
+    n_samples: int,
+    decay_rate: float,
+    transition_steps_factor: int,
+) -> None:
+    """Test that VI training options (num_particles, gradient_clip_norm, kl_tau, lr_scheduler) compose correctly."""
+    update_kwargs: dict = {
+        "num_steps": num_steps,
+        "optimizer_type": optimizer_type,
+        "num_particles": num_particles,
+    }
+    if gradient_clip_norm is not None:
+        update_kwargs["gradient_clip_norm"] = gradient_clip_norm
+    if kl_tau is not None:
+        update_kwargs["kl_tau"] = kl_tau
+    if lr_scheduler_type is not None:
+        update_kwargs["lr_scheduler_type"] = lr_scheduler_type
+        update_kwargs["lr_scheduler_kwargs"] = {
+            "transition_steps": num_steps // transition_steps_factor,
+            "decay_rate": decay_rate,
+        }
+
+    bnn = BayesianNeuralNetwork.cold_start(
+        n_features=n_features,
+        update_method=update_method,
+        update_kwargs=update_kwargs,
+    )
+    context = np.random.rand(n_samples, n_features).astype(np.float32)
+    rewards = _make_random_rewards(n_samples)
+    bnn.update(context=context, rewards=rewards)
+    result = bnn.sample_proba(context=context)
+    assert len(result) == n_samples
+    assert all(0 <= p[0] <= 1 for p in result), f"Probabilities out of [0,1]: {result}"
+    assert all(np.isfinite(p[1]) for p in result), f"Non-finite weights: {result}"
+
+
 @given(
     n_features=st.just(2),
     update_method=st.just("VI"),
@@ -777,13 +913,10 @@ def test_epochs_and_num_steps_warns(n_features: int, update_method: UpdateMethod
 
 @pytest.mark.parametrize("n_features", [1, 2])
 def test_bnn_mcmc_update(
-    n_features,
-    hidden_dim_list=(1,),
-    n_samples=3,
-    update_method="MCMC",
-    update_kwargs={"num_warmup": 2, "num_samples": 2, "num_chains": 1},
+    n_features, hidden_dim_list=(1,), n_samples=3, update_method="MCMC", num_warmup=1, mcmc_num_samples=2, num_chains=1
 ):
     hidden_dim_list = list(hidden_dim_list)
+    update_kwargs = {"num_warmup": num_warmup, "num_samples": mcmc_num_samples, "num_chains": num_chains}
 
     def update(context: np.ndarray, rewards: list):
         bnn = BayesianNeuralNetwork.cold_start(
@@ -813,7 +946,7 @@ def test_bnn_mcmc_update(
                 assert np.all(layer_w[param] != layer_w_init[param])
                 assert np.all(layer_b[param] != layer_b_init[param])
 
-    rewards = np.random.choice([0, 1], size=n_samples).tolist()
+    rewards = _make_random_rewards(n_samples)
     context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
     update(context=context, rewards=rewards)
 
@@ -860,7 +993,7 @@ def test_bnn_fullrank_advi_update(n_features, hidden_dim_list=(1,), n_samples=5,
                 assert np.all(layer_w[param] != layer_w_init[param])
                 assert np.all(layer_b[param] != layer_b_init[param])
 
-    rewards = np.random.choice([0, 1], size=n_samples).tolist()
+    rewards = _make_random_rewards(n_samples)
     context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
     update(context=context, rewards=rewards)
 
@@ -1429,13 +1562,18 @@ def test_embedding_params_init_is_frozen_copy(n_features, cardinality, embedding
 # ---------------------------------------------------------------------------
 
 
-def _make_bnn_with_categoricals(n_features=2, categorical_features=None, dist_type="studentt", hidden_dim_list=None):
+def _make_bnn_with_categoricals(
+    n_features=2, categorical_features=None, dist_type="studentt", hidden_dim_list=None, update_kwargs=None
+):
+    kwargs = {"epochs": 1}
+    if update_kwargs:
+        kwargs.update(update_kwargs)
     return BayesianNeuralNetwork.cold_start(
         n_features=n_features,
         categorical_features=categorical_features or {1: 3},
         hidden_dim_list=hidden_dim_list or [8],
         dist_type=dist_type,
-        update_kwargs={"epochs": 1},
+        update_kwargs=kwargs,
     )
 
 
@@ -1571,7 +1709,7 @@ def test_create_update_model_contains_embedding_variable(n_features, cardinality
     cat_col = n_features - 1
     categorical_features = {cat_col: cardinality}
     bnn = _make_bnn_with_categoricals(n_features=n_features, categorical_features=categorical_features)
-    model_fn = bnn.create_update_model()
+    model_fn = bnn._create_update_model()
     context = jnp.array(_make_categorical_context(n_samples, n_features, categorical_features), dtype=jnp.float32)
     rewards = jnp.array(_make_random_rewards(n_samples), dtype=jnp.int32)
     trace = numpyro.handlers.trace(numpyro.handlers.seed(model_fn, rng_seed=0)).get_trace(context, rewards)
@@ -1591,8 +1729,10 @@ def test_create_update_model_minibatch_with_categoricals(n_features, cardinality
 
     cat_col = n_features - 1
     categorical_features = {cat_col: cardinality}
-    bnn = _make_bnn_with_categoricals(n_features=n_features, categorical_features=categorical_features)
-    model_fn = bnn.create_update_model(batch_size=batch_size)
+    bnn = _make_bnn_with_categoricals(
+        n_features=n_features, categorical_features=categorical_features, update_kwargs={"batch_size": batch_size}
+    )
+    model_fn = bnn._create_update_model()
     context = jnp.array(_make_categorical_context(n_samples, n_features, categorical_features), dtype=jnp.float32)
     rewards = jnp.array(_make_random_rewards(n_samples), dtype=jnp.int32)
     trace = numpyro.handlers.trace(numpyro.handlers.seed(model_fn, rng_seed=0)).get_trace(context, rewards)
@@ -1633,16 +1773,16 @@ def test_reset_restores_embedding_params(n_features, cardinality):
 # ---------------------------------------------------------------------------
 
 
-@settings(deadline=None, max_examples=5)
 @given(
     dist_type=st.sampled_from(["studentt", "normal"]),
     n_features=st.integers(min_value=2, max_value=4),
     cardinality=st.integers(min_value=2, max_value=6),
     hidden_dim_list=st.lists(st.integers(min_value=4, max_value=8), min_size=1, max_size=1),
     n_samples=st.integers(min_value=4, max_value=10),
+    num_steps=st.just(5),
 )
 def test_bnn_vi_update_with_categorical_features_updates_embeddings(
-    dist_type, n_features, cardinality, hidden_dim_list, n_samples
+    dist_type, n_features, cardinality, hidden_dim_list, n_samples, num_steps
 ):
     cat_col = n_features - 1
     categorical_features = {cat_col: cardinality}
@@ -1651,7 +1791,7 @@ def test_bnn_vi_update_with_categorical_features_updates_embeddings(
         categorical_features=categorical_features,
         hidden_dim_list=hidden_dim_list,
         dist_type=dist_type,
-        update_kwargs={"num_steps": 10},
+        update_kwargs={"num_steps": num_steps},
     )
     context = _make_categorical_context(n_samples, n_features, categorical_features)
     rewards = _make_random_rewards(n_samples)


### PR DESCRIPTION
 # Add KL annealing to BNN VI training                                                                                                                                                                                                 
                                                                                                                                                                                                                                        
  > **Note:** This PR is based on the VI training enhancements from PR #132 (`num_particles`, gradient clipping, `kl_tau`, lr scheduler) and should be rebased & merged only after #132 lands on `develop`.                                       
                                                                                                                                                                                                                                        
  ## Summary                                                                                                                                                                                                                            
                                                                                                   
  - Introduces `kl_annealing_fraction` as a new VI `update_kwargs` parameter for `BayesianNeuralNetwork`. When set, the KL divergence term in the ELBO is linearly warmed up from `0 → 1` over the first `kl_annealing_fraction *       
  total_steps` training steps, then held at `1.0` for the remainder.
  - The annealing factor is threaded as a traced JAX scalar through the `model` and `guide` callables, so the warm-up schedule runs entirely inside `lax.scan` with no Python-loop overhead or XLA recompilation per step.              
  - Composes multiplicatively with the existing `kl_tau` temperature scale when both are active: `effective_scale = kl_base_factor * kl_annealing_factor`.                                                                              
  - `kl_annealing_fraction=None` and `=0.0` are both treated as inactive (no-op), validated at construction time.                                                                                                                       
                                                                                                                                                                                                                                        
  ## Test plan                                                                                                                                                                                                                          
                                                                                                                                                                                                                                        
  - [ ] Validation rejects values outside `[0, 1]`                                                 
  - [ ] `None` and `0.0` produce equivalent training behavior (both inactive paths)
  - [ ] Hypothesis-based test covers the full cross-product with existing VI options: `num_particles`, `gradient_clip_norm`, `kl_tau`, `lr_scheduler`  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optax optimizer support with optional LR scheduling, gradient clipping, and configurable num_particles.
  * Per-step KL annealing for variational inference with kl_tau and kl_annealing_fraction controls.

* **Chores**
  * Version bumped to 6.1.0.
  * Added Optax as a runtime dependency.

* **Tests**
  * Expanded test coverage for optimizer/scheduler combinations, VI training options, and KL-annealing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->