### PR TITLE
Add calibrate_output_bias option and rename bias_scale to bias_std

### DIFF
--- a/pybandits/model.py
+++ b/pybandits/model.py
@@ -1253,7 +1253,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
     ]
     _distribution_mapping: ClassVar[Dict[str, type]] = {"normal": NormalArray, "studentt": StudentTArray}
     _embedding_dim_divisor: ClassVar[int] = 4
-    _min_sigma: ClassVar[float] = 1e-6
+    _numerical_eps: ClassVar[float] = 1e-6
     _supported_optimizers: ClassVar[dict] = {
         "sgd": noptim.SGD,
         "momentum": noptim.Momentum,
@@ -1280,6 +1280,8 @@ class BaseBayesianNeuralNetwork(Model, ABC):
     use_residual_connections: bool = False
     feature_config: FeaturesConfig
     random_seed: Optional[NonNegativeInt] = None
+    calibrate_output_bias: bool = False
+    bias_calibrated: bool = False
 
     _rng_key: Any = PrivateAttr(default=None)
 
@@ -1327,6 +1329,12 @@ class BaseBayesianNeuralNetwork(Model, ABC):
                 f"Invalid activation function: {v}. Supported activations are: {list(cls._jax_activations.keys())}"
             )
         return v
+
+    @model_validator(mode="after")
+    def validate_bias_calibrated(self) -> "BaseBayesianNeuralNetwork":
+        if self.bias_calibrated and not self.calibrate_output_bias:
+            raise ValueError("bias_calibrated=True requires calibrate_output_bias=True.")
+        return self
 
     @classmethod
     def get_embedding_var_name(cls, feat_index: int) -> str:
@@ -1407,7 +1415,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         hidden_dim_list: Optional[List[PositiveInt]],
         use_layerwise_scaling: bool = False,
         dist_class: type[BaseLocationScaleArray] = StudentTArray,
-        bias_scale: Optional[PositiveFloat] = None,
+        bias_std: Optional[PositiveFloat] = None,
         **dist_params_init,
     ) -> BnnParams:
         """
@@ -1427,7 +1435,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             Whether to use layerwise scaling in the network (default is False).
         dist_class : type
             The distribution class to use for weights, biases, and embeddings, by default ``StudentTArray``.
-        bias_scale : Optional[PositiveFloat]
+        bias_std : Optional[PositiveFloat]
             If provided, overrides ``sigma`` from ``dist_params_init`` for all layers' bias priors.
             Applied to every layer's bias (including the output layer's logit bias), leaving weight priors unchanged.
             Default is None (use ``sigma`` from ``dist_params_init``).
@@ -1455,7 +1463,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             w_param = dist_class.cold_start(
                 shape=(input_dim, output_dim), use_layerwise_scaling=use_layerwise_scaling, **dist_params_init
             )
-            b_dist_params_init = dist_params_init if bias_scale is None else {**dist_params_init, "sigma": bias_scale}
+            b_dist_params_init = dist_params_init if bias_std is None else {**dist_params_init, "sigma": bias_std}
             b_param = dist_class.cold_start(shape=output_dim, **b_dist_params_init)
             layer_params_init.append(BnnLayerParams(weight=w_param, bias=b_param))
 
@@ -1755,7 +1763,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
                 # Final output processing
                 logit = numpyro.deterministic(
                     self._logit_var_name,
-                    jnp.clip(linear_transform.squeeze(-1), -_LOGIT_CLIPPING_THRESHOLD, _LOGIT_CLIPPING_THRESHOLD),
+                    linear_transform.squeeze(-1),
                 )
                 numpyro.sample("out", NumpyroBernoulli(logits=logit), obs=y_batch)
 
@@ -2035,7 +2043,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             emb_var_name = self.get_embedding_var_name(i)
             emb_values = np.array(samples[emb_var_name])
             emb_mu = np.mean(emb_values, axis=0)
-            emb_sigma = np.maximum(np.std(emb_values, axis=0), self._min_sigma)
+            emb_sigma = np.maximum(np.std(emb_values, axis=0), self._numerical_eps)
             updated_embeddings.append(orig_emb.with_dist_parameters(mu=emb_mu.tolist(), sigma=emb_sigma.tolist()))
         self.model_params.embedding_params.embeddings = updated_embeddings
 
@@ -2079,8 +2087,8 @@ class BaseBayesianNeuralNetwork(Model, ABC):
 
         all_mus_flat = np.concatenate(all_mus)
         init_loc_fn = init_to_median if np.all(all_mus_flat == 0) else init_to_value(values=values)
-        avg_sigma = float(max(np.mean(np.concatenate(all_sigmas)), self._min_sigma))
-        site_sigmas = {name: np.maximum(sigma, self._min_sigma) for name, sigma in site_sigmas.items()}
+        avg_sigma = float(max(np.mean(np.concatenate(all_sigmas)), self._numerical_eps))
+        site_sigmas = {name: np.maximum(sigma, self._numerical_eps) for name, sigma in site_sigmas.items()}
         init_scale_fn = lambda name: site_sigmas.get(name, avg_sigma)  # noqa: E731
         return init_loc_fn, init_scale_fn
 
@@ -2215,7 +2223,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         # AutoNormal stores per-site: {name}_auto_loc (mean) and {name}_auto_scale (already-constrained std)
         site_mu = {k.removesuffix("_auto_loc"): v for k, v in params.items() if k.endswith("_auto_loc")}
         site_sigma = {
-            k.removesuffix("_auto_scale"): np.maximum(v, self._min_sigma)
+            k.removesuffix("_auto_scale"): np.maximum(v, self._numerical_eps)
             for k, v in params.items()
             if k.endswith("_auto_scale")
         }
@@ -2348,9 +2356,9 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             b_values = np.array(samples[bias_layer_params_name])
 
             w_mu = np.mean(w_values, axis=0)
-            w_sigma = np.maximum(np.std(w_values, axis=0), self._min_sigma)
+            w_sigma = np.maximum(np.std(w_values, axis=0), self._numerical_eps)
             b_mu = np.mean(b_values, axis=0)
-            b_sigma = np.maximum(np.std(b_values, axis=0), self._min_sigma)
+            b_sigma = np.maximum(np.std(b_values, axis=0), self._numerical_eps)
 
             updated_layer_params = self._create_updated_layer_params(
                 w_mu, w_sigma, b_mu, b_sigma, layer_params.weight, layer_params.bias
@@ -2387,6 +2395,9 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         y_jnp = jnp.array(np.array(rewards, dtype=np.int32), dtype=jnp.int32)
         n_samples = _context.shape[0]
 
+        if self.calibrate_output_bias:
+            self._calibrate_output_bias(rewards)
+
         if self.update_method == "VI":
             updated_layer_params_list = self._extract_vi_params(x_jnp, y_jnp, n_samples)
 
@@ -2410,9 +2421,10 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         activation: ActivationFunctions = "tanh",
         use_residual_connections: bool = False,
         use_layerwise_scaling: bool = False,
-        bias_scale: Optional[PositiveFloat] = None,
+        bias_std: Optional[PositiveFloat] = None,
         categorical_features: Optional[Dict[NonNegativeInt, NonNegativeInt]] = None,
         random_seed: Optional[NonNegativeInt] = None,
+        calibrate_output_bias: bool = False,
         **kwargs,
     ) -> Self:
         """
@@ -2442,10 +2454,16 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             Whether to use layerwise scaling in the network (default is False).
             When applied, the sigma is scaled by the square root of the input dimension.
             This is useful to enable smoother convergence with Gaussian Process-like behavior.
-        bias_scale : Optional[PositiveFloat]
+        bias_std : Optional[PositiveFloat]
             If provided, overrides ``sigma`` from ``dist_params_init`` for all layers' bias priors,
             leaving weight priors untouched. Useful to restrain the prior on the output-layer logit
             (which otherwise pushes mass towards p=0 / p=1 after sigmoid at cold start). Default is None.
+        calibrate_output_bias : bool
+            If True, the output-layer bias mu is set to ``logit(empirical_reward_rate)`` on the very first
+            ``update()`` call, before VI/MCMC training begins. This replaces the cold-start prior mean
+            (logit 0 ≈ 50 % reward rate) with a data-driven intercept, preventing optimistic over-exploration
+            of arms that have accumulated little data. The calibration fires only once per arm lifetime
+            (or after a ``_reset()``). Default is False.
         categorical_features : Optional[Dict[int, int]], optional
             Categorical columns as ``{column_index: cardinality}``. Each categorical column is
             modelled with a Bayesian embedding matrix; ``embedding_dim`` is set automatically
@@ -2486,7 +2504,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             hidden_dim_list=hidden_dim_list,
             use_layerwise_scaling=use_layerwise_scaling,
             dist_class=dist_class,
-            bias_scale=bias_scale,
+            bias_std=bias_std,
             **dist_params_init,
         )
         return cls(
@@ -2497,8 +2515,44 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             use_residual_connections=use_residual_connections,
             feature_config=feature_config,
             random_seed=random_seed,
+            calibrate_output_bias=calibrate_output_bias,
             **kwargs,
         )
+
+    def _calibrate_output_bias(self, rewards: List[BinaryReward]) -> None:
+        """Set the output-layer bias mu to ``logit(empirical_reward_rate)`` on the first update call.
+
+        Replaces the cold-start prior mean (logit 0 ≈ 50 % reward rate) with a data-driven intercept
+        derived from the observed reward rate in ``rewards``.  This prevents the model from
+        over-exploring arms that have accumulated little data but whose prior pushes predicted
+        probability toward 0.5, making them appear more rewarding than they actually are.
+
+        The calibration fires exactly once per arm lifetime (or after a ``_reset()`` call).
+        Subsequent calls are no-ops guarded by the ``bias_calibrated`` flag.
+
+        Parameters
+        ----------
+        rewards : List[BinaryReward]
+            Binary rewards (0/1) observed in the current update batch.  The empirical reward rate
+            (mean of ``rewards``) is clipped to ``[_numerical_eps, 1 - _numerical_eps]`` before
+            the logit transform to avoid ``log(0)`` / ``log(inf)`` instability.
+
+        Notes
+        -----
+        - The sigma of the output-layer bias prior is left unchanged; only ``mu`` is updated.
+        - This method is called from ``_update`` before VI/MCMC training begins, so the
+          calibrated intercept serves as the warm-start location for the variational guide.
+        - The clipping bounds use ``_numerical_eps`` to stay safely away from the degenerate logit values at 0 and 1.
+        """
+        if self.bias_calibrated or len(rewards) == 0:
+            return
+        reward_rate = float(np.clip(np.mean(rewards), self._numerical_eps, 1 - self._numerical_eps))
+        intercept = float(np.log(reward_rate / (1 - reward_rate)))
+        output_layer = self.model_params.bnn_layer_params[-1]
+        new_mu = np.full(output_layer.bias.shape, intercept)
+        new_bias = output_layer.bias.with_dist_parameters(mu=new_mu.tolist())
+        self.model_params.bnn_layer_params[-1] = BnnLayerParams(weight=output_layer.weight, bias=new_bias)
+        self.bias_calibrated = True
 
     def _reset(self):
         """
@@ -2507,6 +2561,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         self.model_params.bnn_layer_params = deepcopy(self.model_params.bnn_layer_params_init)
         if self.model_params.embedding_params is not None:
             self.model_params.embedding_params.embeddings = deepcopy(self.model_params.embedding_params.embeddings_init)
+        self.bias_calibrated = False
 
 
 class BayesianNeuralNetwork(BaseBayesianNeuralNetwork):
@@ -2605,7 +2660,7 @@ class BaseBayesianNeuralNetworkMO(ModelMO, ABC):
         activation: ActivationFunctions = "tanh",
         use_residual_connections: bool = False,
         use_layerwise_scaling: bool = False,
-        bias_scale: Optional[PositiveFloat] = None,
+        bias_std: Optional[PositiveFloat] = None,
         **kwargs,
     ) -> Self:
         """
@@ -2633,7 +2688,7 @@ class BaseBayesianNeuralNetworkMO(ModelMO, ABC):
             Whether to use residual connections in the network (default is False).
         use_layerwise_scaling : bool
             Whether to use layerwise scaling in the network (default is False).
-        bias_scale : Optional[PositiveFloat]
+        bias_std : Optional[PositiveFloat]
             If provided, overrides ``sigma`` from ``dist_params`` for all layers' bias priors,
             leaving weight priors untouched. Default is None.
         **kwargs
@@ -2656,7 +2711,7 @@ class BaseBayesianNeuralNetworkMO(ModelMO, ABC):
                 activation=activation,
                 use_residual_connections=use_residual_connections,
                 use_layerwise_scaling=use_layerwise_scaling,
-                bias_scale=bias_scale,
+                bias_std=bias_std,
             )
             for _ in range(n_objectives)
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybandits"
-version = "7.0.2"
+version = "7.0.3"
 description = "Python Multi-Armed Bandit Library"
 authors = [
     "Dario d'Andrea <dariod@playtika.com>",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -34,6 +34,7 @@ from numpyro.distributions import Normal as NumpyroNormal
 from numpyro.distributions import StudentT as NumpyroStudentT
 from numpyro.infer import Predictive
 from pydantic import ValidationError
+from utils import make_binary_rewards
 
 from pybandits.model import (
     BaseBayesianNeuralNetwork,
@@ -54,6 +55,29 @@ from pybandits.model import (
     StudentTArray,
     UpdateMethods,
 )
+
+
+@pytest.fixture(scope="module")
+def make_bnn():
+    """Factory fixture: returns a callable that builds a BayesianNeuralNetwork via cold_start."""
+
+    def _factory(
+        n_features: int, hidden_dim_list: list[int], calibrate_output_bias: bool = True
+    ) -> BayesianNeuralNetwork:
+        return BayesianNeuralNetwork.cold_start(
+            n_features=n_features,
+            hidden_dim_list=hidden_dim_list,
+            calibrate_output_bias=calibrate_output_bias,
+        )
+
+    return _factory
+
+
+@pytest.fixture(scope="module")
+def calibration_bnn(make_bnn) -> BayesianNeuralNetwork:
+    """Single BNN instance for calibration tests; call ``_reset()`` before each use to restore fresh state."""
+    return make_bnn(n_features=2, hidden_dim_list=[4])
+
 
 ########################################################################################################################
 
@@ -317,8 +341,8 @@ def test_can_init_bayesian_neural_network(n_features, hidden_dim_list):
         assert bnn.model_params == model_params
 
 
-class TestBiasScale:
-    """Test suite for the ``bias_scale`` cold-start parameter of the BNN."""
+class TestBiasStd:
+    """Test suite for the ``bias_std`` cold-start parameter of the BNN."""
 
     @staticmethod
     def _dist_params(dist_type: Literal["studentt", "normal"], sigma: float, nu: float) -> dict:
@@ -329,33 +353,33 @@ class TestBiasScale:
 
     @settings(deadline=500)
     @given(
-        bias_scale=st.floats(min_value=1e-3, max_value=10.0, allow_nan=False, allow_infinity=False),
+        bias_std=st.floats(min_value=1e-3, max_value=10.0, allow_nan=False, allow_infinity=False),
         sigma=st.floats(min_value=1e-3, max_value=10.0, allow_nan=False, allow_infinity=False),
         nu=st.floats(min_value=1.0, max_value=10.0, allow_nan=False, allow_infinity=False),
         dist_type=st.sampled_from(["studentt", "normal"]),
         n_features=st.integers(min_value=1, max_value=3),
         hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
     )
-    def test_bias_scale_overrides_bias_sigma_only(
+    def test_bias_std_overrides_bias_sigma_only(
         self,
-        bias_scale: float,
+        bias_std: float,
         sigma: float,
         nu: float,
         dist_type: Literal["studentt", "normal"],
         n_features: int,
         hidden_dim_list: list,
     ) -> None:
-        """``bias_scale`` sets the bias prior sigma on every layer while weight priors keep ``sigma``."""
+        """``bias_std`` sets the bias prior sigma on every layer while weight priors keep ``sigma``."""
         bnn = BayesianNeuralNetwork.cold_start(
             n_features=n_features,
             hidden_dim_list=hidden_dim_list,
             dist_type=dist_type,
             dist_params_init=self._dist_params(dist_type, sigma, nu),
-            bias_scale=bias_scale,
+            bias_std=bias_std,
         )
         assert len(bnn.model_params.bnn_layer_params) == len(hidden_dim_list) + 1
         for layer_params in bnn.model_params.bnn_layer_params:
-            np.testing.assert_allclose(layer_params.bias.params["sigma"], bias_scale)
+            np.testing.assert_allclose(layer_params.bias.params["sigma"], bias_std)
             np.testing.assert_allclose(layer_params.weight.params["sigma"], sigma)
 
     @settings(deadline=500)
@@ -367,7 +391,7 @@ class TestBiasScale:
         hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
         random_seed=st.integers(min_value=0, max_value=2**16),
     )
-    def test_bias_scale_none_matches_default(
+    def test_bias_std_none_matches_default(
         self,
         sigma: float,
         nu: float,
@@ -376,7 +400,7 @@ class TestBiasScale:
         hidden_dim_list: list,
         random_seed: int,
     ) -> None:
-        """Passing ``bias_scale=None`` produces the same ``model_params`` as omitting it."""
+        """Passing ``bias_std=None`` produces the same ``model_params`` as omitting it."""
         kwargs = dict(
             n_features=n_features,
             hidden_dim_list=hidden_dim_list,
@@ -385,12 +409,12 @@ class TestBiasScale:
             random_seed=random_seed,
         )
         bnn_default = BayesianNeuralNetwork.cold_start(**kwargs)
-        bnn_none = BayesianNeuralNetwork.cold_start(bias_scale=None, **kwargs)
+        bnn_none = BayesianNeuralNetwork.cold_start(bias_std=None, **kwargs)
         assert bnn_default.model_params == bnn_none.model_params
 
     @settings(deadline=500)
     @given(
-        bias_scale=st.floats(min_value=1e-3, max_value=10.0, allow_nan=False, allow_infinity=False),
+        bias_std=st.floats(min_value=1e-3, max_value=10.0, allow_nan=False, allow_infinity=False),
         sigma=st.floats(min_value=1e-3, max_value=10.0, allow_nan=False, allow_infinity=False),
         nu=st.floats(min_value=1.0, max_value=10.0, allow_nan=False, allow_infinity=False),
         dist_type=st.sampled_from(["studentt", "normal"]),
@@ -398,9 +422,9 @@ class TestBiasScale:
         n_features=st.integers(min_value=1, max_value=3),
         hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
     )
-    def test_bias_scale_propagates_through_mo_cold_start(
+    def test_bias_std_propagates_through_mo_cold_start(
         self,
-        bias_scale: float,
+        bias_std: float,
         sigma: float,
         nu: float,
         dist_type: Literal["studentt", "normal"],
@@ -408,51 +432,174 @@ class TestBiasScale:
         n_features: int,
         hidden_dim_list: list,
     ) -> None:
-        """``bias_scale`` is forwarded to each per-objective BNN in the MO variant."""
+        """``bias_std`` is forwarded to each per-objective BNN in the MO variant."""
         mo_bnn = BayesianNeuralNetworkMO.cold_start(
             n_objectives=n_objectives,
             n_features=n_features,
             hidden_dim_list=hidden_dim_list,
             dist_type=dist_type,
             dist_params=self._dist_params(dist_type, sigma, nu),
-            bias_scale=bias_scale,
+            bias_std=bias_std,
         )
         assert len(mo_bnn.models) == n_objectives
         for model in mo_bnn.models:
             for layer_params in model.model_params.bnn_layer_params:
-                np.testing.assert_allclose(layer_params.bias.params["sigma"], bias_scale)
+                np.testing.assert_allclose(layer_params.bias.params["sigma"], bias_std)
 
     @settings(deadline=500)
     @given(
-        bias_scale=st.floats(min_value=1e-3, max_value=10.0, allow_nan=False, allow_infinity=False),
+        bias_std=st.floats(min_value=1e-3, max_value=10.0, allow_nan=False, allow_infinity=False),
         sigma=st.floats(min_value=1e-3, max_value=10.0, allow_nan=False, allow_infinity=False),
         nu=st.floats(min_value=1.0, max_value=10.0, allow_nan=False, allow_infinity=False),
         dist_type=st.sampled_from(["studentt", "normal"]),
         n_features=st.integers(min_value=1, max_value=5),
         hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
     )
-    def test_bias_scale_independent_of_layerwise_scaling(
+    def test_bias_std_independent_of_layerwise_scaling(
         self,
-        bias_scale: float,
+        bias_std: float,
         sigma: float,
         nu: float,
         dist_type: Literal["studentt", "normal"],
         n_features: int,
         hidden_dim_list: list,
     ) -> None:
-        """``bias_scale`` applies verbatim to bias sigma even when ``use_layerwise_scaling`` shrinks weight sigma."""
+        """``bias_std`` applies verbatim to bias sigma even when ``use_layerwise_scaling`` shrinks weight sigma."""
         bnn = BayesianNeuralNetwork.cold_start(
             n_features=n_features,
             hidden_dim_list=hidden_dim_list,
             dist_type=dist_type,
             dist_params_init=self._dist_params(dist_type, sigma, nu),
             use_layerwise_scaling=True,
-            bias_scale=bias_scale,
+            bias_std=bias_std,
         )
         fan_ins = [n_features] + hidden_dim_list
         for layer_params, fan_in in zip(bnn.model_params.bnn_layer_params, fan_ins):
-            np.testing.assert_allclose(layer_params.bias.params["sigma"], bias_scale)
+            np.testing.assert_allclose(layer_params.bias.params["sigma"], bias_std)
             np.testing.assert_allclose(layer_params.weight.params["sigma"], sigma / np.sqrt(fan_in))
+
+
+class TestCalibrateOutputBias:
+    """Test suite for ``calibrate_output_bias`` and the ``bias_calibrated`` flag on the BNN."""
+
+    @pytest.mark.parametrize(
+        "calibrate_output_bias, bias_calibrated, should_raise",
+        [
+            (False, True, True),
+            (True, True, False),
+            (True, False, False),
+        ],
+    )
+    def test_validator_bias_calibrated_consistency(
+        self, calibrate_output_bias: bool, bias_calibrated: bool, should_raise: bool, n_features: int = 2
+    ) -> None:
+        """Validator rejects bias_calibrated=True when calibrate_output_bias=False; allows all other combos."""
+        fc = FeaturesConfig(n_features=n_features)
+        model_params = BayesianNeuralNetwork.create_model_params(fc, [])
+        kwargs = dict(
+            model_params=model_params,
+            feature_config=fc,
+            calibrate_output_bias=calibrate_output_bias,
+            bias_calibrated=bias_calibrated,
+        )
+        if should_raise:
+            with pytest.raises(ValidationError):
+                BayesianNeuralNetwork(**kwargs)
+        else:
+            BayesianNeuralNetwork(**kwargs)
+
+    @given(
+        n_rewards=st.integers(min_value=5, max_value=50),
+        reward_rate=st.floats(min_value=0.05, max_value=0.95, allow_nan=False),
+        rtol=st.just(1e-5),
+    )
+    def test_output_bias_mu_set_to_logit_of_reward_rate(
+        self, calibration_bnn: BayesianNeuralNetwork, n_rewards: int, reward_rate: float, rtol
+    ) -> None:
+        """After ``_calibrate_output_bias``, the output-layer bias mu equals ``logit(empirical_reward_rate)``."""
+        calibration_bnn._reset()
+        rewards = make_binary_rewards(n_rewards, reward_rate)
+        calibration_bnn._calibrate_output_bias(rewards)
+
+        eps = BaseBayesianNeuralNetwork._numerical_eps
+        empirical_rate = float(np.clip(np.mean(rewards), eps, 1 - eps))
+        expected_intercept = float(np.log(empirical_rate / (1 - empirical_rate)))
+        np.testing.assert_allclose(
+            np.array(calibration_bnn.model_params.bnn_layer_params[-1].bias.params["mu"]),
+            expected_intercept,
+            rtol=rtol,
+        )
+
+    @given(
+        n_features=st.integers(min_value=1, max_value=3),
+        hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
+        n_rewards=st.integers(min_value=5, max_value=50),
+        reward_rate=st.floats(min_value=0.05, max_value=0.95, allow_nan=False),
+    )
+    def test_calibration_fires_only_once(
+        self, make_bnn, n_features: int, hidden_dim_list: list[int], n_rewards: int, reward_rate: float
+    ) -> None:
+        """A second call to ``_calibrate_output_bias`` is a no-op (bias_calibrated guard)."""
+        bnn = make_bnn(n_features, hidden_dim_list)
+        rewards = make_binary_rewards(n_rewards, reward_rate)
+
+        bnn._calibrate_output_bias(rewards)
+        mu_after_first = list(bnn.model_params.bnn_layer_params[-1].bias.params["mu"])
+
+        bnn._calibrate_output_bias([1 - r for r in rewards])
+        assert list(bnn.model_params.bnn_layer_params[-1].bias.params["mu"]) == mu_after_first
+
+    @given(
+        n_features=st.integers(min_value=1, max_value=3),
+        hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
+        rewards=st.lists(st.integers(min_value=0, max_value=1), min_size=5, max_size=50),
+    )
+    def test_calibration_flag_lifecycle(
+        self, make_bnn, n_features: int, hidden_dim_list: list[int], rewards: list[int]
+    ) -> None:
+        """``bias_calibrated`` is set by ``_calibrate_output_bias`` and cleared by ``_reset``."""
+        bnn = make_bnn(n_features, hidden_dim_list)
+        bnn._calibrate_output_bias(rewards)
+        assert bnn.bias_calibrated is True
+        bnn._reset()
+        assert bnn.bias_calibrated is False
+
+    @given(
+        n_features=st.integers(min_value=1, max_value=3),
+        hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
+        rewards=st.lists(st.integers(min_value=0, max_value=1), min_size=5, max_size=50),
+    )
+    def test_calibration_only_mutates_output_layer_bias_mu(
+        self, make_bnn, n_features: int, hidden_dim_list: list[int], rewards: list[int]
+    ) -> None:
+        """Calibration touches only output-layer bias mu; all sigmas and hidden-layer mus are unchanged."""
+        bnn = make_bnn(n_features, hidden_dim_list)
+        output_sigma_before = list(bnn.model_params.bnn_layer_params[-1].bias.params["sigma"])
+        hidden_mus_before = [list(layer.bias.params["mu"]) for layer in bnn.model_params.bnn_layer_params[:-1]]
+
+        bnn._calibrate_output_bias(rewards)
+
+        assert list(bnn.model_params.bnn_layer_params[-1].bias.params["sigma"]) == output_sigma_before
+        assert [list(layer.bias.params["mu"]) for layer in bnn.model_params.bnn_layer_params[:-1]] == hidden_mus_before
+
+    @pytest.mark.parametrize("constant_reward", [0, 1])
+    @given(
+        n_features=st.integers(min_value=1, max_value=3),
+        hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
+        n_rewards=st.integers(min_value=5, max_value=50),
+    )
+    def test_constant_rewards_clip_to_finite_logit(
+        self,
+        make_bnn,
+        constant_reward: int,
+        n_features: int,
+        hidden_dim_list: list[int],
+        n_rewards: int,
+    ) -> None:
+        """All-identical rewards clip to eps / 1-eps, keeping the logit finite."""
+        bnn = make_bnn(n_features, hidden_dim_list)
+        bnn._calibrate_output_bias([constant_reward] * n_rewards)
+        assert all(np.isfinite(bnn.model_params.bnn_layer_params[-1].bias.params["mu"]))
 
 
 @settings(deadline=500)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,7 @@ import json
 import pickle
 import random
 from tempfile import NamedTemporaryFile
-from typing import Any, List, Tuple, get_args
+from typing import Any, List, Optional, Tuple, get_args
 
 import numpy as np
 from bokeh.core.serialization import Serializable
@@ -36,6 +36,12 @@ class _EvalArray:
 
 def sample_with_replacement(source: list, length: PositiveInt):
     return [random.choice(source) for _ in range(length)]
+
+
+def make_binary_rewards(n: int, rate: float, rng: Optional[np.random.Generator] = None) -> List[int]:
+    """Return a list of n binary rewards drawn from Bernoulli(rate)."""
+    _rng = rng if rng is not None else np.random.default_rng()
+    return _rng.binomial(1, rate, size=n).tolist()
 
 
 def to_temporary_pickle(model: PyBanditsBaseModel):


### PR DESCRIPTION
### Changes:

- Rename bias_scale parameter to bias_std in BaseBayesianNeuralNetwork.cold_start() and BaseBayesianNeuralNetworkMO.cold_start() for naming clarity
- Add calibrate_output_bias field to BaseBayesianNeuralNetwork — fires once on first _update() to set output-layer bias mu to logit(empirical_CVR), preventing over-exploration when the cold-start prior pushes predicted probability toward 0.5
- Add _calibrate_output_bias() method implementing the one-shot calibration, guarded by a bias_calibrated flag that resets on _reset()
- Remove logit clipping in the forward pass (jnp.clip on linear_transform) — calibrated bias makes this unnecessary
- Rename _min_sigma class variable to _numerical_eps to reflect its broader use across epsilon-floor operations
- Update TestBiasScale → TestBiasStd and all related test methods/parameters to match the renamed parameter


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional calibrate_output_bias to initialize output bias from observed rewards; introduces a one-time calibrated flag.

* **Refactor**
  * Renamed public parameter bias_scale → bias_std across cold-start and model APIs; cold-start now accepts calibrate_output_bias.

* **Bug Fixes**
  * Improved numerical stability for posterior standard deviations; final model outputs are no longer clipped.

* **Tests**
  * Updated tests and fixtures; added a binary-reward helper to cover bias_std and calibration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PlaytikaOSS/pybandits/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->