### PR TITLE
Introduce BaseMetaModel abstraction for cmab actions managers

### DIFF
--- a/pybandits/actions_manager.py
+++ b/pybandits/actions_manager.py
@@ -22,8 +22,21 @@
 
 import warnings
 from abc import ABC, abstractmethod
-from collections import defaultdict
-from typing import Any, Callable, ClassVar, Dict, Generic, List, Optional, Set, Tuple, Type, TypeVar, Union
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    Generic,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    get_args,
+    get_origin,
+)
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -32,19 +45,24 @@ from pydantic import (
     Field,
     NonNegativeInt,
     NonPositiveInt,
-    field_validator,
+    PositiveInt,
+    model_validator,
     validate_call,
 )
 
 from pybandits.base import (
-    ACTION_IDS_PREFIX,
-    QUANTITATIVE_ACTION_IDS_PREFIX,
     ActionId,
     BinaryReward,
     PositiveProbability,
     PyBanditsBaseModel,
 )
 from pybandits.base_model import BaseModel, BaseModelMO, BaseModelSO
+from pybandits.meta_model import (
+    BaseMetaModel,
+    CmabPerActionMetaModel,
+    PerActionMetaModel,
+    SampleProbaResult,
+)
 from pybandits.model import (
     BaseBayesianNeuralNetwork,
     BaseBayesianNeuralNetworkMO,
@@ -70,7 +88,16 @@ from pybandits.quantitative_model import (
     Zooming,
     ZoomingCC,
 )
-from pybandits.utils import classproperty, extract_argument_names_from_function
+
+SmabModelType = TypeVar("SmabModelType", bound=Union[BaseBeta, BaseBetaMO, BaseZooming])
+CmabModelType = TypeVar(
+    "CmabModelType",
+    bound=Union[
+        BaseBayesianNeuralNetwork,
+        BaseBayesianNeuralNetworkMO,
+        BaseQuantitativeBayesianNeuralNetwork,
+    ],
+)
 
 
 class ActionsManager(PyBanditsBaseModel, ABC):
@@ -86,35 +113,39 @@ class ActionsManager(PyBanditsBaseModel, ABC):
 
     Parameters
     ----------
-    actions : Dict[ActionId, Model]
-        The list of possible actions, and their associated Model.
+    meta_model : BaseMetaModel
+        The meta-model that owns per-action state and dispatches ``sample_proba``,
+        ``update``, and ``reset``. Constructed automatically from an ``actions``
+        dict when the manager is instantiated via the ``actions=`` kwarg.
     delta : Optional[PositiveProbability]
         The confidence level for the adaptive window. None for skipping the change point detection.
     """
 
-    actions: Dict[ActionId, BaseModel]
+    meta_model: BaseMetaModel
     delta: Optional[PositiveProbability] = None
-    _no_change_point: ClassVar[NonNegativeInt] = -1
-    _min_adaptive_window_size: ClassVar[NonPositiveInt] = 10000
+    _no_change_point: ClassVar[NonPositiveInt] = -1
+    _min_adaptive_window_size: ClassVar[PositiveInt] = 10000
     _memory_parameters_suffix: ClassVar[str] = "_memory"
     actions_with_change: Set[Tuple[ActionId, NonNegativeInt]] = Field(default_factory=set)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    @field_validator("actions", mode="after")
+    @property
+    def actions(self) -> Dict[ActionId, BaseModel]:
+        """Per-action models, delegated to ``meta_model.actions``."""
+        return self.meta_model.actions
+
     @classmethod
-    def at_least_one_action_is_defined(cls, v):
-        # validate number of actions
-        if len(v) == 0:
-            raise AttributeError("At least one action should be defined.")
-        elif len(v) == 1:
-            warnings.warn("Only a single action was supplied. This MAB will be deterministic.")
-        # validate that all actions are of the same configuration
-        action_models = list(v.values())
-        action_type = cls._get_field_type("actions")
-        if any(not isinstance(action, action_type) for action in action_models):
-            raise TypeError(f"All actions should follow {action_type} type.")
-        return v
+    def _get_meta_model_cls(cls) -> Type[BaseMetaModel]:
+        """Return the concrete meta-model class from the manager's ``meta_model`` field annotation."""
+        meta_model_field = cls.model_fields.get("meta_model")
+        if meta_model_field is not None and meta_model_field.annotation is not None:
+            annotation = meta_model_field.annotation
+            type_args = get_args(annotation)
+            if type_args and not isinstance(type_args[0], TypeVar):
+                return annotation  # type: ignore[return-value]
+            return get_origin(annotation) or annotation  # type: ignore[return-value]
+        return PerActionMetaModel
 
     @classmethod
     def _get_expected_memory_length(cls, actions: Dict[ActionId, BaseModel]) -> NonNegativeInt:
@@ -152,13 +183,23 @@ class ActionsManager(PyBanditsBaseModel, ABC):
         quantitative_action_ids: Optional[Set[ActionId]] = None,
         kwargs: Optional[Dict[str, Any]] = None,
         actions_with_change: Optional[Set[Tuple[ActionId, NonNegativeInt]]] = None,
+        meta_model: Optional[BaseMetaModel] = None,
     ):
-        kwargs = kwargs or {}
-        actions = self._instantiate_actions(
-            actions=actions, action_ids=action_ids, quantitative_action_ids=quantitative_action_ids, kwargs=kwargs
-        )
+        action_args = (actions, action_ids, quantitative_action_ids)
+        if meta_model is not None and any(a is not None for a in action_args):
+            raise ValueError(
+                "Provide either 'meta_model' or action-construction arguments "
+                "('actions', 'action_ids', 'quantitative_action_ids'), not both."
+            )
+        if meta_model is None:
+            meta_model = self._get_meta_model_cls()(
+                actions=actions,
+                action_ids=action_ids,
+                quantitative_action_ids=quantitative_action_ids,
+                kwargs=kwargs or {},
+            )
         actions_with_change = actions_with_change or set()
-        super().__init__(actions=actions, delta=delta, actions_with_change=actions_with_change)
+        super().__init__(meta_model=meta_model, delta=delta, actions_with_change=actions_with_change)
 
     def _validate_update_params(
         self,
@@ -202,6 +243,31 @@ class ActionsManager(PyBanditsBaseModel, ABC):
     @classmethod
     def _to_key(cls, key: str) -> str:
         return key.replace(cls._memory_parameters_suffix, "")
+
+    def sample_proba(
+        self,
+        rng: np.random.Generator,
+        valid_action_ids: Optional[Set[ActionId]] = None,
+        **kwargs: Any,
+    ) -> Dict[ActionId, SampleProbaResult]:
+        """Sample per-action probabilities/scores for the bandit's predict path.
+
+        Delegates to ``self.meta_model.sample_proba``. With the default
+        ``PerActionMetaModel`` this is a per-action dispatch loop; alternative
+        meta-models (e.g. a shared backbone) may evaluate all actions jointly.
+
+        Parameters
+        ----------
+        rng : numpy.random.Generator
+            Central random generator from the bandit.
+        valid_action_ids : Optional[Set[ActionId]]
+            If provided, restrict sampling to these action ids; otherwise
+            sample for all actions.
+        **kwargs
+            Forwarded to per-action ``sample_proba`` (e.g. ``context`` for
+            cmab, ``n_samples`` for smab).
+        """
+        return self.meta_model.sample_proba(rng=rng, valid_action_ids=valid_action_ids, **kwargs)
 
     @validate_call(config=dict(arbitrary_types_allowed=True))
     def update(
@@ -276,7 +342,11 @@ class ActionsManager(PyBanditsBaseModel, ABC):
                 for action_model in self.actions.values():
                     if not isinstance(action_model, QuantitativeModel):
                         action_model.reset()
-                regular_actions = [a for a in actions if not isinstance(self.actions[a], QuantitativeModel)]
+                # Non-quantitative models were just reset; retrain on the trimmed memory window.
+                # Filter from `actions_memory` so the action labels align with `rewards_memory`
+                # / `memory_kwargs` (which are filtered from the same source below).
+                regular_actions = [a for a in actions_memory if not isinstance(self.actions[a], QuantitativeModel)]
+                # Quantitative models keep their state (no reset), so they only need the new batch.
                 quantitative_actions = [a for a in actions if isinstance(self.actions[a], QuantitativeModel)]
 
                 if regular_actions:
@@ -647,175 +717,6 @@ class ActionsManager(PyBanditsBaseModel, ABC):
             raise TypeError(f"Model type {type(action_model)} not supported.")
         return current_sum, current_trials
 
-    @classmethod
-    def _instantiate_actions(
-        cls,
-        actions: Optional[Dict[ActionId, Model]],
-        action_ids: Optional[Set[ActionId]],
-        quantitative_action_ids: Optional[Set[ActionId]],
-        kwargs: Dict[str, Any],
-    ):
-        """
-        Utility function to instantiate the action models based on the provided kwargs.
-
-        Parameters
-        ----------
-        actions : Optional[Dict[ActionId, Model]]
-            The list of possible actions and their associated models.
-        action_ids : Optional[Set[ActionId]]
-            The list of possible actions.
-        quantitative_action_ids : Optional[Set[ActionId]]
-            The list of quantitative actions.
-        kwargs : Dict[str, Any]
-            Additional parameters for the mab and for the action model.
-
-        Returns
-        -------
-        actions : Dict[ActionId, Model]
-            Dictionary of actions and the parameters of their associated model.
-        """
-        if actions is None:
-            action_specific_kwargs, quantitative_action_specific_kwargs = cls._extract_action_specific_kwargs(kwargs)
-
-            # Extract inner_action_ids
-            inner_action_ids = action_ids or set(action_specific_kwargs)
-            inner_quantitative_action_ids = quantitative_action_ids or set(quantitative_action_specific_kwargs)
-            if not inner_action_ids and not inner_quantitative_action_ids:
-                raise ValueError("At least one action should be defined.")
-
-            # Assign model for each action
-            (
-                model_cold_start,
-                quantitative_model_cold_start,
-                action_general_kwargs,
-                quantitative_action_general_kwargs,
-            ) = cls._extract_action_model_class_and_attributes(kwargs)
-
-            # Instantiate the actions
-            actions = {}
-            for action_ids, cold_start, general_kwargs, specific_kwargs in zip(
-                [inner_action_ids, inner_quantitative_action_ids],
-                [model_cold_start, quantitative_model_cold_start],
-                [action_general_kwargs, quantitative_action_general_kwargs],
-                [action_specific_kwargs, quantitative_action_specific_kwargs],
-            ):
-                for a in action_ids:
-                    actions[a] = cold_start(**general_kwargs, **specific_kwargs.get(a, {}))
-
-        return actions
-
-    @staticmethod
-    def _extract_action_specific_kwargs(kwargs: Dict[str, Any]) -> Tuple[Dict[str, Dict], Dict[str, Dict]]:
-        """
-        Utility function to extract kwargs that are specific for each action when constructing the action model.
-
-        Parameters
-        ----------
-        kwargs : Dict[str, Any]
-            Additional parameters for the mab and for the action model.
-
-        Returns
-        -------
-        action_specific_kwargs : Dict[str, Dict]
-            Dictionary of actions and the parameters of their associated model.
-        quantitative_action_specific_kwargs : Dict[str, Dict]
-            Dictionary of quantitative actions and the parameters of their associated model.
-        kwargs : Dict[str, Any]
-            Dictionary of parameters and their quantities, without the action_specific_kwargs.
-        """
-        action_specific_kwargs = defaultdict(dict)
-        quantitative_action_specific_kwargs = defaultdict(dict)
-        for keyword in list(kwargs):
-            argument = kwargs[keyword]
-            for prefix, target_kwargs in zip(
-                [ACTION_IDS_PREFIX, QUANTITATIVE_ACTION_IDS_PREFIX],
-                [action_specific_kwargs, quantitative_action_specific_kwargs],
-            ):
-                if keyword.startswith(prefix) and type(argument) is dict:
-                    kwargs.pop(keyword)
-                    inner_keyword = keyword.split(prefix)[1]
-                    for action_id, value in argument.items():
-                        target_kwargs[action_id][inner_keyword] = value
-        return dict(action_specific_kwargs), dict(quantitative_action_specific_kwargs)
-
-    @classmethod
-    def _extract_action_model_class_and_attributes(
-        cls, kwargs
-    ) -> Tuple[Callable, Callable, Dict[str, Dict], Dict[str, Dict]]:
-        """
-        Utility function to extract kwargs that are specific for each action when constructing the action model.
-
-        Parameters
-        ----------
-        kwargs : Dict[str, Any]
-            Additional parameters for the mab and for the action model.
-
-        Returns
-        -------
-        action_model_cold_start : Callable
-            Function handle for factoring the required action model.
-        quantitative_action_model_cold_start : Callable
-            Function handle for factoring the required quantitative action model.
-        action_general_kwargs : Dict[str, any]
-            Dictionary of parameters and their values for the action model.
-        quantitative_action_general_kwargs : Dict[str, any]
-            Dictionary of parameters and their values for the quantitative action model.
-        """
-        action_model_classes = cls._action_model_classes
-        if len(action_model_classes) > 2:
-            raise ValueError("Only up to two types of action models are supported.")
-        quantitative_model_cold_start = model_cold_start = lambda **kwargs: None  # dummy callable
-        action_general_kwargs = quantitative_action_general_kwargs = None
-        for action_model_class in action_model_classes:
-            if hasattr(action_model_class, "cold_start"):
-                action_model_cold_start = action_model_class.cold_start
-                action_model_attributes = extract_argument_names_from_function(action_model_cold_start)
-                # cover for cold_start kwargs
-                action_model_attributes = action_model_attributes + extract_argument_names_from_function(
-                    action_model_class
-                )
-            else:
-                action_model_cold_start = action_model_class
-                action_model_attributes = extract_argument_names_from_function(action_model_cold_start)
-            general_kwargs = {k: kwargs[k] for k in action_model_attributes if k in kwargs.keys()}
-
-            if issubclass(action_model_class, (Model, ModelMO)):
-                model_cold_start = action_model_cold_start
-                action_general_kwargs = general_kwargs
-            elif issubclass(action_model_class, QuantitativeModel):
-                quantitative_model_cold_start = action_model_cold_start
-                quantitative_action_general_kwargs = general_kwargs
-            else:
-                raise TypeError(f"Unsupported action model class: {action_model_class}")
-
-        used_kwargs = (action_general_kwargs or {}) | (quantitative_action_general_kwargs or {})
-        for k in used_kwargs.keys():
-            kwargs.pop(k)
-
-        return (
-            model_cold_start,
-            quantitative_model_cold_start,
-            action_general_kwargs,
-            quantitative_action_general_kwargs,
-        )
-
-    @classproperty
-    def _action_model_classes(cls) -> Tuple[Type[BaseModel], ...]:
-        """
-        Utility function to extract the action model classes from the actions field.
-
-        Returns
-        -------
-        action_model_classes : Tuple[Type[BaseModel],...]
-            Tuple of action model classes.
-        """
-        action_model_type = cls._get_field_type("actions")
-        action_model_classes = action_model_type if isinstance(action_model_type, tuple) else (action_model_type,)
-        return action_model_classes
-
-
-SmabModelType = TypeVar("SmabModelType", bound=Union[BaseBeta, BaseBetaMO, BaseZooming])
-
 
 class SmabActionsManager(ActionsManager, Generic[SmabModelType]):
     """
@@ -824,28 +725,30 @@ class SmabActionsManager(ActionsManager, Generic[SmabModelType]):
 
     Parameters
     ----------
-    actions : Dict[ActionId, BaseBeta]
-        The list of possible actions, and their associated Model.
-    delta : Optional[PositiveProbability], 0.1 if not specified.
-        The confidence level for the adaptive window.
+    meta_model : PerActionMetaModel[SmabModelType]
+        The meta-model owning per-action state. Constructed automatically from an ``actions`` dict
+        when the manager is instantiated via the ``actions=`` kwarg.
+    delta : Optional[PositiveProbability]
+        The confidence level for the adaptive window. ``None`` disables change-point detection.
     """
 
-    actions: Dict[ActionId, SmabModelType]
+    meta_model: PerActionMetaModel[SmabModelType]  # type: ignore[valid-type]
 
-    @field_validator("actions", mode="after")
-    @classmethod
-    def all_actions_have_same_number_of_objectives(cls, actions: Dict[ActionId, SmabModelType]):
-        n_objs_per_action = [len(beta.models) if hasattr(beta, "models") else None for beta in actions.values()]
+    @model_validator(mode="after")
+    def all_actions_have_same_number_of_objectives(self) -> "SmabActionsManager":
+        n_objs_per_action = [
+            len(beta.models) if isinstance(beta, BaseBetaMO) else None for beta in self.meta_model.actions.values()
+        ]
         if len(set(n_objs_per_action)) != 1:
             raise ValueError("All actions should have the same number of objectives")
-        return actions
+        return self
 
     @validate_call
     def update(
         self,
         actions: List[ActionId],
         rewards: Union[List[BinaryReward], List[List[BinaryReward]]],
-        quantities: Optional[List[Union[float, List[float], None]]],
+        quantities: Optional[List[Union[float, List[float], None]]] = None,
         actions_memory: Optional[List[ActionId]] = None,
         rewards_memory: Optional[Union[List[BinaryReward], List[List[BinaryReward]]]] = None,
     ):
@@ -876,7 +779,7 @@ class SmabActionsManager(ActionsManager, Generic[SmabModelType]):
     ):
         """
         Update the stochastic Bernoulli bandit given the list of selected actions and their corresponding binary
-        rewards.
+        rewards. Delegates to ``self.meta_model.update``.
 
         Parameters
         ----------
@@ -892,36 +795,7 @@ class SmabActionsManager(ActionsManager, Generic[SmabModelType]):
         quantities : Optional[List[Union[float, List[float], None]]]
             The value associated with each action. If none, the value is not used, i.e. non-quantitative action.
         """
-
-        rewards_dict = defaultdict(list)
-
-        if quantities is None:
-            for a, r in zip(actions, rewards):
-                rewards_dict[a].append(r)
-            for a in set(actions):
-                self.actions[a].update(rewards=rewards_dict[a])
-        else:
-            quantities = quantities[-len(actions) :]
-            quantities_dict = defaultdict(list)
-            for a, v, r in zip(actions, quantities, rewards):
-                if v is not None:
-                    quantities_dict[a].append(v)
-                rewards_dict[a].append(r)
-            for a in set(actions):
-                if quantities_dict[a]:  # quantitative action
-                    self.actions[a].update(rewards=rewards_dict[a], quantities=quantities_dict[a])
-                else:  # non-quantitative action
-                    self.actions[a].update(rewards=rewards_dict[a])
-
-
-CmabModelType = TypeVar(
-    "CmabModelType",
-    bound=Union[
-        BaseBayesianNeuralNetwork,
-        BaseBayesianNeuralNetworkMO,
-        BaseQuantitativeBayesianNeuralNetwork,
-    ],
-)
+        self.meta_model.update(actions=actions, rewards=rewards, quantities=quantities)
 
 
 class CmabActionsManager(ActionsManager, Generic[CmabModelType]):
@@ -931,53 +805,15 @@ class CmabActionsManager(ActionsManager, Generic[CmabModelType]):
 
     Parameters
     ----------
-    actions : Dict[ActionId, BaseBayesianNeuralNetwork]
-        The list of possible actions, and their associated Model.
-    delta : Optional[PositiveProbability], 0.1 if not specified.
-        The confidence level for the adaptive window.
+    meta_model : CmabPerActionMetaModel[CmabModelType]
+        The cmab-specific meta-model owning per-action state and the cross-action consistency
+        validator (input dim / update method / update kwargs). Constructed automatically from an
+        ``actions`` dict when the manager is instantiated via the ``actions=`` kwarg.
+    delta : Optional[PositiveProbability]
+        The confidence level for the adaptive window. ``None`` disables change-point detection.
     """
 
-    actions: Dict[ActionId, CmabModelType]
-
-    @staticmethod
-    def _maybe_crawl_model(model: CmabModelType):
-        """
-        Utility function to crawl the model to get the base model.
-        """
-        if isinstance(model, BaseBayesianNeuralNetworkMO):
-            return model.models[0]
-        elif isinstance(model, BaseQuantitativeBayesianNeuralNetwork):
-            return model.bnn
-        else:
-            return model
-
-    @staticmethod
-    def _get_expected_context_size(model: CmabModelType):
-        """
-        Utility function to get the expected context size for the model.
-        """
-        if isinstance(model, BaseBayesianNeuralNetworkMO):
-            return model.models[0].input_dim
-        elif isinstance(model, (BaseBayesianNeuralNetwork, BaseQuantitativeBayesianNeuralNetwork)):
-            return model.input_dim
-        else:
-            raise TypeError(f"Unsupported model type: {type(model)}")
-
-    @field_validator("actions", mode="after")
-    @classmethod
-    def check_models(cls, v):
-        action_models = list(v.values())
-        first_action = action_models[0]
-        test_first_action = cls._maybe_crawl_model(first_action)
-        for action in action_models[1:]:
-            test_action = cls._maybe_crawl_model(action)
-            if not cls._get_expected_context_size(first_action) == cls._get_expected_context_size(action):
-                raise AttributeError("All actions should have the same input size.")
-            if not test_first_action.update_method == test_action.update_method:
-                raise AttributeError("All actions should have the same update method.")
-            if not test_first_action.update_kwargs == test_action.update_kwargs:
-                raise AttributeError("All actions should have the same update kwargs.")
-        return v
+    meta_model: CmabPerActionMetaModel[CmabModelType]  # type: ignore[valid-type]
 
     @validate_call(config=dict(arbitrary_types_allowed=True))
     def update(
@@ -1059,6 +895,11 @@ class CmabActionsManager(ActionsManager, Generic[CmabModelType]):
         """
         Update the models associated with the given actions using the provided rewards.
 
+        Delegates to ``self.meta_model.update``. With the default
+        ``PerActionMetaModel`` this preserves the historical per-action
+        loop; alternative meta-models (introduced in follow-up PRs) may
+        run a joint update across actions instead.
+
         Parameters
         ----------
         actions : List[UnifiedActionId] of shape (n_samples,), e.g. ['a1', 'a2', 'a3', 'a4', 'a5']
@@ -1074,33 +915,12 @@ class CmabActionsManager(ActionsManager, Generic[CmabModelType]):
         context: np.ndarray of shape (n_samples, n_features)
             Matrix of contextual features.
         """
-        context = context[-len(actions) :]
-
-        rewards_dict = defaultdict(list)
-        context_dict = defaultdict(list)
-        if quantities is None:
-            for a, r, c in zip(actions, rewards, context):
-                rewards_dict[a].append(r)
-                context_dict[a].append(c)
-
-            for a in set(actions):
-                self.actions[a].update(rewards=rewards_dict[a], context=np.array(context_dict[a]))
-
-        else:
-            quantities = quantities[-len(actions) :]
-            quantities_dict = defaultdict(list)
-            for a, r, c, q in zip(actions, rewards, context, quantities):
-                rewards_dict[a].append(r)
-                context_dict[a].append(c)
-                quantities_dict[a].append(q)
-
-            for a in set(actions):
-                if any(quantities_dict[a]):  # quantitative action
-                    self.actions[a].update(
-                        context=np.array(context_dict[a]), rewards=rewards_dict[a], quantities=quantities_dict[a]
-                    )
-                else:  # non-quantitative action
-                    self.actions[a].update(context=np.array(context_dict[a]), rewards=rewards_dict[a])
+        self.meta_model.update(
+            actions=actions,
+            rewards=rewards,
+            quantities=quantities,
+            context=context,
+        )
 
 
 # For pickling purposes

--- a/pybandits/cmab.py
+++ b/pybandits/cmab.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 from abc import ABC
-from typing import Dict, List, Optional, Set, Union
+from typing import Dict, List, Optional, Set, Union, cast
 
 import numpy as np
 from pydantic import validate_call
@@ -216,7 +216,16 @@ class BaseCmabBernoulli(BaseMab, ABC):
         state = super().update_old_state(state)
 
         # Migrate update_kwargs from old PyMC format to new NumPyro format
-        for action_id, action_state in state["actions_manager"]["actions"].items():
+        # Support both old format (actions_manager.actions) and current format (actions_manager.meta_model.actions).
+        actions_manager = cast(Dict, state["actions_manager"])
+        if "actions" in actions_manager:
+            actions_dict = cast(Dict, actions_manager["actions"])
+            _old_format = True
+        else:
+            actions_dict = cast(Dict, actions_manager["meta_model"]["actions"])
+            _old_format = False
+
+        for action_id, action_state in actions_dict.items():
             if "feature_config" not in action_state:  # v5.0.0 compatability
                 layer_params = action_state["model_params"]["bnn_layer_params"]
                 if not layer_params:
@@ -262,6 +271,9 @@ class BaseCmabBernoulli(BaseMab, ABC):
                     opt_kwargs = kwargs["optimizer_kwargs"]
                     if "learning_rate" in opt_kwargs:
                         opt_kwargs["step_size"] = opt_kwargs.pop("learning_rate")
+
+        if _old_format:
+            actions_manager["meta_model"] = {"actions": actions_manager.pop("actions")}
 
         return state
 

--- a/pybandits/mab.py
+++ b/pybandits/mab.py
@@ -310,11 +310,9 @@ class BaseMab(PyBanditsBaseModel, ABC):
         """
 
         valid_actions = self._get_valid_actions(forbidden_actions)
-        action_probabilities = {
-            action: model.sample_proba(**kwargs, rng=self._rng)
-            for action, model in self.actions.items()
-            if action in valid_actions
-        }
+        action_probabilities = self.actions_manager.sample_proba(
+            rng=self._rng, valid_action_ids=valid_actions, **kwargs
+        )
         # Handle standard actions for which the value is a (probability, weight) tuple
         actions_transformations = [[{key: proba} for proba in value] for key, value in action_probabilities.items()]
         action_probabilities = self._transform_nested_list(actions_transformations)

--- a/pybandits/meta_model.py
+++ b/pybandits/meta_model.py
@@ -1,0 +1,511 @@
+# MIT License
+#
+# Copyright (c) 2022 Playtika Ltd.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Meta-model abstraction layer for action managers.
+
+A meta-model sits between an actions manager (e.g. ``CmabActionsManager``)
+and the per-action models. The manager delegates ``sample_proba``, ``update``,
+and ``reset`` to the meta-model. The meta-model decides whether per-action
+calls are independent (simple dispatch loop) or require coordinated state
+(e.g. a shared learned representation).
+
+One concrete class is provided:
+
+- ``PerActionMetaModel[T]``: generic implementation wrapping a
+  ``Dict[ActionId, T]`` with an independent per-action dispatch loop.
+  Behaviour is identical to the pre-meta-model smab/cmab pattern.
+  Domain validators (e.g. same number of objectives for smab; consistent
+  input size / update method for cmab) live on the respective manager
+  subclasses, not here.
+
+The interface is intentionally minimal and will be extended as additional
+meta-model patterns (e.g. shared-backbone neural-linear) are introduced.
+"""
+
+import warnings
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from typing import Any, Callable, Dict, Generic, List, Optional, Set, Tuple, Type, TypeVar, Union, get_args, get_origin
+
+import numpy as np
+from pydantic import ConfigDict, field_validator, model_validator
+
+from pybandits.base import (
+    ACTION_IDS_PREFIX,
+    QUANTITATIVE_ACTION_IDS_PREFIX,
+    ActionId,
+    BinaryReward,
+    MOProbability,
+    MOProbabilityWeight,
+    Probability,
+    ProbabilityWeight,
+    PyBanditsBaseModel,
+    QuantitativeMOProbability,
+    QuantitativeMOProbabilityWeight,
+    QuantitativeProbability,
+    QuantitativeProbabilityWeight,
+)
+from pybandits.base_model import BaseModel
+from pybandits.model import (
+    BayesianNeuralNetwork,
+    BayesianNeuralNetworkCC,
+    BayesianNeuralNetworkMO,
+    BayesianNeuralNetworkMOCC,
+    Beta,
+    BetaCC,
+    BetaMO,
+    BetaMOCC,
+    Model,
+    ModelMO,
+)
+from pybandits.quantitative_model import (
+    QuantitativeBayesianNeuralNetwork,
+    QuantitativeBayesianNeuralNetworkCC,
+    QuantitativeModel,
+    Zooming,
+    ZoomingCC,
+)
+from pybandits.utils import classproperty, extract_argument_names_from_function
+
+# Possible return shapes from a per-action sample_proba call.
+SampleProbaResult = Union[
+    List[Probability],
+    List[MOProbability],
+    List[ProbabilityWeight],
+    List[MOProbabilityWeight],
+    List[QuantitativeProbability],
+    List[QuantitativeMOProbability],
+    List[QuantitativeProbabilityWeight],
+    List[QuantitativeMOProbabilityWeight],
+]
+
+ActionModelType = TypeVar("ActionModelType", bound=BaseModel)
+
+
+class BaseMetaModel(PyBanditsBaseModel, ABC):
+    """Abstract base for objects that own per-action state and dispatch logic.
+
+    The manager class (e.g. ``CmabActionsManager``) delegates ``sample_proba``,
+    ``update``, and ``reset`` to a meta-model instance. The meta-model owns the
+    per-action models (exposed via the ``actions`` field) and decides whether
+    they are dispatched independently or with coordinated shared state.
+
+    Subclasses may narrow the value type of ``actions`` (e.g.
+    ``Dict[ActionId, BayesianNeuralNetwork]``); Pydantic preserves identity of
+    nested model instances, so mutations via ``update()`` remain visible to
+    holders of the original references.
+    """
+
+    actions: Dict[ActionId, BaseModel]
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @property
+    def action_ids(self) -> List[ActionId]:
+        """Action identifiers covered by this meta-model."""
+        return list(self.actions.keys())
+
+    @abstractmethod
+    def sample_proba(
+        self,
+        rng: np.random.Generator,
+        valid_action_ids: Optional[Set[ActionId]] = None,
+        **kwargs: Any,
+    ) -> Dict[ActionId, SampleProbaResult]:
+        """Sample per-action probabilities/scores under the current context.
+
+        Parameters
+        ----------
+        rng : numpy.random.Generator
+            Central random generator from the bandit (for reproducibility).
+        valid_action_ids : Optional[Set[ActionId]]
+            If provided, restrict sampling to these action ids (the bandit's
+            allowed actions after removing ``forbidden_actions``). When
+            ``None`` all action ids are sampled. Meta-models with shared
+            state may use this to skip unnecessary head/branch evaluations.
+        **kwargs
+            Additional sampling inputs. For contextual bandits this includes
+            ``context: np.ndarray``.
+
+        Returns
+        -------
+        Dict[ActionId, SampleProbaResult]
+            Per-action probability/score collection in whatever shape the
+            underlying model returns from its ``sample_proba``.
+        """
+
+    @abstractmethod
+    def update(
+        self,
+        actions: List[ActionId],
+        rewards: Union[List[BinaryReward], List[List[BinaryReward]]],
+        quantities: Optional[List[Union[float, List[float], None]]] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Update per-action state from a batch of (action, reward, ...) tuples.
+
+        Parameters
+        ----------
+        actions : List[ActionId]
+            Selected action per sample.
+        rewards : Union[List[BinaryReward], List[List[BinaryReward]]]
+            Reward per sample (scalar for single-objective; list per sample
+            for multi-objective).
+        quantities : Optional[List[Union[float, List[float], None]]]
+            Per-sample quantity for quantitative actions; ``None`` for
+            non-quantitative actions in the same batch.
+        **kwargs
+            Additional update inputs. For contextual bandits this includes
+            ``context: np.ndarray``.
+        """
+
+    @abstractmethod
+    def reset(self) -> None:
+        """Reset every per-action model to its cold-start state."""
+
+    @classmethod
+    def _preprocess_actions(
+        cls,
+        actions: Optional[Dict[ActionId, BaseModel]],
+        action_ids: Optional[Set[ActionId]],
+        quantitative_action_ids: Optional[Set[ActionId]],
+        kwargs: Dict[str, Any],
+    ) -> Dict[ActionId, BaseModel]:
+        """Return the canonical per-action dict the meta-model should store.
+
+        Default behaviour (used by ``PerActionMetaModel`` and any subclass whose state is
+        a 1:1 per-action mapping): if ``actions`` is None, cold-start the per-action models
+        from ``action_ids`` / ``quantitative_action_ids`` and the remaining ``kwargs``.
+        Shared-state meta-models (e.g. neural-linear) override this to materialise per-action
+        regression heads on top of a jointly-trained backbone.
+        """
+        return cls._instantiate_actions(
+            actions=actions,
+            action_ids=action_ids,
+            quantitative_action_ids=quantitative_action_ids,
+            kwargs=kwargs,
+        )
+
+    @classmethod
+    def _instantiate_actions(
+        cls,
+        actions: Optional[Dict[ActionId, BaseModel]],
+        action_ids: Optional[Set[ActionId]],
+        quantitative_action_ids: Optional[Set[ActionId]],
+        kwargs: Dict[str, Any],
+    ) -> Dict[ActionId, BaseModel]:
+        """Construct per-action model instances from cold-start kwargs, or pass through a pre-built dict."""
+        if actions is not None:
+            return actions
+        action_specific_kwargs, quantitative_action_specific_kwargs = cls._extract_action_specific_kwargs(kwargs)
+        inner_action_ids = action_ids or set(action_specific_kwargs)
+        inner_quantitative_action_ids = quantitative_action_ids or set(quantitative_action_specific_kwargs)
+        if not inner_action_ids and not inner_quantitative_action_ids:
+            raise AttributeError("At least one action should be defined.")
+        (
+            model_cold_start,
+            quantitative_model_cold_start,
+            action_general_kwargs,
+            quantitative_action_general_kwargs,
+        ) = cls._extract_action_model_class_and_attributes(kwargs)
+        actions = {}
+        for _action_ids, cold_start, general_kwargs, specific_kwargs in zip(
+            [inner_action_ids, inner_quantitative_action_ids],
+            [model_cold_start, quantitative_model_cold_start],
+            [action_general_kwargs, quantitative_action_general_kwargs],
+            [action_specific_kwargs, quantitative_action_specific_kwargs],
+        ):
+            for a in _action_ids:
+                actions[a] = cold_start(**general_kwargs, **specific_kwargs.get(a, {}))
+        return actions
+
+    @staticmethod
+    def _extract_action_specific_kwargs(kwargs: Dict[str, Any]) -> Tuple[Dict[str, Dict], Dict[str, Dict]]:
+        """Split ``kwargs`` into per-action and per-quantitative-action sub-dicts, removing them from ``kwargs``."""
+        action_specific_kwargs = defaultdict(dict)
+        quantitative_action_specific_kwargs = defaultdict(dict)
+        for keyword in list(kwargs):
+            argument = kwargs[keyword]
+            for prefix, target_kwargs in zip(
+                [ACTION_IDS_PREFIX, QUANTITATIVE_ACTION_IDS_PREFIX],
+                [action_specific_kwargs, quantitative_action_specific_kwargs],
+            ):
+                if keyword.startswith(prefix) and type(argument) is dict:
+                    kwargs.pop(keyword)
+                    inner_keyword = keyword.split(prefix)[1]
+                    for action_id, value in argument.items():
+                        target_kwargs[action_id][inner_keyword] = value
+        return dict(action_specific_kwargs), dict(quantitative_action_specific_kwargs)
+
+    @classmethod
+    def _extract_action_model_class_and_attributes(
+        cls, kwargs: Dict[str, Any]
+    ) -> Tuple[Callable, Callable, Dict[str, Any], Dict[str, Any]]:
+        """Extract cold-start callables and their kwargs from the manager's ``kwargs`` dict."""
+        action_model_classes = cls._action_model_classes
+        if len(action_model_classes) > 2:
+            raise ValueError("Only up to two types of action models are supported.")
+        quantitative_model_cold_start = model_cold_start = lambda **kw: None  # dummy callable
+        action_general_kwargs = quantitative_action_general_kwargs = None
+        for action_model_class in action_model_classes:
+            if hasattr(action_model_class, "cold_start"):
+                action_model_cold_start = action_model_class.cold_start
+                action_model_attributes = extract_argument_names_from_function(action_model_cold_start)
+                action_model_attributes = action_model_attributes + extract_argument_names_from_function(
+                    action_model_class
+                )
+            else:
+                action_model_cold_start = action_model_class
+                action_model_attributes = extract_argument_names_from_function(action_model_cold_start)
+            general_kwargs = {k: kwargs[k] for k in action_model_attributes if k in kwargs}
+
+            if issubclass(action_model_class, (Model, ModelMO)):
+                model_cold_start = action_model_cold_start
+                action_general_kwargs = general_kwargs
+            elif issubclass(action_model_class, QuantitativeModel):
+                quantitative_model_cold_start = action_model_cold_start
+                quantitative_action_general_kwargs = general_kwargs
+            else:
+                raise TypeError(f"Unsupported action model class: {action_model_class}")
+
+        used_kwargs = (action_general_kwargs or {}) | (quantitative_action_general_kwargs or {})
+        for k in used_kwargs:
+            kwargs.pop(k)
+
+        return (
+            model_cold_start,
+            quantitative_model_cold_start,
+            action_general_kwargs,
+            quantitative_action_general_kwargs,
+        )
+
+    @classproperty
+    def _action_model_classes(cls) -> Tuple[Type[BaseModel], ...]:
+        """Extract concrete action-model classes from the ``actions`` field annotation (``Dict[ActionId, T]`` → ``T``).
+
+        Raises ``TypeError`` when the annotation is unparameterised or still a TypeVar,
+        since cold-starting from kwargs needs a concrete class to call ``cold_start`` on.
+        """
+        actions_annotation = cls.model_fields["actions"].annotation
+        type_args = get_args(actions_annotation)  # (ActionId, T)
+        if not type_args or len(type_args) < 2:
+            raise TypeError(
+                f"{cls.__name__}.actions has no concrete value type annotation; "
+                "parameterise the meta-model (e.g. PerActionMetaModel[Beta]) before cold-starting."
+            )
+        action_model_type = type_args[1]
+        if isinstance(action_model_type, TypeVar):
+            raise TypeError(
+                f"{cls.__name__}.actions value type is still a TypeVar ({action_model_type}); "
+                "parameterise the meta-model with a concrete model class before cold-starting."
+            )
+        if get_origin(action_model_type) is Union:
+            return get_args(action_model_type)
+        return (action_model_type,)
+
+
+class PerActionMetaModel(BaseMetaModel, Generic[ActionModelType]):
+    """Meta-model that dispatches independently to per-action models.
+
+    Wraps a ``Dict[ActionId, ActionModelType]`` and routes each ``sample_proba`` /
+    ``update`` / ``reset`` call to the relevant action's model. This is the
+    historical cmab/smab pattern, lifted into the meta-model abstraction without
+    any behavioural change.
+
+    The ``actions`` dict is a regular Pydantic field. Pydantic v2 with its
+    default ``revalidate_instances='never'`` does not deep-copy nested model
+    instances during validation, so the original model references are preserved.
+    This guarantees that mutations via ``update()`` are visible to callers that
+    hold references to the original per-action model objects.
+
+    Domain invariants (e.g. same number of objectives for smab; consistent
+    input size / update method for cmab) are validated on the respective manager
+    subclasses, not here.
+    """
+
+    actions: Dict[ActionId, ActionModelType]  # type: ignore[valid-type]
+
+    @field_validator("actions", mode="after")
+    @classmethod
+    def at_least_one_action_is_defined(cls, v: Dict[ActionId, ActionModelType]) -> Dict[ActionId, ActionModelType]:
+        if len(v) == 0:
+            raise AttributeError("At least one action should be defined.")
+        elif len(v) == 1:
+            warnings.warn("Only a single action was supplied. This MAB will be deterministic.")
+        return v
+
+    def __init__(
+        self,
+        actions: Optional[Dict[ActionId, BaseModel]] = None,
+        action_ids: Optional[Set[ActionId]] = None,
+        quantitative_action_ids: Optional[Set[ActionId]] = None,
+        kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        """Construct a meta-model from either a pre-built ``actions`` dict or cold-start specs.
+
+        Mirrors the ``ActionsManager.__init__`` pattern: optional construction kwargs are
+        resolved into a per-action dict, then handed to Pydantic's ``BaseModel.__init__``
+        via ``super().__init__(actions=...)``.
+        """
+        actions_dict = type(self)._preprocess_actions(
+            actions=actions,
+            action_ids=action_ids,
+            quantitative_action_ids=quantitative_action_ids,
+            kwargs=kwargs or {},
+        )
+        super().__init__(actions=actions_dict)
+
+    def sample_proba(
+        self,
+        rng: np.random.Generator,
+        valid_action_ids: Optional[Set[ActionId]] = None,
+        **kwargs: Any,
+    ) -> Dict[ActionId, SampleProbaResult]:
+        return {
+            action_id: model.sample_proba(rng=rng, **kwargs)
+            for action_id, model in self.actions.items()
+            if valid_action_ids is None or action_id in valid_action_ids
+        }
+
+    def update(
+        self,
+        actions: List[ActionId],
+        rewards: Union[List[BinaryReward], List[List[BinaryReward]]],
+        quantities: Optional[List[Union[float, List[float], None]]] = None,
+        context: Optional[np.ndarray] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Group rows by action and dispatch to each action's ``update``.
+
+        ``context`` and ``quantities`` may be longer than ``actions`` when the
+        adaptive-window manager prepends memory rows before calling here.  We
+        slice to the trailing ``len(actions)`` rows so only the current batch
+        is passed to each per-action model.
+        """
+        if context is not None:
+            if len(context) < len(actions):
+                raise ValueError(
+                    f"context has {len(context)} rows but {len(actions)} actions were provided; "
+                    "context must have at least as many rows as actions."
+                )
+            context = context[-len(actions) :]
+
+        rewards_dict: Dict[ActionId, List[Any]] = defaultdict(list)
+        context_dict: Dict[ActionId, List[Any]] = defaultdict(list)
+
+        if quantities is None:
+            for i, (a, r) in enumerate(zip(actions, rewards)):
+                rewards_dict[a].append(r)
+                if context is not None:
+                    context_dict[a].append(context[i])
+            for a in set(actions):
+                call_kwargs: Dict[str, Any] = {"rewards": rewards_dict[a]}
+                if context is not None:
+                    call_kwargs["context"] = np.array(context_dict[a])
+                self.actions[a].update(**call_kwargs)
+        else:
+            if len(quantities) < len(actions):
+                raise ValueError(
+                    f"quantities has {len(quantities)} elements but {len(actions)} actions were provided; "
+                    "quantities must have at least as many elements as actions."
+                )
+            quantities = quantities[-len(actions) :]
+            quantities_dict: Dict[ActionId, List[Any]] = defaultdict(list)
+            for i, (a, r, q) in enumerate(zip(actions, rewards, quantities)):
+                rewards_dict[a].append(r)
+                if context is not None:
+                    context_dict[a].append(context[i])
+                quantities_dict[a].append(q)
+            for a in set(actions):
+                call_kwargs = {"rewards": rewards_dict[a]}
+                if context is not None:
+                    call_kwargs["context"] = np.array(context_dict[a])
+                if any(quantities_dict[a]):
+                    call_kwargs["quantities"] = quantities_dict[a]
+                self.actions[a].update(**call_kwargs)
+
+    def reset(self) -> None:
+        for model in self.actions.values():
+            model.reset()
+
+
+class CmabPerActionMetaModel(PerActionMetaModel[ActionModelType], Generic[ActionModelType]):
+    """Per-action meta-model for cmab variants.
+
+    Adds a cross-action consistency validator (same input dim, same update method, same
+    update kwargs) that the cmab branch needs at construction time. This lives on the
+    meta-model rather than on ``CmabActionsManager`` because the constraint is about the
+    per-action *models* (their BNN shape and training config), not about the manager.
+    """
+
+    @staticmethod
+    def _maybe_crawl_model(model: Any) -> "BayesianNeuralNetwork":
+        """Unwrap MO/quantitative wrappers to the base BNN."""
+        from pybandits.model import BaseBayesianNeuralNetworkMO  # local import: avoids circular at module top
+        from pybandits.quantitative_model import BaseQuantitativeBayesianNeuralNetwork
+
+        if isinstance(model, BaseBayesianNeuralNetworkMO):
+            return model.models[0]
+        if isinstance(model, BaseQuantitativeBayesianNeuralNetwork):
+            return model.bnn
+        return model
+
+    @staticmethod
+    def _get_expected_context_size(model: Any) -> int:
+        """Return the expected ``input_dim`` for the given cmab model."""
+        from pybandits.model import BaseBayesianNeuralNetworkMO
+
+        if isinstance(model, BaseBayesianNeuralNetworkMO):
+            return model.models[0].input_dim
+        return model.input_dim
+
+    @model_validator(mode="after")
+    def check_models(self) -> "CmabPerActionMetaModel":
+        action_models = list(self.actions.values())
+        first_action = action_models[0]
+        test_first_action = self._maybe_crawl_model(first_action)
+        for action in action_models[1:]:
+            test_action = self._maybe_crawl_model(action)
+            if not self._get_expected_context_size(first_action) == self._get_expected_context_size(action):
+                raise AttributeError("All actions should have the same input size.")
+            if not test_first_action.update_method == test_action.update_method:
+                raise AttributeError("All actions should have the same update method.")
+            if not test_first_action.update_kwargs == test_action.update_kwargs:
+                raise AttributeError("All actions should have the same update kwargs.")
+        return self
+
+
+# Module-level aliases for concrete parameterisations.
+# These are required for pickling: Python's pickle resolves a class by looking
+# up ``cls.__qualname__`` on ``sys.modules[cls.__module__]``.  Pydantic sets the
+# qualname of a parameterised generic to e.g.
+# ``PerActionMetaModel[Union[Beta, Zooming]]``; defining the alias here makes
+# that attribute accessible on this module.
+PerActionMetaModelSmabSO = PerActionMetaModel[Union[Beta, Zooming]]
+PerActionMetaModelSmabCC = PerActionMetaModel[Union[BetaCC, ZoomingCC]]
+PerActionMetaModelSmabMO = PerActionMetaModel[BetaMO]
+PerActionMetaModelSmabMOCC = PerActionMetaModel[BetaMOCC]
+
+PerActionMetaModelCmabSO = CmabPerActionMetaModel[Union[BayesianNeuralNetwork, QuantitativeBayesianNeuralNetwork]]
+PerActionMetaModelCmabCC = CmabPerActionMetaModel[Union[BayesianNeuralNetworkCC, QuantitativeBayesianNeuralNetworkCC]]
+PerActionMetaModelCmabMO = CmabPerActionMetaModel[BayesianNeuralNetworkMO]
+PerActionMetaModelCmabMOCC = CmabPerActionMetaModel[BayesianNeuralNetworkMOCC]

--- a/pybandits/transfer.py
+++ b/pybandits/transfer.py
@@ -334,8 +334,8 @@ def _merge_mabs(
     state2 = _get_state_dict(mab2)
 
     # Extract actions
-    actions1 = state1["actions_manager"]["actions"]
-    actions2 = state2["actions_manager"]["actions"]
+    actions1 = state1["actions_manager"]["meta_model"]["actions"]
+    actions2 = state2["actions_manager"]["meta_model"]["actions"]
 
     # Count overlapping actions
     overlapping = set(actions1.keys()) & set(actions2.keys())
@@ -370,7 +370,7 @@ def _merge_mabs(
     # Create merged state using mab2 as base (provides all configuration)
     # Then replace actions with merged versions (which have learned state from mab1)
     merged_state = state2
-    merged_state["actions_manager"]["actions"] = merged_actions
+    merged_state["actions_manager"]["meta_model"]["actions"] = merged_actions
 
     # Merge actions_with_change sets (for adaptive windowing)
     actions_with_change_1 = set(state1["actions_manager"].get("actions_with_change", []))
@@ -565,8 +565,8 @@ def _expand_with_template_weights(
     current_state = _get_state_dict(current_cmab)
     template_state = _get_state_dict(template_cmab)
 
-    current_actions = current_state["actions_manager"]["actions"]
-    template_actions = template_state["actions_manager"]["actions"]
+    current_actions = current_state["actions_manager"]["meta_model"]["actions"]
+    template_actions = template_state["actions_manager"]["meta_model"]["actions"]
 
     # For each overlapping action, expand by appending template's new features
     for action_id in set(current_actions.keys()) & set(template_actions.keys()):

--- a/tests/test_actions_manager.py
+++ b/tests/test_actions_manager.py
@@ -22,27 +22,32 @@
 
 import math
 from collections import defaultdict
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import pytest
-from hypothesis import given, settings
+from hypothesis import HealthCheck, assume, given, settings
 from hypothesis import strategies as st
 from pydantic import ValidationError
 from pytest_mock.plugin import MockerFixture
 
 import pybandits
-from pybandits.actions_manager import ActionsManager, CmabActionsManager, SmabActionsManager
-from pybandits.base import ACTION_IDS_PREFIX, QUANTITATIVE_ACTION_IDS_PREFIX, ActionId, BinaryReward
+from pybandits.actions_manager import (
+    ActionsManager,
+    CmabActionsManager,
+    SmabActionsManager,
+)
+from pybandits.base import ActionId, BinaryReward
+from pybandits.meta_model import BaseMetaModel, PerActionMetaModel
 from pybandits.model import BayesianNeuralNetwork, Beta, BetaMO
 from pybandits.quantitative_model import QuantitativeBayesianNeuralNetwork, Zooming
-from tests.utils import mock_update
+from tests.utils import make_action_ids, make_binary_rewards, make_context_matrix, mock_update
 
 REFERENCE_DELTA = 0.0001
 
 
 class DummyActionsManager(ActionsManager):
-    actions: Dict[ActionId, Union[Beta, BetaMO, Zooming]]
+    meta_model: PerActionMetaModel[Union[Beta, BetaMO, Zooming]]
 
     def _update_actions(
         self,
@@ -145,9 +150,8 @@ def test_update_with_valid_inputs(action_list=("action1", "action2", "action1"),
 
 
 def test_empty_actions_raises_error():
-    with pytest.raises(AttributeError) as exc_info:
+    with pytest.raises(AttributeError, match="At least one action should be defined"):
         DummyActionsManager(actions={})
-    assert str(exc_info.value) == "At least one action should be defined."
 
 
 def test_single_action_warning():
@@ -229,153 +233,6 @@ def test_change_detection(n_successes, n_failures, delta, reference):
     # Check that action1 is in the detected changes
     detected_actions = {action_id for action_id, _ in manager.actions_with_change}
     assert "action1" in detected_actions
-
-
-########################################################################################################################
-
-
-# ActionsManager._extract_action_specific_kwargs functionality tests
-
-
-def test_returns_empty_dict_when_no_action_specific_kwargs():
-    kwargs = {"param1": 1, "param2": 2}
-    result = ActionsManager._extract_action_specific_kwargs(kwargs)
-    assert result == ({}, {})
-
-
-def test_processes_kwargs_with_non_dict_values():
-    kwargs = {
-        f"{ACTION_IDS_PREFIX}param1": "not_a_dict",
-    }
-    result = ActionsManager._extract_action_specific_kwargs(kwargs)
-    assert result == ({}, {})
-
-
-def test_manages_kwargs_with_empty_dicts():
-    kwargs = {f"{ACTION_IDS_PREFIX}param1": {}, f"{ACTION_IDS_PREFIX}param2": {}}
-    result = ActionsManager._extract_action_specific_kwargs(kwargs)
-    assert result == ({}, {})
-    assert kwargs == {}
-
-
-def test_extracts_action_specific_kwargs_with_valid_keys():
-    kwargs = {
-        f"{ACTION_IDS_PREFIX}param1": {"action1": 1, "action2": 2},
-        f"{ACTION_IDS_PREFIX}param2": {"action1": 3, "action2": 4},
-    }
-    expected_output = ({"action1": {"param1": 1, "param2": 3}, "action2": {"param1": 2, "param2": 4}}, {})
-    result = ActionsManager._extract_action_specific_kwargs(kwargs)
-    assert result == expected_output
-    assert kwargs == {}
-
-
-def test_extracts_quantitative_action_specific_kwargs_with_valid_keys():
-    kwargs = {
-        f"{QUANTITATIVE_ACTION_IDS_PREFIX}param1": {"action1": 1, "action2": 2},
-        f"{QUANTITATIVE_ACTION_IDS_PREFIX}param2": {"action1": 3, "action2": 4},
-    }
-    expected_output = ({}, {"action1": {"param1": 1, "param2": 3}, "action2": {"param1": 2, "param2": 4}})
-    result = ActionsManager._extract_action_specific_kwargs(kwargs)
-    assert result == expected_output
-    assert kwargs == {}
-
-
-########################################################################################################################
-
-
-# ActionsManager._extract_action_model_class_and_attributes functionality tests
-class MockActionModel:
-    def __init__(self, param1, param2):
-        pass
-
-    @classmethod
-    def cold_start(cls):
-        pass
-
-
-def test_handles_empty_kwargs_gracefully(mocker: MockerFixture):
-    mocker.patch("pybandits.utils.extract_argument_names_from_function", return_value=[])
-    mocker.patch("pybandits.base.PyBanditsBaseModel._get_field_type", return_value=MockActionModel)
-    mocker.patch("pybandits.actions_manager.issubclass", return_value=True)
-
-    (
-        _,
-        _,
-        action_general_kwargs,
-        quantitative_action_general_kwargs,
-    ) = ActionsManager._extract_action_model_class_and_attributes({})
-
-    assert action_general_kwargs == {}
-    assert quantitative_action_general_kwargs is None
-
-    mocker.patch("pybandits.actions_manager.issubclass", side_effect=[False, True])
-    (
-        _,
-        _,
-        action_general_kwargs,
-        quantitative_action_general_kwargs,
-    ) = ActionsManager._extract_action_model_class_and_attributes({})
-    assert action_general_kwargs is None
-    assert quantitative_action_general_kwargs == {}
-
-
-def test_handles_kwargs_with_no_matching_action_model_attributes(mocker: MockerFixture):
-    mocker.patch("pybandits.utils.extract_argument_names_from_function", return_value=[])
-    mocker.patch("pybandits.base.PyBanditsBaseModel._get_field_type", return_value=MockActionModel)
-    mocker.patch("pybandits.actions_manager.issubclass", return_value=True)
-    kwargs = {"irrelevant_param": 1}
-    kwargs_copy = kwargs.copy()
-    (
-        _,
-        _,
-        action_general_kwargs,
-        quantitative_action_general_kwargs,
-    ) = ActionsManager._extract_action_model_class_and_attributes(kwargs_copy)
-
-    assert action_general_kwargs == {}
-    assert quantitative_action_general_kwargs is None
-    assert kwargs == kwargs_copy
-
-    mocker.patch("pybandits.actions_manager.issubclass", side_effect=[False, True])
-    (
-        _,
-        _,
-        action_general_kwargs,
-        quantitative_action_general_kwargs,
-    ) = ActionsManager._extract_action_model_class_and_attributes(kwargs_copy)
-
-    assert action_general_kwargs is None
-    assert quantitative_action_general_kwargs == {}
-    assert kwargs == kwargs_copy
-
-
-def test_extracts_action_model_class_and_attributes_with_valid_kwargs(mocker: MockerFixture):
-    mocker.patch("pybandits.utils.extract_argument_names_from_function", return_value=["param1", "param2"])
-    mocker.patch("pybandits.base.PyBanditsBaseModel._get_field_type", return_value=MockActionModel)
-
-    kwargs = {"param1": 1, "param2": 2}
-    with pytest.raises(TypeError):
-        ActionsManager._extract_action_model_class_and_attributes(kwargs.copy())
-
-    mocker.patch("pybandits.actions_manager.issubclass", return_value=True)
-    (
-        _,
-        _,
-        action_general_kwargs,
-        quantitative_action_general_kwargs,
-    ) = ActionsManager._extract_action_model_class_and_attributes(kwargs.copy())
-    assert action_general_kwargs == kwargs
-    assert quantitative_action_general_kwargs is None
-
-    mocker.patch("pybandits.actions_manager.issubclass", side_effect=[False, True])
-    (
-        _,
-        _,
-        action_general_kwargs,
-        quantitative_action_general_kwargs,
-    ) = ActionsManager._extract_action_model_class_and_attributes(kwargs.copy())
-    assert action_general_kwargs is None
-    assert quantitative_action_general_kwargs == kwargs
 
 
 ########################################################################################################################
@@ -899,13 +756,12 @@ def test_actions_with_change_hypothesis(change_point_indices, monkeymodule):
             },
             20,
         ),
-        ({"action1": Beta(n_successes=7, n_failures=3)}, 8),
+        ({"action1": Beta(n_successes=7, n_failures=3), "action2": Beta()}, 8),
     ],
 )
 def test_get_expected_memory_length_with_base_model_so(actions, expected_len):
     """Test _get_expected_memory_length with BaseModelSO models."""
-    actual_length = ActionsManager._get_expected_memory_length(actions)
-    assert actual_length == expected_len
+    assert ActionsManager._get_expected_memory_length(actions) == expected_len
 
 
 @pytest.mark.parametrize(
@@ -922,41 +778,7 @@ def test_get_expected_memory_length_with_base_model_so(actions, expected_len):
 )
 def test_get_expected_memory_length_with_base_model_mo(actions, expected_len):
     """Test _get_expected_memory_length with BaseModelMO models."""
-    actual_length = ActionsManager._get_expected_memory_length(actions)
-    assert actual_length == expected_len
-
-
-@pytest.mark.parametrize(
-    "actions, error_type, error_msg",
-    [
-        ({}, AttributeError, "At least one action should be defined."),
-        ({"action1": object()}, ValueError, "Model type.*not supported."),
-    ],
-)
-def test_get_expected_memory_length_with_errors(actions, error_type, error_msg):
-    """Test _get_expected_memory_length with empty or unsupported actions."""
-    with pytest.raises(error_type, match=error_msg):
-        ActionsManager._get_expected_memory_length(actions)
-
-
-def test_get_expected_memory_length_with_mixed_model_types():
-    """Test _get_expected_memory_length with mixed model types uses first model type."""
-
-    # Create mixed model types - should use the first one (BaseModelSO)
-    beta1 = Beta(n_successes=2, n_failures=1)  # count = 3
-    beta2 = Beta(n_successes=1, n_failures=1)  # count = 2
-    beta_mo = BetaMO(models=[beta1, beta2])
-
-    actions = {
-        "action1": Beta(n_successes=3, n_failures=2),  # count = 5, BaseModelSO
-        "action2": beta_mo,  # BaseModelMO
-    }
-
-    # The method should use the first model type (BaseModelSO) for consistency
-    # But since BetaMO doesn't have a count attribute, this will raise an error
-    # This test demonstrates the limitation of mixed model types
-    with pytest.raises(AttributeError, match="'BetaMO' object has no attribute 'count'"):
-        ActionsManager._get_expected_memory_length(actions)
+    assert ActionsManager._get_expected_memory_length(actions) == expected_len
 
 
 ########################################################################################################################
@@ -1095,3 +917,118 @@ def test_update_adaptive_window_size_validation(
             manager.update(
                 actions=action_list, rewards=rewards, actions_memory=actions_memory, rewards_memory=rewards_memory
             )
+
+
+########################################################################################################################
+# ActionsManager <-> meta-model integration
+
+# Both managers (smab + cmab) share the same delegation contract; we parametrize over manager
+# kind via the ``manager_factory`` fixture below so each test verifies the contract for both
+# implementations from a single body.
+
+
+# Hypothesis strategies for cross-manager shape sweeps.
+_n_actions_strategy = st.integers(min_value=2, max_value=6)
+_n_features_strategy = st.integers(min_value=1, max_value=20)
+_batch_size_strategy = st.integers(min_value=1, max_value=10)
+
+
+@pytest.fixture(
+    params=[
+        pytest.param("smab", id="smab"),
+        pytest.param("cmab", id="cmab"),
+    ]
+)
+def manager_factory(request):
+    """Yield ``build(n_actions, n_features) -> (actions_dict, manager, ctx_builder)``.
+
+    ``ctx_builder(batch_size, rng) -> Optional[np.ndarray]`` is ``None`` for smab and
+    a context-matrix builder for cmab. Tests use it to compose batch inputs without
+    knowing the manager kind.
+    """
+    kind = request.param
+
+    def build(n_actions=2, n_features=3):
+        ids = make_action_ids(n_actions)
+        if kind == "cmab":
+            actions = {a: BayesianNeuralNetwork.cold_start(n_features=n_features) for a in ids}
+            manager = CmabActionsManager[BayesianNeuralNetwork](actions=actions)
+
+            def ctx_builder(batch_size, rng):
+                return make_context_matrix(batch_size, n_features, rng=rng)
+
+            return actions, manager, ctx_builder
+        actions = {a: Beta() for a in ids}
+        return actions, SmabActionsManager[Beta](actions=actions), None
+
+    build.kind = kind  # exposed so tests can branch on context-vs-no-context cleanly
+    return build
+
+
+@settings(deadline=None, max_examples=10, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(n_actions=_n_actions_strategy, n_features=_n_features_strategy)
+def test_manager_meta_model_wiring(manager_factory, n_actions, n_features):
+    """meta_model is owned by the manager; `actions` reads through to it without copying."""
+    actions, manager, _ = manager_factory(n_actions=n_actions, n_features=n_features)
+    assert isinstance(manager.meta_model, BaseMetaModel)
+    assert isinstance(manager.meta_model, PerActionMetaModel)
+    # meta_model is a regular Pydantic field; repeated reads return the same instance.
+    assert manager.meta_model is manager.meta_model
+    assert set(manager.meta_model.action_ids) == set(manager.actions.keys())
+    for action_id in actions:
+        assert manager.actions[action_id] is manager.meta_model.actions[action_id]
+
+
+@settings(deadline=None, max_examples=15, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(n_actions=_n_actions_strategy, batch_size=_batch_size_strategy, n_features=_n_features_strategy)
+def test_manager_update_delegates_to_meta_model(monkeypatch, rng, manager_factory, n_actions, batch_size, n_features):
+    """`ActionsManager.update` forwards actions/rewards/quantities/context to the meta-model."""
+    _, manager, ctx_builder = manager_factory(n_actions=n_actions, n_features=n_features)
+    action_ids = list(manager.actions.keys())
+    captured: List[Dict[str, Any]] = []
+    monkeypatch.setattr(PerActionMetaModel, "update", lambda self, **kw: captured.append(kw), raising=True)
+
+    sampled_actions = [action_ids[i % len(action_ids)] for i in range(batch_size)]
+    rewards = make_binary_rewards(batch_size, rate=0.5, rng=rng)
+    update_kwargs = {"actions": sampled_actions, "rewards": rewards, "quantities": None}
+    if ctx_builder is not None:
+        update_kwargs["context"] = ctx_builder(batch_size, rng)
+
+    manager.update(**update_kwargs)
+
+    assert len(captured) == 1
+    assert captured[0]["actions"] == sampled_actions
+    assert captured[0]["rewards"] == rewards
+    assert captured[0]["quantities"] is None
+    if ctx_builder is not None:
+        np.testing.assert_array_equal(captured[0]["context"], update_kwargs["context"])
+
+
+@settings(deadline=None, max_examples=15, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(n_actions=_n_actions_strategy, n_valid=st.integers(min_value=1, max_value=2), n_features=_n_features_strategy)
+def test_manager_sample_proba_delegates_to_meta_model(
+    monkeypatch, rng, manager_factory, n_actions, n_valid, n_features
+):
+    """`ActionsManager.sample_proba` forwards rng/valid_action_ids/**kwargs to the meta-model."""
+    assume(n_valid <= n_actions)
+    _, manager, ctx_builder = manager_factory(n_actions=n_actions, n_features=n_features)
+    valid_ids = set(list(manager.actions.keys())[:n_valid])
+    captured = {}
+
+    def spy(self, rng, valid_action_ids=None, **kwargs):
+        captured.update(rng=rng, valid_action_ids=valid_action_ids, kwargs=kwargs)
+        return {a: [0.5] for a in (valid_action_ids or self.actions.keys())}
+
+    monkeypatch.setattr(PerActionMetaModel, "sample_proba", spy, raising=True)
+
+    if ctx_builder is not None:
+        ctx = ctx_builder(1, rng)
+        result = manager.sample_proba(rng=rng, valid_action_ids=valid_ids, context=ctx)
+        np.testing.assert_array_equal(captured["kwargs"]["context"], ctx)
+    else:
+        result = manager.sample_proba(rng=rng, valid_action_ids=valid_ids, n_samples=3)
+        assert captured["kwargs"]["n_samples"] == 3
+
+    assert set(result.keys()) == valid_ids
+    assert captured["rng"] is rng
+    assert captured["valid_action_ids"] == valid_ids

--- a/tests/test_cmab.py
+++ b/tests/test_cmab.py
@@ -81,7 +81,7 @@ from tests.utils import (
 
 
 def _apply_update_method_to_state(state, update_method):
-    for model_state in state["actions_manager"]["actions"].values():
+    for model_state in state["actions_manager"]["meta_model"]["actions"].values():
         model_state["update_method"] = update_method
 
 
@@ -847,7 +847,7 @@ def test_cmab_from_old_state_missing_feature_config(
     _, state_json = cmab.get_state()
     state = json.loads(state_json)
     state.pop("version", None)
-    for action_state in state["actions_manager"]["actions"].values():
+    for action_state in state["actions_manager"]["meta_model"]["actions"].values():
         action_state.pop("feature_config", None)
 
     reconstructed = CmabClass.from_old_state(json.dumps(state))
@@ -933,7 +933,7 @@ def test_cmab_update_kwargs_migration(
     migrated = CmabBernoulli.update_old_state(state)
 
     for action_id in ("a1", "a2"):
-        actual_kwargs = migrated["actions_manager"]["actions"][action_id].get("update_kwargs")
+        actual_kwargs = migrated["actions_manager"]["meta_model"]["actions"][action_id].get("update_kwargs")
         assert actual_kwargs == expected_kwargs
 
 

--- a/tests/test_meta_model.py
+++ b/tests/test_meta_model.py
@@ -1,0 +1,411 @@
+# MIT License
+#
+# Copyright (c) 2022 Playtika Ltd.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Tests for the meta-model abstraction layer (pybandits.meta_model)."""
+
+import pickle
+from typing import Any, Dict, List
+
+import numpy as np
+import pytest
+from pydantic import ValidationError
+from pytest_mock import MockerFixture
+
+import pybandits.model as model_mod
+from pybandits.base import ACTION_IDS_PREFIX, QUANTITATIVE_ACTION_IDS_PREFIX
+from pybandits.meta_model import (
+    BaseMetaModel,
+    PerActionMetaModel,
+    PerActionMetaModelSmabMO,
+    PerActionMetaModelSmabSO,
+)
+from pybandits.model import Beta, BetaCC, BetaMO
+from pybandits.utils import classproperty
+from tests.utils import make_action_ids
+
+########################################################################################################################
+# Shared fixtures
+
+
+@pytest.fixture
+def make_beta_actions():
+    """Factory returning a fresh ``{action_id: Beta()}`` dict each call.
+
+    Defaults to 2 actions; pass ``n`` to vary. Each call builds *new* model
+    instances so tests stay independent.
+    """
+
+    def _make(n: int = 2, factory=Beta):
+        return {a: factory() for a in make_action_ids(n)}
+
+    return _make
+
+
+@pytest.fixture
+def make_beta_meta(make_beta_actions):
+    """Factory returning a fresh ``PerActionMetaModel`` over N Beta actions."""
+
+    def _make(n: int = 2, factory=Beta):
+        return PerActionMetaModel(actions=make_beta_actions(n, factory))
+
+    return _make
+
+
+@pytest.fixture
+def spy_beta_update(monkeypatch) -> List[Dict[str, Any]]:
+    """Replace ``BaseBeta.update`` with a kwargs-capturing spy; return the captured list."""
+    captured: List[Dict[str, Any]] = []
+    monkeypatch.setattr(model_mod.BaseBeta, "update", lambda self, **kw: captured.append(kw), raising=True)
+    return captured
+
+
+########################################################################################################################
+# PerActionMetaModel — core behaviour
+
+
+def test_base_meta_model_is_abstract():
+    """BaseMetaModel cannot be instantiated directly."""
+    with pytest.raises(TypeError, match="abstract"):
+        BaseMetaModel()
+
+
+@pytest.mark.parametrize("n", [2, 4, 8])
+def test_independent_actions_meta_model_construction(make_beta_meta, n):
+    meta = make_beta_meta(n)
+    assert isinstance(meta, BaseMetaModel)
+    # Typed alias must also construct.
+    PerActionMetaModelSmabSO(actions=meta.actions.copy())
+
+
+@pytest.mark.parametrize("n", [2, 4, 8])
+def test_action_ids_property(make_beta_meta, n):
+    meta = make_beta_meta(n)
+    assert set(meta.action_ids) == set(make_action_ids(n))
+
+
+@pytest.mark.parametrize("n", [2, 4])
+def test_actions_field_preserves_model_instances(make_beta_actions, n):
+    """The ``actions`` field exposes the same model instances stored by the meta-model.
+
+    Callers that access per-action state directly (e.g. cost retrieval,
+    change-point detection) must see the same model objects via the manager's
+    ``actions`` property as the meta-model holds internally.
+    """
+    actions = make_beta_actions(n)
+    meta = PerActionMetaModel(actions=actions)
+    for a, beta in actions.items():
+        assert meta.actions[a] is beta
+
+
+@pytest.mark.parametrize("n_actions, n_samples", [(2, 1), (3, 3), (5, 7)])
+def test_sample_proba_dispatches_to_each_action(make_beta_meta, rng, n_actions, n_samples):
+    meta = make_beta_meta(n_actions)
+    result = meta.sample_proba(rng=rng, n_samples=n_samples)
+    assert set(result.keys()) == set(meta.action_ids)
+    assert all(len(v) == n_samples for v in result.values())
+
+
+@pytest.mark.parametrize("n_actions, valid_ratio, n_samples", [(4, 0.5, 2), (4, 1.0, 3), (8, 0.25, 5)])
+def test_sample_proba_restricts_to_valid_action_ids(make_beta_meta, rng, n_actions, valid_ratio, n_samples):
+    meta = make_beta_meta(n_actions)
+    valid = set(list(meta.action_ids)[: max(1, int(len(meta.action_ids) * valid_ratio))])
+    result = meta.sample_proba(rng=rng, valid_action_ids=valid, n_samples=n_samples)
+    assert set(result.keys()) == valid
+
+
+@pytest.mark.parametrize("rewards_per_action", [(2, 0), (3, 1), (5, 2)])
+def test_update_dispatches_per_action_with_no_context(make_beta_meta, rewards_per_action):
+    """smab-flavored update path: rewards only, no context.
+
+    For each action we issue ``rewards_per_action[i]`` successful pulls;
+    other actions should remain at their cold-start state.
+    """
+    meta = make_beta_meta(len(rewards_per_action))
+    actions_arg, rewards_arg = [], []
+    expected_delta = {}
+    for action_id, n in zip(meta.action_ids, rewards_per_action):
+        actions_arg.extend([action_id] * n)
+        rewards_arg.extend([1] * n)
+        expected_delta[action_id] = n
+    initial = {a: meta.actions[a].n_successes for a in meta.action_ids}
+
+    meta.update(actions=actions_arg, rewards=rewards_arg)
+
+    for a in meta.action_ids:
+        assert meta.actions[a].n_successes == initial[a] + expected_delta[a]
+
+
+@pytest.mark.parametrize("n", [2, 4])
+def test_update_resets_via_reset_method(make_beta_meta, n):
+    meta = make_beta_meta(n)
+    action_ids = list(meta.action_ids)
+    meta.update(actions=action_ids, rewards=[1] * n)
+    assert all(meta.actions[a].n_successes > 1 for a in action_ids)
+    meta.reset()
+    assert all(meta.actions[a].n_successes == 1 for a in action_ids)
+    assert all(meta.actions[a].n_failures == 1 for a in action_ids)
+
+
+@pytest.mark.parametrize("n_actions, batch_size", [(2, 5), (3, 1), (4, 10)])
+def test_update_with_only_some_actions_in_batch_leaves_others_untouched(make_beta_actions, n_actions, batch_size):
+    """Update only the first action's model; others must remain at cold-start state."""
+    actions = make_beta_actions(n_actions)
+    targeted = next(iter(actions))
+    others_before = {a: (m.n_successes, m.n_failures) for a, m in actions.items() if a != targeted}
+    meta = PerActionMetaModel(actions=actions)
+
+    meta.update(actions=[targeted] * batch_size, rewards=[1] * batch_size)
+
+    assert actions[targeted].n_successes > 1
+    for a, before in others_before.items():
+        assert (actions[a].n_successes, actions[a].n_failures) == before
+
+
+@pytest.mark.parametrize(
+    "quantities, forwarded",
+    [
+        # All-None quantities → quantities arg should NOT be forwarded.
+        ([None, None], False),
+        # Any truthy quantity → full list passed through unchanged.
+        ([None, 1.5], True),
+        ([0.5, 2.0], True),
+    ],
+)
+def test_update_with_quantities_only_passes_quantities_when_any_present(
+    make_beta_meta, spy_beta_update, quantities, forwarded
+):
+    """Mirrors the historical cmab behaviour for the ``any(quantities)`` guard."""
+    meta = make_beta_meta(1)
+    a0 = meta.action_ids[0]
+    meta.update(actions=[a0] * len(quantities), rewards=[1] * len(quantities), quantities=quantities)
+    assert len(spy_beta_update) == 1
+    if forwarded:
+        assert spy_beta_update[0]["quantities"] == quantities
+    else:
+        assert "quantities" not in spy_beta_update[0]
+
+
+@pytest.mark.parametrize("n_actions", [2, 4])
+@pytest.mark.parametrize("context_extra_rows", [0, 1, 5])
+@pytest.mark.parametrize("n_features", [1, 3, 8])
+def test_update_context_oversize_is_sliced_to_actions(
+    make_beta_meta, spy_beta_update, n_actions, context_extra_rows, n_features
+):
+    """Oversized context (memory prefix scenario): trailing ``len(actions)`` rows are used per action."""
+    meta = make_beta_meta(n_actions)
+    action_list = list(meta.action_ids)  # one row per action
+    context = np.arange((len(action_list) + context_extra_rows) * n_features, dtype=float).reshape(-1, n_features)
+    meta.update(actions=action_list, rewards=[1] * len(action_list), context=context)
+    # Each per-action update should see exactly its own row (1 row, n_features cols).
+    assert all(call["context"].shape == (1, n_features) for call in spy_beta_update)
+
+
+@pytest.mark.parametrize("n_actions, n_features", [(2, 3), (3, 5), (5, 1)])
+def test_update_context_length_guard_rejects_short_context(make_beta_meta, n_actions, n_features):
+    meta = make_beta_meta(n_actions)
+    action_list = list(meta.action_ids)
+    with pytest.raises(ValueError, match="context"):
+        meta.update(
+            actions=action_list,
+            rewards=[1] * n_actions,
+            context=np.zeros((len(action_list) - 1, n_features)),
+        )
+
+
+@pytest.mark.parametrize("n_actions", [2, 4])
+def test_update_quantities_length_guard(make_beta_meta, n_actions):
+    """update() rejects quantities shorter than actions."""
+    meta = make_beta_meta(n_actions)
+    action_list = list(meta.action_ids)
+    with pytest.raises(ValueError, match="quantities"):
+        meta.update(actions=action_list, rewards=[1] * n_actions, quantities=[1.0] * (n_actions - 1))
+
+
+@pytest.mark.parametrize("costs", [(1.0, 2.0), (0.1, 5.0, 10.0)])
+def test_independent_actions_meta_model_accepts_cc_models(costs):
+    """Cost-controlled models (BetaCC) satisfy the BaseModel constraint."""
+    actions = {a: BetaCC(cost=c) for a, c in zip(make_action_ids(len(costs)), costs)}
+    meta = PerActionMetaModel(actions=actions)
+    for action_id, expected_cost in zip(meta.action_ids, costs):
+        assert meta.actions[action_id].cost == expected_cost
+
+
+def test_per_action_meta_model_rejects_empty_actions():
+    with pytest.raises(AttributeError, match="At least one action"):
+        PerActionMetaModel[Beta](actions={})
+
+
+def test_per_action_meta_model_warns_on_single_action(make_beta_actions):
+    with pytest.warns(UserWarning, match="deterministic"):
+        PerActionMetaModel[Beta](actions=make_beta_actions(1))
+
+
+def test_per_action_meta_model_rejects_wrong_action_type():
+    """PerActionMetaModel[Beta] rejects BetaMO instances (wrong concrete type)."""
+    with pytest.raises((ValidationError, TypeError)):
+        PerActionMetaModel[Beta](actions={"a0": Beta(), "a1": BetaMO()})
+
+
+@pytest.mark.parametrize(
+    "alias, factory",
+    [
+        (PerActionMetaModelSmabSO, lambda: Beta()),
+        (PerActionMetaModelSmabMO, lambda: BetaMO(models=[Beta(), Beta()])),
+    ],
+    ids=["smab-SO", "smab-MO"],
+)
+@pytest.mark.parametrize("n_actions", [2, 3])
+def test_pickle_roundtrip_meta_model_aliases(alias, factory, n_actions):
+    """Module-level aliases are pickle-safe (require module-level name for qualname lookup)."""
+    meta = alias(actions={a: factory() for a in make_action_ids(n_actions)})
+    restored = pickle.loads(pickle.dumps(meta))
+    assert set(restored.actions.keys()) == set(meta.action_ids)
+    assert type(restored) is type(meta)
+
+
+########################################################################################################################
+# PerActionMetaModel._extract_action_specific_kwargs
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_action, expected_quant, expected_remaining",
+    [
+        # No action-specific keys: returns empty dicts, kwargs untouched.
+        ({"param1": 1, "param2": 2}, {}, {}, {"param1": 1, "param2": 2}),
+        # Non-dict value at an action-prefixed key: silently ignored.
+        ({f"{ACTION_IDS_PREFIX}param1": "not_a_dict"}, {}, {}, {f"{ACTION_IDS_PREFIX}param1": "not_a_dict"}),
+        # Empty dicts at action-prefixed keys: consumed, return empty.
+        ({f"{ACTION_IDS_PREFIX}param1": {}, f"{ACTION_IDS_PREFIX}param2": {}}, {}, {}, {}),
+        # Valid action-prefixed keys: pivoted by action id.
+        (
+            {
+                f"{ACTION_IDS_PREFIX}param1": {"action1": 1, "action2": 2},
+                f"{ACTION_IDS_PREFIX}param2": {"action1": 3, "action2": 4},
+            },
+            {"action1": {"param1": 1, "param2": 3}, "action2": {"param1": 2, "param2": 4}},
+            {},
+            {},
+        ),
+        # Valid quantitative-action-prefixed keys: pivoted into the second dict.
+        (
+            {
+                f"{QUANTITATIVE_ACTION_IDS_PREFIX}param1": {"action1": 1, "action2": 2},
+                f"{QUANTITATIVE_ACTION_IDS_PREFIX}param2": {"action1": 3, "action2": 4},
+            },
+            {},
+            {"action1": {"param1": 1, "param2": 3}, "action2": {"param1": 2, "param2": 4}},
+            {},
+        ),
+    ],
+)
+def test_extract_action_specific_kwargs(kwargs, expected_action, expected_quant, expected_remaining):
+    action, quant = PerActionMetaModel._extract_action_specific_kwargs(kwargs)
+    assert action == expected_action
+    assert quant == expected_quant
+    assert kwargs == expected_remaining
+
+
+########################################################################################################################
+# BaseMetaModel._extract_action_model_class_and_attributes
+
+
+class _MockActionModel:
+    """Stand-in action-model class for kwargs-extraction tests.
+
+    Constructor signature carries the ``param1``/``param2`` names that the
+    extractor introspects via ``extract_argument_names_from_function``.
+    """
+
+    def __init__(self, param1, param2):
+        pass
+
+    @classmethod
+    def cold_start(cls):
+        pass
+
+
+class _MockMetaModel(PerActionMetaModel):
+    """Concrete subclass that exposes ``_MockActionModel`` as the only action-model class.
+
+    Avoids patching the ``_action_model_classes`` classproperty (which now raises on
+    unparameterised classes by design); instead we override it directly here so the
+    kwargs-extractor tests can exercise the routing logic with a controlled mock class.
+    """
+
+    @classproperty
+    def _action_model_classes(cls):  # noqa: D401
+        return (_MockActionModel,)
+
+
+@pytest.mark.parametrize(
+    "issubclass_side_effect, expected_branch",
+    [
+        # The extractor's first `issubclass(...)` against (Model, ModelMO) returns True →
+        # the mock is treated as a non-quantitative ("regular") action model.
+        ({"return_value": True}, "regular"),
+        # First call returns False, second returns True → quantitative branch.
+        ({"side_effect": [False, True]}, "quantitative"),
+    ],
+)
+@pytest.mark.parametrize(
+    "kwargs, arg_names",
+    [
+        ({}, []),
+        ({"irrelevant_param": 1}, []),
+        ({"param1": 1, "param2": 2}, ["param1", "param2"]),
+    ],
+)
+def test_extract_action_model_class_and_attributes(
+    mocker: MockerFixture, issubclass_side_effect, expected_branch, kwargs, arg_names
+):
+    """The extractor routes kwargs into the regular or quantitative bucket based on ``issubclass``."""
+    mocker.patch("pybandits.meta_model.extract_argument_names_from_function", return_value=arg_names)
+    mocker.patch("pybandits.meta_model.issubclass", **issubclass_side_effect)
+
+    kwargs_copy = kwargs.copy()
+    (_, _, action_general_kwargs, quantitative_action_general_kwargs) = (
+        _MockMetaModel._extract_action_model_class_and_attributes(kwargs_copy)
+    )
+
+    # Only kwargs whose names are in `arg_names` are consumed; others remain untouched.
+    expected_consumed = {k: v for k, v in kwargs.items() if k in arg_names}
+    if expected_branch == "regular":
+        assert action_general_kwargs == expected_consumed
+        assert quantitative_action_general_kwargs is None
+    else:
+        assert action_general_kwargs is None
+        assert quantitative_action_general_kwargs == expected_consumed
+    # The non-consumed kwargs must remain in the input dict.
+    assert kwargs_copy == {k: v for k, v in kwargs.items() if k not in expected_consumed}
+
+
+def test_extract_action_model_class_and_attributes_raises_without_subclass_match(mocker: MockerFixture):
+    """When ``_MockActionModel`` matches neither Model/ModelMO nor QuantitativeModel, the extractor raises."""
+    mocker.patch("pybandits.meta_model.extract_argument_names_from_function", return_value=["param1", "param2"])
+    with pytest.raises(TypeError):
+        _MockMetaModel._extract_action_model_class_and_attributes({"param1": 1, "param2": 2})
+
+
+def test_action_model_classes_raises_on_unparameterised_meta_model():
+    """The classproperty refuses to return a fallback on unparameterised subclasses."""
+    with pytest.raises(TypeError, match="parameterise"):
+        _ = PerActionMetaModel._action_model_classes

--- a/tests/test_smab.py
+++ b/tests/test_smab.py
@@ -313,7 +313,7 @@ def test_bad_initialization(
             action_ids[0]: BetaMO(models=[Beta() for _ in range(real_n_objectives)]),
             action_ids[1]: BetaMO(models=[Beta() for _ in range(real_n_objectives + 1)]),
         }
-        with pytest.raises(AttributeError):
+        with pytest.raises(ValidationError):
             config.smab_class(actions=mo_actions_wrong)
 
 

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -911,8 +911,12 @@ class TestHiddenDimExpansion:
 
         current_state = json.loads(current.get_state()[1])
         result_state = json.loads(result.get_state()[1])
-        current_layers = current_state["actions_manager"]["actions"][_ACTION_ID]["model_params"]["bnn_layer_params"]
-        result_layers = result_state["actions_manager"]["actions"][_ACTION_ID]["model_params"]["bnn_layer_params"]
+        current_layers = current_state["actions_manager"]["meta_model"]["actions"][_ACTION_ID]["model_params"][
+            "bnn_layer_params"
+        ]
+        result_layers = result_state["actions_manager"]["meta_model"]["actions"][_ACTION_ID]["model_params"][
+            "bnn_layer_params"
+        ]
 
         assert len(current_layers) == len(result_layers), (
             f"Layer count changed after expansion: {len(current_layers)} -> {len(result_layers)}"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -38,10 +38,29 @@ def sample_with_replacement(source: list, length: PositiveInt):
     return [random.choice(source) for _ in range(length)]
 
 
+def make_action_ids(n: int) -> Tuple[str, ...]:
+    """Stable, indexable action-id tuple of length ``n``: ('a0', 'a1', ...).
+
+    Used by tests that parametrize over action count and need predictable
+    keys without hard-coding strings at each call site.
+    """
+    return tuple(f"a{i}" for i in range(n))
+
+
 def make_binary_rewards(n: int, rate: float, rng: Optional[np.random.Generator] = None) -> List[int]:
     """Return a list of n binary rewards drawn from Bernoulli(rate)."""
     _rng = rng if rng is not None else np.random.default_rng()
     return _rng.binomial(1, rate, size=n).tolist()
+
+
+def make_context_matrix(n_samples: int, n_features: int, rng: Optional[np.random.Generator] = None) -> np.ndarray:
+    """Return a ``(n_samples, n_features)`` matrix of standard-normal context features.
+
+    Used by cmab tests to build per-batch context arrays without each test reaching
+    into ``np.random`` directly.
+    """
+    _rng = rng if rng is not None else np.random.default_rng()
+    return _rng.normal(size=(n_samples, n_features))
 
 
 def to_temporary_pickle(model: PyBanditsBaseModel):


### PR DESCRIPTION
### Summary

Introduces a `BaseMetaModel` layer between `ActionsManager` (sMAB and cMAB) and per-action models. Managers store a `meta_model` field and delegate `update`, `sample_proba`, and `reset` to it. Per-action models live in the meta-model; `actions` is a property over `meta_model.actions_view()` so `mab.actions` and downstream code keep the same model instances.

Default implementation: `PerActionMetaModel` (historical per-action dispatch — **behaviour unchanged**). `SmabMetaModel[T]` and `CmabMetaModel[T]` hold the typed validators formerly on the manager classes. Optional `meta_model=` supports future shared-backbone meta-models.

### Changes

- **New module** `pybandits/meta_model.py`: `BaseMetaModel`, `PerActionMetaModel`, `SmabMetaModel[T]`, `CmabMetaModel[T]`, module aliases for pickling; `SmabModelType` / `CmabModelType` moved here.
- **`pybandits/actions_manager.py`**: `meta_model` as a Pydantic field (built via `_build_meta_model` from `actions=` or passed explicitly); `actions` as a view; base `sample_proba`; sMAB/cMAB `_update_actions` → `meta_model.update`.
- **`pybandits/mab.py`**: `_get_action_probabilities` uses `actions_manager.sample_proba(...)` instead of a local loop.
- **`pybandits/cmab.py`**, **`pybandits/transfer.py`**: serialized state under `actions_manager.meta_model.actions`; cMAB `update_old_state` migrates legacy flat `actions` where applicable.
- **Tests**: new `tests/test_meta_model.py`; integration tests in `tests/test_actions_manager.py`; updates in `tests/test_cmab.py`, `tests/test_transfer.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a meta-model layer for action management.
  * Sampling now supports restricting to valid actions.

* **Bug Fixes**
  * State migration updated to handle legacy and current action layouts.

* **Refactor**
  * Training updates and probability sampling now delegate via the meta-model.
  * Action storage/exposure moved to the meta-model view for consistent wiring.

* **Tests**
  * New/regressed tests verifying meta-model behavior, delegation, and migration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PlaytikaOSS/pybandits/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->