### PR TITLE
Add ParameterizedScaleAutoNormal ADVI guide with per-site scale init

### DIFF
--- a/.cursor/rules/test-cost-co.mdc
+++ b/.cursor/rules/test-cost-co.mdc
@@ -1,5 +1,0 @@
----
-alwaysApply: true
----
-
-test_cost_control_logic_callable_cost_and_proba

--- a/.github/workflows/pull_request_style_check.yml
+++ b/.github/workflows/pull_request_style_check.yml
@@ -22,24 +22,3 @@ jobs:
         with:
           hasSome: bug, documentation, enhancement, skip-changelog
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-
-  single-commit-check:
-    name: check for single commit in PR
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Get number of commits in the PR
-        id: commit_count
-        run: |
-          COMMITS=$(gh pr view ${{ github.event.pull_request.number }} --json commits -q ".commits | length")
-          echo "Number of commits: $COMMITS"
-          echo "count=$COMMITS" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Fail if more than one commit
-        if: steps.commit_count.outputs.count != '1'
-        run: |
-          echo "PR must have exactly one commit. Found ${{ steps.commit_count.outputs.count }}."
-          exit 1

--- a/pybandits/model.py
+++ b/pybandits/model.py
@@ -22,7 +22,7 @@
 
 import warnings
 from abc import ABC, abstractmethod
-from contextlib import nullcontext
+from contextlib import ExitStack, nullcontext
 from copy import deepcopy
 from math import ceil
 from types import ModuleType
@@ -39,9 +39,12 @@ from numpy import sqrt
 from numpyro.distributions import Bernoulli as NumpyroBernoulli
 from numpyro.distributions import Normal as NumpyroNormal
 from numpyro.distributions import StudentT as NumpyroStudentT
+from numpyro.distributions import constraints
+from numpyro.distributions.transforms import biject_to
 from numpyro.infer import MCMC, NUTS, SVI, Trace_ELBO, TraceMeanField_ELBO
 from numpyro.infer.autoguide import AutoMultivariateNormal, AutoNormal
-from numpyro.infer.initialization import init_to_median, init_to_value
+from numpyro.infer.initialization import init_to_median, init_to_uniform, init_to_value
+from numpyro.infer.util import helpful_support_errors
 from scipy.special import erf
 from tqdm import trange
 from typing_extensions import Self
@@ -299,13 +302,13 @@ class BaseLocationScaleArray(PyBanditsBaseModel, ABC):
     ----------
     mu : Union[List[float], List[List[float]]]
         The mean values of the distributions. Can be a 1D (for the layer bias term) or 2D list (for the layer weight term).
-    sigma : Union[List[NonNegativeFloat], List[List[NonNegativeFloat]]]
-        The scale (standard deviation) values of the distributions. Must be non-negative.
+    sigma : Union[List[PositiveFloat], List[List[PositiveFloat]]]
+        The scale (standard deviation) values of the distributions. Must be strictly positive.
         Can be a 1D or 2D list.
     """
 
     mu: Union[List[float], List[List[float]]]
-    sigma: Union[List[NonNegativeFloat], List[List[NonNegativeFloat]]]
+    sigma: Union[List[PositiveFloat], List[List[PositiveFloat]]]
 
     _mu_array: np.ndarray = PrivateAttr()
     _sigma_array: np.ndarray = PrivateAttr()
@@ -1017,6 +1020,174 @@ class EarlyStopping(PyBanditsBaseModel):
         return self._no_improvement_count >= self.patience
 
 
+class ParameterizedScaleAutoNormal(AutoNormal):
+    """AutoNormal guide with per-site scale initialization via a callable.
+
+    Extends :class:`~numpyro.infer.autoguide.AutoNormal` so that the initial
+    variational scale of every latent site can be set individually rather than
+    sharing a single global scalar.  All other behaviour (diagonal-normal
+    approximation, ``init_loc_fn``, plate handling, constrained-support
+    transforms) is inherited unchanged from the parent.
+
+    Two modes are supported:
+
+    * **Per-site** (``init_scale_fn`` provided): the callable is invoked once
+      per latent site and must return a value broadcast-compatible with that
+      site's shape.  ``init_scale`` is ignored in this mode.
+    * **Scalar fallback** (``init_scale_fn=None``): behaves identically to
+      :class:`~numpyro.infer.autoguide.AutoNormal` with the given scalar
+      ``init_scale``.
+
+    Parameters
+    ----------
+    model : callable
+        The NumPyro model whose posterior is being approximated.
+    prefix : str, optional
+        String prefix prepended to all variational parameter names, by default
+        ``"auto"``.
+    init_loc_fn : callable, optional
+        Per-site initialisation strategy for the location parameters; see
+        :mod:`numpyro.infer.initialization`.  Defaults to
+        :func:`~numpyro.infer.initialization.init_to_uniform`.
+    init_scale : float, optional
+        Global initial scale used when ``init_scale_fn`` is ``None``, by
+        default ``0.1``.
+    init_scale_fn : Optional[Callable[[str], Union[float, np.ndarray, jax.Array]]], optional
+        Callable with signature ``(site_name: str) -> scale`` where ``scale``
+        is a scalar or an array broadcast-compatible with the site's shape.
+        When provided, ``init_scale`` is ignored.  ``None`` (default) falls
+        back to the scalar ``init_scale``.
+    create_plates : callable, optional
+        Optional function that creates :func:`numpyro.plate` contexts; passed
+        directly to the parent ``AutoNormal.__init__``.
+
+    Raises
+    ------
+    ValueError
+        If ``init_scale_fn`` is provided but is not callable.
+
+    Examples
+    --------
+    Seed each BNN weight/bias site from the current posterior sigma stored in
+    ``model_params``::
+
+        site_sigmas = {
+            "weight_0": layer_params.weight.params["sigma"],
+            "bias_0":   layer_params.bias.params["sigma"],
+        }
+        guide = ParameterizedScaleAutoNormal(
+            numpyro_model,
+            init_loc_fn=init_to_value(values={"weight_0": w_mu, "bias_0": b_mu}),
+            init_scale_fn=lambda name: site_sigmas.get(name, fallback_sigma),
+        )
+    """
+
+    def __init__(
+        self,
+        model: Callable,
+        *,
+        prefix: str = "auto",
+        init_loc_fn: Callable = init_to_uniform,
+        init_scale: float = 0.1,
+        init_scale_fn: Optional[Callable[[str], Union[float, np.ndarray, jax.Array]]] = None,
+        create_plates: Optional[Callable] = None,
+    ) -> None:
+        if init_scale_fn is not None and not callable(init_scale_fn):
+            raise ValueError("init_scale_fn must be callable or None.")
+        self._init_scale_fn = init_scale_fn
+        super().__init__(
+            model,
+            prefix=prefix,
+            init_loc_fn=init_loc_fn,
+            init_scale=init_scale,
+            create_plates=create_plates,
+        )
+
+    def _get_site_init_scale(self, name: str, init_loc: jax.Array) -> jax.Array:
+        """Return the initial scale for ``name``, broadcast to match ``init_loc``.
+
+        Parameters
+        ----------
+        name : str
+            NumPyro site name.
+        init_loc : jax.Array
+            Initialised location array for this site; used only to determine
+            the required output shape.
+
+        Returns
+        -------
+        jax.Array
+            Scale array with the same shape as ``init_loc``.
+        """
+        if self._init_scale_fn is not None:
+            raw = self._init_scale_fn(name)
+            return jnp.broadcast_to(jnp.array(raw), jnp.shape(init_loc))
+        return jnp.full(jnp.shape(init_loc), self._init_scale)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Dict[str, jax.Array]:
+        """Sample the variational posterior and register variational parameters.
+
+        On the first call the prototype trace is built via
+        ``_setup_prototype``; subsequent calls reuse it.  For every unobserved
+        sample site a ``Normal(loc, scale)`` variational distribution is
+        registered via :func:`numpyro.param`.  The initial scale is provided
+        by :meth:`_get_site_init_scale`; for constrained sites the Normal is
+        wrapped in a :class:`~numpyro.distributions.TransformedDistribution`
+        using the site's bijection.
+
+        Parameters
+        ----------
+        *args : Any
+            Positional arguments forwarded to the model (used only during
+            prototype construction).
+        **kwargs : Any
+            Keyword arguments forwarded to the model (used only during
+            prototype construction).
+
+        Returns
+        -------
+        Dict[str, jax.Array]
+            Mapping from site name to the sampled value in the *constrained*
+            space.
+        """
+        if self.prototype_trace is None:
+            self._setup_prototype(*args, **kwargs)
+
+        plates = self._create_plates(*args, **kwargs)
+        result: Dict[str, jax.Array] = {}
+        for name, site in self.prototype_trace.items():
+            if site["type"] != "sample" or site["is_observed"]:
+                continue
+
+            event_dim = self._event_dims[name]
+            init_loc = self._init_locs[name]
+            with ExitStack() as stack:
+                for frame in site["cond_indep_stack"]:
+                    stack.enter_context(plates[frame.name])
+
+                site_loc = numpyro.param("{}_{}_loc".format(name, self.prefix), init_loc, event_dim=event_dim)
+                site_scale = numpyro.param(
+                    "{}_{}_scale".format(name, self.prefix),
+                    self._get_site_init_scale(name, init_loc),
+                    constraint=self.scale_constraint,
+                    event_dim=event_dim,
+                )
+
+                site_fn = npdist.Normal(site_loc, site_scale).to_event(event_dim)
+                if site["fn"].support is constraints.real or (
+                    isinstance(site["fn"].support, constraints.independent)
+                    and site["fn"].support.base_constraint is constraints.real
+                ):
+                    result[name] = numpyro.sample(name, site_fn)
+                else:
+                    with helpful_support_errors(site):
+                        transform = biject_to(site["fn"].support)
+                    guide_dist = npdist.TransformedDistribution(site_fn, transform)
+                    result[name] = numpyro.sample(name, guide_dist)
+
+        return result
+
+
 class BaseBayesianNeuralNetwork(Model, ABC):
     """Bayesian Neural Network model for binary classification.
 
@@ -1028,6 +1199,12 @@ class BaseBayesianNeuralNetwork(Model, ABC):
     ----------
     Bayesian Learning for Neural Networks (Radford M. Neal, 1995)
     https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=db869fa192a3222ae4f2d766674a378e47013b1b
+
+    Weight Uncertainty in Neural Networks (Blundell, Cornebise, Kavukcuoglu, Wierstra, ICML 2015)
+    https://arxiv.org/abs/1505.05424
+
+    Variational Continual Learning (Nguyen, Li, Bui, Turner, ICLR 2018)
+    https://arxiv.org/abs/1710.10628
 
     Parameters
     ----------
@@ -1093,7 +1270,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
     ]
     _distribution_mapping: ClassVar[Dict[str, type]] = {"normal": NormalArray, "studentt": StudentTArray}
     _embedding_dim_divisor: ClassVar[int] = 4
-    _min_vi_sigma: ClassVar[float] = 1e-6
+    _min_sigma: ClassVar[float] = 1e-6
     _supported_optimizers: ClassVar[dict] = {
         "sgd": noptim.SGD,
         "momentum": noptim.Momentum,
@@ -1142,7 +1319,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
     )
 
     _vi_method_config: ClassVar[dict] = {
-        "advi": {"guide": AutoNormal, "loss": TraceMeanField_ELBO},
+        "advi": {"guide": ParameterizedScaleAutoNormal, "loss": TraceMeanField_ELBO},
         "fullrank_advi": {"guide": AutoMultivariateNormal, "loss": Trace_ELBO},
     }
 
@@ -1870,21 +2047,28 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             emb_var_name = self.get_embedding_var_name(i)
             emb_values = np.array(samples[emb_var_name])
             emb_mu = np.mean(emb_values, axis=0)
-            emb_sigma = np.std(emb_values, axis=0)
+            emb_sigma = np.maximum(np.std(emb_values, axis=0), self._min_sigma)
             updated_embeddings.append(orig_emb.with_dist_parameters(mu=emb_mu.tolist(), sigma=emb_sigma.tolist()))
         self.model_params.embedding_params.embeddings = updated_embeddings
 
     def _build_svi_guide_init(self) -> tuple:
-        """Build ``init_loc_fn`` and ``init_scale`` for the AutoNormal/AutoMultivariateNormal guide.
+        """Build ``init_loc_fn`` and ``init_scale_fn`` for the SVI guide.
 
         ``init_loc_fn`` is ``init_to_value`` seeded with the current model mu values, unless all
         mu values are zero (cold start), in which case ``init_to_median`` is used instead.
-        ``init_scale`` is the mean of all current sigma values so the guide scale starts close to
-        the model's posterior width rather than at the AutoNormal default of 0.1.
+        ``init_scale_fn`` maps each site name to its current sigma array so the
+        :class:`ParameterizedScaleAutoNormal` guide starts with the correct per-parameter width.
+        Unknown site names (e.g. for fullrank_advi's scalar fallback) return the global avg sigma.
+
+        Returns
+        -------
+        tuple
+            ``(init_loc_fn, init_scale_fn)``
         """
         values: dict = {}
         all_mus: list = []
         all_sigmas: list = []
+        site_sigmas: dict = {}
 
         for layer_ind, layer_params in enumerate(self.model_params.bnn_layer_params):
             w_name, b_name = self.get_layer_params_name(layer_ind)
@@ -1894,6 +2078,8 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             all_mus.append(layer_params.bias.params["mu"].ravel())
             all_sigmas.append(layer_params.weight.params["sigma"].ravel())
             all_sigmas.append(layer_params.bias.params["sigma"].ravel())
+            site_sigmas[w_name] = layer_params.weight.params["sigma"]
+            site_sigmas[b_name] = layer_params.bias.params["sigma"]
 
         if self.model_params.embedding_params is not None:
             for i, emb in enumerate(self.model_params.embedding_params.embeddings):
@@ -1901,11 +2087,14 @@ class BaseBayesianNeuralNetwork(Model, ABC):
                 values[emb_name] = jnp.array(emb.params["mu"])
                 all_mus.append(emb.params["mu"].ravel())
                 all_sigmas.append(emb.params["sigma"].ravel())
+                site_sigmas[emb_name] = emb.params["sigma"]
 
         all_mus_flat = np.concatenate(all_mus)
         init_loc_fn = init_to_median if np.all(all_mus_flat == 0) else init_to_value(values=values)
-        init_scale = float(np.mean(np.concatenate(all_sigmas)))
-        return init_loc_fn, init_scale
+        avg_sigma = float(max(np.mean(np.concatenate(all_sigmas)), self._min_sigma))
+        site_sigmas = {name: np.maximum(sigma, self._min_sigma) for name, sigma in site_sigmas.items()}
+        init_scale_fn = lambda name: site_sigmas.get(name, avg_sigma)  # noqa: E731
+        return init_loc_fn, init_scale_fn
 
     def _run_svi_training_loop(self, x_jnp: jnp.ndarray, y_jnp: jnp.ndarray, n_samples: int) -> tuple:
         """
@@ -1948,8 +2137,16 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         # Set up VI method (guide + loss) dynamically
         vi_method = self._update_kwargs["method"]
         method_config = self._vi_method_config[vi_method]
-        init_loc_fn, init_scale = self._build_svi_guide_init()
-        guide = method_config["guide"](_model, init_loc_fn=init_loc_fn, init_scale=init_scale)
+        init_loc_fn, init_scale_fn = self._build_svi_guide_init()
+        if vi_method == "advi":
+            guide = ParameterizedScaleAutoNormal(
+                _model,
+                init_loc_fn=init_loc_fn,
+                init_scale_fn=init_scale_fn,
+            )
+        else:
+            # fullrank_advi needs a scalar; use the avg sigma via the unknown-site fallback
+            guide = method_config["guide"](_model, init_loc_fn=init_loc_fn, init_scale=init_scale_fn(""))
         loss = method_config["loss"]()
         svi = SVI(_model, guide, self._obj_optimizer, loss=loss)
 
@@ -2030,7 +2227,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         # AutoNormal stores per-site: {name}_auto_loc (mean) and {name}_auto_scale (already-constrained std)
         site_mu = {k.removesuffix("_auto_loc"): v for k, v in params.items() if k.endswith("_auto_loc")}
         site_sigma = {
-            k.removesuffix("_auto_scale"): np.maximum(v, self._min_vi_sigma)
+            k.removesuffix("_auto_scale"): np.maximum(v, self._min_sigma)
             for k, v in params.items()
             if k.endswith("_auto_scale")
         }
@@ -2163,9 +2360,9 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             b_values = np.array(samples[bias_layer_params_name])
 
             w_mu = np.mean(w_values, axis=0)
-            w_sigma = np.std(w_values, axis=0)
+            w_sigma = np.maximum(np.std(w_values, axis=0), self._min_sigma)
             b_mu = np.mean(b_values, axis=0)
-            b_sigma = np.std(b_values, axis=0)
+            b_sigma = np.maximum(np.std(b_values, axis=0), self._min_sigma)
 
             updated_layer_params = self._create_updated_layer_params(
                 w_mu, w_sigma, b_mu, b_sigma, layer_params.weight, layer_params.bias

--- a/pybandits/utils.py
+++ b/pybandits/utils.py
@@ -165,7 +165,7 @@ class classproperty(property):
 
 
 _DE_PARAMS = {
-    "maxiter": 100,  # Ensure minimum iterations for convergence
+    "maxiter": 1000,  # Match scipy's default; nonlinear constraints require more iterations
     "popsize": 15,  # Population size multiplier (total pop = popsize * len(bounds))
     "atol": 1e-6,  # Relaxed tolerance for boundary convergence
     "tol": 1e-6,  # Relaxed tolerance for boundary convergence
@@ -225,7 +225,6 @@ def maximize_by_quantity(
     de_params = {
         "func": lambda x: -quantity_score_func(x),  # Minimize negative = maximize
         "bounds": bounds,
-        "maxiter": max(100, n_trials // 10),  # Ensure minimum iterations for convergence
         **_DE_PARAMS,
     }
     de_params["maxiter"] = max(de_params["maxiter"], n_trials // maxiter_factor)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybandits"
-version = "6.0.8"
+version = "6.1.0"
 description = "Python Multi-Armed Bandit Library"
 authors = [
     "Dario d'Andrea <dariod@playtika.com>",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -23,6 +23,8 @@
 from typing import Literal, Optional
 from unittest.mock import patch
 
+import jax
+import jax.numpy as jnp
 import numpy as np
 import numpyro
 import pytest
@@ -30,6 +32,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 from numpyro.distributions import Normal as NumpyroNormal
 from numpyro.distributions import StudentT as NumpyroStudentT
+from numpyro.infer import Predictive
 
 from pybandits.model import (
     BaseBayesianNeuralNetwork,
@@ -234,7 +237,7 @@ def test_can_init_beta_mo_cc(a_float):
         st.tuples(st.integers(min_value=1, max_value=10), st.integers(min_value=1, max_value=10)),
     ),
     mu=st.floats(allow_nan=False, allow_infinity=False),
-    sigma=st.floats(min_value=0, allow_nan=False, allow_infinity=False),
+    sigma=st.floats(min_value=0, exclude_min=True, allow_nan=False, allow_infinity=False),
     nu=st.floats(min_value=0.001, allow_nan=False, allow_infinity=False),
 )
 def test_can_init_location_scale_array(array_class, shape, mu, sigma, nu):
@@ -914,7 +917,7 @@ def test_bnn_svi_nan_loss_raises_error(
 
     def nan_mean(a, *args, **kwargs):
         call_count["n"] += 1
-        if call_count["n"] == 1:
+        if call_count["n"] == 2:  # call 1 is avg_sigma in _build_svi_guide_init; call 2 is epoch loss
             return float("nan")
         return original_mean(a, *args, **kwargs)
 
@@ -1719,3 +1722,121 @@ def test_bnn_sample_proba_and_update_both_use_forward_layers(
     with patch.object(BaseBayesianNeuralNetwork, "_forward_layers", tracking_forward_layers):
         bnn.update(context=context, rewards=rewards)
     assert call_count >= ref, "update must call _forward_layers"
+
+
+########################################################################################################################
+
+
+# ParameterizedScaleAutoNormal / ADVI guide consistency
+
+
+@settings(deadline=None, max_examples=5)
+@given(
+    n_features=st.integers(min_value=1, max_value=2),
+    hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=1),
+    dist_type=st.sampled_from(["studentt", "normal"]),
+    n_samples=st.integers(min_value=5, max_value=10),
+    sigma_init=st.floats(min_value=0.1, max_value=1.0),
+    nu=st.just(5.0),
+    epochs=st.just(2),
+    n_predictive_samples=st.just(4000),
+    n_sigma_tolerance=st.just(5),
+)
+def test_advi_extracted_params_match_predictive_moments(
+    n_features, hidden_dim_list, dist_type, n_samples, sigma_init, nu, epochs, n_predictive_samples, n_sigma_tolerance
+):
+    """Stored (mu, sigma) from _extract_advi_params must match guide posterior sample moments.
+
+    AutoNormal draws each site from Normal(loc, scale), so posterior predictive
+    sample mean/std must recover the extracted loc/scale up to sampling noise.
+    sigma_init is bounded so SE = sigma/sqrt(n_predictive_samples) stays far below tolerance.
+    """
+    dist_params_init = {"sigma": sigma_init} if dist_type == "normal" else {"sigma": sigma_init, "nu": nu}
+    context = np.random.default_rng(0).standard_normal((n_samples, n_features)).astype(np.float32)
+    rewards = np.random.choice([0, 1], size=n_samples).tolist()
+
+    bnn = BayesianNeuralNetwork.cold_start(
+        n_features=n_features,
+        hidden_dim_list=hidden_dim_list,
+        update_method="VI",
+        update_kwargs={"epochs": epochs, "method": "advi"},
+        dist_type=dist_type,
+        dist_params_init=dist_params_init,
+    )
+
+    x_jnp = jnp.array(context)
+    y_jnp = jnp.array(rewards, dtype=jnp.int32)
+    _, guide, params = bnn._run_svi_training_loop(x_jnp, y_jnp, n_samples)
+    site_mu, site_sigma = bnn._extract_advi_params(params)
+
+    samples = Predictive(guide, params=params, num_samples=n_predictive_samples)(jax.random.PRNGKey(0), x_jnp, y_jnp)
+
+    # tolerances are n_sigma_tolerance * SE; atol_mu is per-site since ADVI can widen sigma above sigma_init
+    rtol_sigma = n_sigma_tolerance * np.sqrt(2.0 / n_predictive_samples)
+
+    for layer_ind in range(len(bnn.model_params.bnn_layer_params)):
+        for name in bnn.get_layer_params_name(layer_ind):
+            draw = np.array(samples[name])
+            atol_mu = n_sigma_tolerance * float(np.max(site_sigma[name])) / np.sqrt(n_predictive_samples)
+            np.testing.assert_allclose(site_mu[name], np.mean(draw, axis=0), atol=atol_mu)
+            np.testing.assert_allclose(site_sigma[name], np.std(draw, axis=0), rtol=rtol_sigma)
+
+
+@settings(deadline=None, max_examples=5)
+@given(
+    n_features=st.integers(min_value=1, max_value=2),
+    hidden_dim_list=st.lists(st.integers(min_value=1, max_value=2), min_size=0, max_size=1),
+    dist_type=st.sampled_from(["studentt", "normal"]),
+    n_samples=st.integers(min_value=2, max_value=5),
+    mu_init=st.floats(min_value=0.1, max_value=2.0),
+    sigma_init=st.floats(min_value=0.5, max_value=3.0),
+    nu=st.just(5.0),
+    num_steps=st.just(3),
+    lr=st.just(0.0),
+)
+def test_advi_zero_lr_posterior_equals_prior(
+    n_features, hidden_dim_list, dist_type, n_samples, mu_init, sigma_init, nu, num_steps, lr
+):
+    """With SGD step_size=0, ADVI must leave mu and sigma identical to the prior.
+
+    mu_init > 0 ensures init_to_value is used (not the stochastic init_to_median
+    triggered for all-zero priors), so the guide loc is seeded exactly at prior_mu
+    and stays there with zero gradient steps.
+    """
+    dist_params_init = (
+        {"mu": mu_init, "sigma": sigma_init}
+        if dist_type == "normal"
+        else {"mu": mu_init, "sigma": sigma_init, "nu": nu}
+    )
+    bnn = BayesianNeuralNetwork.cold_start(
+        n_features=n_features,
+        hidden_dim_list=hidden_dim_list,
+        update_method="VI",
+        update_kwargs={
+            "num_steps": num_steps,
+            "method": "advi",
+            "optimizer_type": "sgd",
+            "optimizer_kwargs": {"step_size": lr},
+        },
+        dist_type=dist_type,
+        dist_params_init=dist_params_init,
+    )
+
+    context = np.random.standard_normal((n_samples, n_features)).astype(np.float32)
+    rewards = np.random.choice([0, 1], size=n_samples).tolist()
+    bnn.update(context=context, rewards=rewards)
+
+    # float32 rounding on mu; softplus(softplus_inverse(sigma)) rounding on sigma
+    atol_mu = max(mu_init, sigma_init) * np.finfo(np.float32).eps * 100
+    rtol_sigma = np.finfo(np.float32).eps * 100
+
+    for layer_ind in range(len(bnn.model_params.bnn_layer_params)):
+        prior_w = bnn.model_params.bnn_layer_params_init[layer_ind].weight
+        prior_b = bnn.model_params.bnn_layer_params_init[layer_ind].bias
+        post_w = bnn.model_params.bnn_layer_params[layer_ind].weight
+        post_b = bnn.model_params.bnn_layer_params[layer_ind].bias
+
+        np.testing.assert_allclose(post_w.params["mu"], prior_w.params["mu"], atol=atol_mu)
+        np.testing.assert_allclose(post_b.params["mu"], prior_b.params["mu"], atol=atol_mu)
+        np.testing.assert_allclose(post_w.params["sigma"], prior_w.params["sigma"], rtol=rtol_sigma)
+        np.testing.assert_allclose(post_b.params["sigma"], prior_b.params["sigma"], rtol=rtol_sigma)


### PR DESCRIPTION
### Changes:
- Add ParameterizedScaleAutoNormal — subclass of AutoNormal that accepts init_scale_fn(site_name) -> array, enabling per-parameter scale seeding instead of a single global mean
- Refactor _build_svi_guide_init to return (init_loc_fn, init_scale_fn) with per-site sigma dict captured in closure; fullrank_advi retrieves the avg-sigma fallback via init_scale_fn("")
- Wire ParameterizedScaleAutoNormal into _run_svi_training_loop for advi; fullrank_advi continues using AutoMultivariateNormal with scalar avg sigma
- Add test_advi_extracted_params_match_predictive_moments — verifies extracted (mu, sigma) match Predictive sample moments within N-sigma tolerances derived from sigma_init and n_predictive_samples
- Add test_advi_zero_lr_posterior_equals_prior — verifies that lr=0 SGD leaves posterior identical to prior; uses mu_init > 0 to guarantee init_to_value (avoiding the stochastic init_to_median cold-start path)
- Removed single commit PR check. Shall be enforced via "Squash & Merge" from now on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Package version bumped to 6.1.0
  * CI style check updated to validate conventional-commit labels; single-commit enforcement removed
  * Removed an obsolete rule entry

* **Refactor**
  * Variational guide initialization now supports per-site scale initialization and tighter numeric clamping; sigma types/limits tightened
  * Default optimization iteration limit increased for differential evolution

* **Tests**
  * New JAX/NumPyro-backed tests for ADVI consistency, NaN-loss handling, and VI stability

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PlaytikaOSS/pybandits/pull/139)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->