### PR TITLE
Add `bias_scale` option for BNN bias priors

### DIFF
--- a/pybandits/model.py
+++ b/pybandits/model.py
@@ -1407,6 +1407,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         hidden_dim_list: Optional[List[PositiveInt]],
         use_layerwise_scaling: bool = False,
         dist_class: type[BaseLocationScaleArray] = StudentTArray,
+        bias_scale: Optional[PositiveFloat] = None,
         **dist_params_init,
     ) -> BnnParams:
         """
@@ -1426,6 +1427,10 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             Whether to use layerwise scaling in the network (default is False).
         dist_class : type
             The distribution class to use for weights, biases, and embeddings, by default ``StudentTArray``.
+        bias_scale : Optional[PositiveFloat]
+            If provided, overrides ``sigma`` from ``dist_params_init`` for all layers' bias priors.
+            Applied to every layer's bias (including the output layer's logit bias), leaving weight priors unchanged.
+            Default is None (use ``sigma`` from ``dist_params_init``).
         **dist_params_init : dict, optional
             Additional parameters for initializing the distribution of weights and biases.
 
@@ -1450,7 +1455,8 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             w_param = dist_class.cold_start(
                 shape=(input_dim, output_dim), use_layerwise_scaling=use_layerwise_scaling, **dist_params_init
             )
-            b_param = dist_class.cold_start(shape=output_dim, **dist_params_init)
+            b_dist_params_init = dist_params_init if bias_scale is None else {**dist_params_init, "sigma": bias_scale}
+            b_param = dist_class.cold_start(shape=output_dim, **b_dist_params_init)
             layer_params_init.append(BnnLayerParams(weight=w_param, bias=b_param))
 
         if feature_config.categorical_features_configs:
@@ -2404,6 +2410,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         activation: ActivationFunctions = "tanh",
         use_residual_connections: bool = False,
         use_layerwise_scaling: bool = False,
+        bias_scale: Optional[PositiveFloat] = None,
         categorical_features: Optional[Dict[NonNegativeInt, NonNegativeInt]] = None,
         random_seed: Optional[NonNegativeInt] = None,
         **kwargs,
@@ -2435,6 +2442,10 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             Whether to use layerwise scaling in the network (default is False).
             When applied, the sigma is scaled by the square root of the input dimension.
             This is useful to enable smoother convergence with Gaussian Process-like behavior.
+        bias_scale : Optional[PositiveFloat]
+            If provided, overrides ``sigma`` from ``dist_params_init`` for all layers' bias priors,
+            leaving weight priors untouched. Useful to restrain the prior on the output-layer logit
+            (which otherwise pushes mass towards p=0 / p=1 after sigmoid at cold start). Default is None.
         categorical_features : Optional[Dict[int, int]], optional
             Categorical columns as ``{column_index: cardinality}``. Each categorical column is
             modelled with a Bayesian embedding matrix; ``embedding_dim`` is set automatically
@@ -2475,6 +2486,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             hidden_dim_list=hidden_dim_list,
             use_layerwise_scaling=use_layerwise_scaling,
             dist_class=dist_class,
+            bias_scale=bias_scale,
             **dist_params_init,
         )
         return cls(
@@ -2593,6 +2605,7 @@ class BaseBayesianNeuralNetworkMO(ModelMO, ABC):
         activation: ActivationFunctions = "tanh",
         use_residual_connections: bool = False,
         use_layerwise_scaling: bool = False,
+        bias_scale: Optional[PositiveFloat] = None,
         **kwargs,
     ) -> Self:
         """
@@ -2620,6 +2633,9 @@ class BaseBayesianNeuralNetworkMO(ModelMO, ABC):
             Whether to use residual connections in the network (default is False).
         use_layerwise_scaling : bool
             Whether to use layerwise scaling in the network (default is False).
+        bias_scale : Optional[PositiveFloat]
+            If provided, overrides ``sigma`` from ``dist_params`` for all layers' bias priors,
+            leaving weight priors untouched. Default is None.
         **kwargs
             Additional keyword arguments.
 
@@ -2640,6 +2656,7 @@ class BaseBayesianNeuralNetworkMO(ModelMO, ABC):
                 activation=activation,
                 use_residual_connections=use_residual_connections,
                 use_layerwise_scaling=use_layerwise_scaling,
+                bias_scale=bias_scale,
             )
             for _ in range(n_objectives)
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybandits"
-version = "7.0.0"
+version = "7.0.1"
 description = "Python Multi-Armed Bandit Library"
 authors = [
     "Dario d'Andrea <dariod@playtika.com>",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -317,6 +317,144 @@ def test_can_init_bayesian_neural_network(n_features, hidden_dim_list):
         assert bnn.model_params == model_params
 
 
+class TestBiasScale:
+    """Test suite for the ``bias_scale`` cold-start parameter of the BNN."""
+
+    @staticmethod
+    def _dist_params(dist_type: Literal["studentt", "normal"], sigma: float, nu: float) -> dict:
+        params = {"mu": 0.0, "sigma": sigma}
+        if dist_type == "studentt":
+            params["nu"] = nu
+        return params
+
+    @settings(deadline=500)
+    @given(
+        bias_scale=st.floats(min_value=1e-3, max_value=10.0, allow_nan=False, allow_infinity=False),
+        sigma=st.floats(min_value=1e-3, max_value=10.0, allow_nan=False, allow_infinity=False),
+        nu=st.floats(min_value=1.0, max_value=10.0, allow_nan=False, allow_infinity=False),
+        dist_type=st.sampled_from(["studentt", "normal"]),
+        n_features=st.integers(min_value=1, max_value=3),
+        hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
+    )
+    def test_bias_scale_overrides_bias_sigma_only(
+        self,
+        bias_scale: float,
+        sigma: float,
+        nu: float,
+        dist_type: Literal["studentt", "normal"],
+        n_features: int,
+        hidden_dim_list: list,
+    ) -> None:
+        """``bias_scale`` sets the bias prior sigma on every layer while weight priors keep ``sigma``."""
+        bnn = BayesianNeuralNetwork.cold_start(
+            n_features=n_features,
+            hidden_dim_list=hidden_dim_list,
+            dist_type=dist_type,
+            dist_params_init=self._dist_params(dist_type, sigma, nu),
+            bias_scale=bias_scale,
+        )
+        assert len(bnn.model_params.bnn_layer_params) == len(hidden_dim_list) + 1
+        for layer_params in bnn.model_params.bnn_layer_params:
+            np.testing.assert_allclose(layer_params.bias.params["sigma"], bias_scale)
+            np.testing.assert_allclose(layer_params.weight.params["sigma"], sigma)
+
+    @settings(deadline=500)
+    @given(
+        sigma=st.floats(min_value=1e-3, max_value=10.0, allow_nan=False, allow_infinity=False),
+        nu=st.floats(min_value=1.0, max_value=10.0, allow_nan=False, allow_infinity=False),
+        dist_type=st.sampled_from(["studentt", "normal"]),
+        n_features=st.integers(min_value=1, max_value=3),
+        hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
+        random_seed=st.integers(min_value=0, max_value=2**16),
+    )
+    def test_bias_scale_none_matches_default(
+        self,
+        sigma: float,
+        nu: float,
+        dist_type: Literal["studentt", "normal"],
+        n_features: int,
+        hidden_dim_list: list,
+        random_seed: int,
+    ) -> None:
+        """Passing ``bias_scale=None`` produces the same ``model_params`` as omitting it."""
+        kwargs = dict(
+            n_features=n_features,
+            hidden_dim_list=hidden_dim_list,
+            dist_type=dist_type,
+            dist_params_init=self._dist_params(dist_type, sigma, nu),
+            random_seed=random_seed,
+        )
+        bnn_default = BayesianNeuralNetwork.cold_start(**kwargs)
+        bnn_none = BayesianNeuralNetwork.cold_start(bias_scale=None, **kwargs)
+        assert bnn_default.model_params == bnn_none.model_params
+
+    @settings(deadline=500)
+    @given(
+        bias_scale=st.floats(min_value=1e-3, max_value=10.0, allow_nan=False, allow_infinity=False),
+        sigma=st.floats(min_value=1e-3, max_value=10.0, allow_nan=False, allow_infinity=False),
+        nu=st.floats(min_value=1.0, max_value=10.0, allow_nan=False, allow_infinity=False),
+        dist_type=st.sampled_from(["studentt", "normal"]),
+        n_objectives=st.integers(min_value=1, max_value=3),
+        n_features=st.integers(min_value=1, max_value=3),
+        hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
+    )
+    def test_bias_scale_propagates_through_mo_cold_start(
+        self,
+        bias_scale: float,
+        sigma: float,
+        nu: float,
+        dist_type: Literal["studentt", "normal"],
+        n_objectives: int,
+        n_features: int,
+        hidden_dim_list: list,
+    ) -> None:
+        """``bias_scale`` is forwarded to each per-objective BNN in the MO variant."""
+        mo_bnn = BayesianNeuralNetworkMO.cold_start(
+            n_objectives=n_objectives,
+            n_features=n_features,
+            hidden_dim_list=hidden_dim_list,
+            dist_type=dist_type,
+            dist_params=self._dist_params(dist_type, sigma, nu),
+            bias_scale=bias_scale,
+        )
+        assert len(mo_bnn.models) == n_objectives
+        for model in mo_bnn.models:
+            for layer_params in model.model_params.bnn_layer_params:
+                np.testing.assert_allclose(layer_params.bias.params["sigma"], bias_scale)
+
+    @settings(deadline=500)
+    @given(
+        bias_scale=st.floats(min_value=1e-3, max_value=10.0, allow_nan=False, allow_infinity=False),
+        sigma=st.floats(min_value=1e-3, max_value=10.0, allow_nan=False, allow_infinity=False),
+        nu=st.floats(min_value=1.0, max_value=10.0, allow_nan=False, allow_infinity=False),
+        dist_type=st.sampled_from(["studentt", "normal"]),
+        n_features=st.integers(min_value=1, max_value=5),
+        hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
+    )
+    def test_bias_scale_independent_of_layerwise_scaling(
+        self,
+        bias_scale: float,
+        sigma: float,
+        nu: float,
+        dist_type: Literal["studentt", "normal"],
+        n_features: int,
+        hidden_dim_list: list,
+    ) -> None:
+        """``bias_scale`` applies verbatim to bias sigma even when ``use_layerwise_scaling`` shrinks weight sigma."""
+        bnn = BayesianNeuralNetwork.cold_start(
+            n_features=n_features,
+            hidden_dim_list=hidden_dim_list,
+            dist_type=dist_type,
+            dist_params_init=self._dist_params(dist_type, sigma, nu),
+            use_layerwise_scaling=True,
+            bias_scale=bias_scale,
+        )
+        fan_ins = [n_features] + hidden_dim_list
+        for layer_params, fan_in in zip(bnn.model_params.bnn_layer_params, fan_ins):
+            np.testing.assert_allclose(layer_params.bias.params["sigma"], bias_scale)
+            np.testing.assert_allclose(layer_params.weight.params["sigma"], sigma / np.sqrt(fan_in))
+
+
 @settings(deadline=500)
 @given(
     n_samples=st.integers(min_value=1, max_value=1000),


### PR DESCRIPTION
### Changes:
* Add `bias_scale` parameter to `BaseBayesianNeuralNetwork._init_bnn_params` and `cold_start` (plus the `MO` variant) to override `sigma` for all layer bias priors while leaving weight priors untouched
  - Restrains the output-layer logit prior, which otherwise concentrates mass near p=0/p=1 after sigmoid at cold start
* Add tests in `tests/test_model.py` covering the new `bias_scale` behaviour
* Bump version to `7.0.1` in `pyproject.toml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional bias_scale parameter to Bayesian Neural Network cold-starts, allowing independent control of bias prior scale separate from weight priors for single- and multi-objective models.
* **Tests**
  * Added tests validating bias_scale behavior and its interaction with existing scaling options.
* **Chores**
  * Package version bumped to 7.0.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PlaytikaOSS/pybandits/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->