### PR TITLE
Add Dynamic Pricing Strategy

### DIFF
--- a/pybandits/actions_manager.py
+++ b/pybandits/actions_manager.py
@@ -70,10 +70,12 @@ from pybandits.model import (
     BaseBetaMO,
     BayesianNeuralNetwork,
     BayesianNeuralNetworkCC,
+    BayesianNeuralNetworkDP,
     BayesianNeuralNetworkMO,
     BayesianNeuralNetworkMOCC,
     Beta,
     BetaCC,
+    BetaDP,
     BetaMO,
     BetaMOCC,
     Model,
@@ -84,9 +86,11 @@ from pybandits.quantitative_model import (
     BaseZooming,
     QuantitativeBayesianNeuralNetwork,
     QuantitativeBayesianNeuralNetworkCC,
+    QuantitativeBayesianNeuralNetworkDP,
     QuantitativeModel,
     Zooming,
     ZoomingCC,
+    ZoomingDP,
 )
 
 SmabModelType = TypeVar("SmabModelType", bound=Union[BaseBeta, BaseBetaMO, BaseZooming])
@@ -926,10 +930,12 @@ class CmabActionsManager(ActionsManager, Generic[CmabModelType]):
 # For pickling purposes
 SmabActionsManagerSO = SmabActionsManager[Union[Beta, Zooming]]
 SmabActionsManagerCC = SmabActionsManager[Union[BetaCC, ZoomingCC]]
+SmabActionsManagerDP = SmabActionsManager[Union[BetaDP, ZoomingDP]]
 SmabActionsManagerMO = SmabActionsManager[BetaMO]
 SmabActionsManagerMOCC = SmabActionsManager[BetaMOCC]
 
 CmabActionsManagerSO = CmabActionsManager[Union[BayesianNeuralNetwork, QuantitativeBayesianNeuralNetwork]]
 CmabActionsManagerCC = CmabActionsManager[Union[BayesianNeuralNetworkCC, QuantitativeBayesianNeuralNetworkCC]]
+CmabActionsManagerDP = CmabActionsManager[Union[BayesianNeuralNetworkDP, QuantitativeBayesianNeuralNetworkDP]]
 CmabActionsManagerMO = CmabActionsManager[BayesianNeuralNetworkMO]
 CmabActionsManagerMOCC = CmabActionsManager[BayesianNeuralNetworkMOCC]

--- a/pybandits/base_model.py
+++ b/pybandits/base_model.py
@@ -269,3 +269,16 @@ class BaseModelCC(PyBanditsBaseModel, ABC):
     """
 
     cost: Union[NonNegativeFloat, Callable[[Union[float, np.ndarray]], NonNegativeFloat]]
+
+
+class BaseModelDP(PyBanditsBaseModel, ABC):
+    """
+    Class to model action price.
+
+    Parameters
+    ----------
+    price: Union[NonNegativeFloat, Callable[[Union[float, np.ndarray]], NonNegativeFloat]]
+        Price associated to the action.
+    """
+
+    price: Union[NonNegativeFloat, Callable[[Union[float, np.ndarray]], NonNegativeFloat]]

--- a/pybandits/cmab.py
+++ b/pybandits/cmab.py
@@ -29,6 +29,7 @@ from pydantic import validate_call
 from pybandits.actions_manager import (
     CmabActionsManager,
     CmabActionsManagerCC,
+    CmabActionsManagerDP,
     CmabActionsManagerMO,
     CmabActionsManagerMOCC,
     CmabActionsManagerSO,
@@ -52,6 +53,7 @@ from pybandits.strategy import (
     BestActionIdentificationBandit,
     ClassicBandit,
     CostControlBandit,
+    DynamicPricingBandit,
     MultiObjectiveBandit,
     MultiObjectiveCostControlBandit,
     MultiObjectiveStrategy,
@@ -349,6 +351,34 @@ class CmabBernoulliCC(BaseCmabBernoulli):
 
     actions_manager: CmabActionsManagerCC
     strategy: CostControlBandit
+    _predict_with_proba: bool = True
+
+
+class CmabBernoulliDP(BaseCmabBernoulli):
+    """
+    Contextual Bernoulli Multi-Armed Bandit with Thompson Sampling, and Dynamic Pricing strategy.
+
+    The Cmab is extended to perform personalized price optimization. Each action is associated with a
+    predefined "price" (a scalar for discrete actions, or a callable mapping a quantity to a price for
+    quantitative actions). At prediction time, the action that maximizes the expected revenue
+    ``price * P(purchase | context)`` is recommended, where ``P(purchase | context)`` is the sampled
+    probability of a positive reward provided by the Bayesian posterior.
+
+    References
+    ----------
+    Nonparametric Pricing Analytics with Customer Covariates (Chen and Gallego, 2021)
+    https://arxiv.org/abs/1805.01136
+
+    Parameters
+    ----------
+    actions_manager: CmabActionsManagerDP
+        The manager for actions and their associated models.
+    strategy: DynamicPricingBandit
+        The strategy used to select actions.
+    """
+
+    actions_manager: CmabActionsManagerDP
+    strategy: DynamicPricingBandit
     _predict_with_proba: bool = True
 
 

--- a/pybandits/meta_model.py
+++ b/pybandits/meta_model.py
@@ -68,10 +68,12 @@ from pybandits.base_model import BaseModel
 from pybandits.model import (
     BayesianNeuralNetwork,
     BayesianNeuralNetworkCC,
+    BayesianNeuralNetworkDP,
     BayesianNeuralNetworkMO,
     BayesianNeuralNetworkMOCC,
     Beta,
     BetaCC,
+    BetaDP,
     BetaMO,
     BetaMOCC,
     Model,
@@ -80,9 +82,11 @@ from pybandits.model import (
 from pybandits.quantitative_model import (
     QuantitativeBayesianNeuralNetwork,
     QuantitativeBayesianNeuralNetworkCC,
+    QuantitativeBayesianNeuralNetworkDP,
     QuantitativeModel,
     Zooming,
     ZoomingCC,
+    ZoomingDP,
 )
 from pybandits.utils import classproperty, extract_argument_names_from_function
 
@@ -502,10 +506,12 @@ class CmabPerActionMetaModel(PerActionMetaModel[ActionModelType], Generic[Action
 # that attribute accessible on this module.
 PerActionMetaModelSmabSO = PerActionMetaModel[Union[Beta, Zooming]]
 PerActionMetaModelSmabCC = PerActionMetaModel[Union[BetaCC, ZoomingCC]]
+PerActionMetaModelSmabDP = PerActionMetaModel[Union[BetaDP, ZoomingDP]]
 PerActionMetaModelSmabMO = PerActionMetaModel[BetaMO]
 PerActionMetaModelSmabMOCC = PerActionMetaModel[BetaMOCC]
 
 PerActionMetaModelCmabSO = CmabPerActionMetaModel[Union[BayesianNeuralNetwork, QuantitativeBayesianNeuralNetwork]]
 PerActionMetaModelCmabCC = CmabPerActionMetaModel[Union[BayesianNeuralNetworkCC, QuantitativeBayesianNeuralNetworkCC]]
+PerActionMetaModelCmabDP = CmabPerActionMetaModel[Union[BayesianNeuralNetworkDP, QuantitativeBayesianNeuralNetworkDP]]
 PerActionMetaModelCmabMO = CmabPerActionMetaModel[BayesianNeuralNetworkMO]
 PerActionMetaModelCmabMOCC = CmabPerActionMetaModel[BayesianNeuralNetworkMOCC]

--- a/pybandits/model.py
+++ b/pybandits/model.py
@@ -63,7 +63,7 @@ from tqdm import trange
 from typing_extensions import Self
 
 from pybandits.base import BinaryReward, MOProbability, Probability, ProbabilityWeight, PyBanditsBaseModel
-from pybandits.base_model import BaseModelCC, BaseModelMO, BaseModelSO
+from pybandits.base_model import BaseModelCC, BaseModelDP, BaseModelMO, BaseModelSO
 
 _Array = Union[np.ndarray, jax.Array]
 
@@ -127,6 +127,19 @@ class ModelCC(BaseModelCC, ABC):
     """
 
     cost: NonNegativeFloat
+
+
+class ModelDP(BaseModelDP, ABC):
+    """
+    Class to model action price.
+
+    Parameters
+    ----------
+    price: NonNegativeFloat
+        Price associated to the action.
+    """
+
+    price: NonNegativeFloat
 
 
 class ModelMO(BaseModelMO, ABC):
@@ -220,6 +233,21 @@ class BetaCC(BaseBeta, ModelCC):
         Counter of the number of failures.
     cost : NonNegativeFloat
         Cost associated to the Beta distribution.
+    """
+
+
+class BetaDP(BaseBeta, ModelDP):
+    """
+    Beta Distribution model for Bernoulli multi-armed bandits with dynamic pricing.
+
+    Parameters
+    ----------
+    n_successes : PositiveInt = 1
+        Counter of the number of successes.
+    n_failures : PositiveInt = 1
+        Counter of the number of failures.
+    price : NonNegativeFloat
+        Price associated to the Beta distribution.
     """
 
 
@@ -2591,6 +2619,33 @@ class BayesianNeuralNetworkCC(BaseBayesianNeuralNetwork, ModelCC):
         For VI, it contains both 'trace' and 'fit' settings.
     cost : NonNegativeFloat
         Cost associated to the Bayesian Neural Network model.
+
+    Notes
+    -----
+    - The model uses tanh activation for hidden layers and sigmoid activation for the output layer.
+    - The output layer is designed for binary classification tasks, with probabilities modeled
+      using a Bernoulli likelihood.
+    """
+
+
+class BayesianNeuralNetworkDP(BaseBayesianNeuralNetwork, ModelDP):
+    """Bayesian Neural Network model for binary classification with dynamic pricing.
+
+    This class implements a Bayesian Neural Network with an arbitrary number of fully connected layers
+    using PyMC for binary classification tasks. It supports both Markov Chain Monte Carlo (MCMC)
+    and Variational Inference (VI) methods for posterior inference.
+
+    Parameters
+    ----------
+    model_params : BnnParams
+        The parameters of the Bayesian Neural Network, including weights and biases for each layer and their initial values for resetting
+    update_method : str, optional
+        The method used for posterior inference, either "MCMC" or "VI" (default is "MCMC").
+    update_kwargs : Optional[dict], optional
+        A dictionary of keyword arguments for the update method. For MCMC, it contains 'trace' settings.
+        For VI, it contains both 'trace' and 'fit' settings.
+    price : NonNegativeFloat
+        Price associated to the Bayesian Neural Network model.
 
     Notes
     -----

--- a/pybandits/quantitative_model.py
+++ b/pybandits/quantitative_model.py
@@ -52,7 +52,7 @@ from pybandits.base import (
     QuantitativeProbabilityWeight,
     QuantitativeWeight,
 )
-from pybandits.base_model import BaseModelCC, BaseModelSO
+from pybandits.base_model import BaseModelCC, BaseModelDP, BaseModelSO
 from pybandits.model import BayesianNeuralNetwork, Beta, Model
 
 
@@ -128,17 +128,17 @@ class QuantitativeModel(BaseModelSO, ABC):
         """
 
 
-class QuantitativeModelCC(BaseModelCC, ABC):
+class CallableFieldSerde(PyBanditsBaseModel, ABC):
     """
-    Class to model quantitative action cost.
+    Mixin providing (de)serialization for a model field that holds a named callable.
 
-    Parameters
-    ----------
-    cost: Callable[[Union[float, NonNegativeFloat]], NonNegativeFloat]
-        Cost associated to the Beta distribution.
+    Pydantic cannot serialize a function directly, so this mixin serializes a named
+    (non-lambda) function to its source code and reconstructs it on deserialization.
+    Concrete models declare their own field-specific ``field_serializer`` /
+    ``field_validator`` hooks that delegate to :meth:`_serialize_callable` /
+    :meth:`_deserialize_callable` (see :class:`QuantitativeModelCC` for ``cost`` and
+    :class:`QuantitativeModelDP` for ``price``).
     """
-
-    cost: Callable[[Union[float, NonNegativeFloat]], NonNegativeFloat]
 
     @staticmethod
     def _serialize_function(func: Callable) -> str:
@@ -186,18 +186,18 @@ class QuantitativeModelCC(BaseModelCC, ABC):
         return eval(func_name)
 
     @staticmethod
-    def serialize_cost(cost_value) -> str:
-        """Serialize cost value to string representation."""
-        if isinstance(cost_value, functools.partial):
-            return f"functools.partial({QuantitativeModelCC._serialize_function(cost_value.func)}, {cost_value.args}, {cost_value.keywords})"
-        elif callable(cost_value):
-            return QuantitativeModelCC._serialize_function(cost_value)
+    def _serialize_callable(value) -> str:
+        """Serialize a callable value to its string representation."""
+        if isinstance(value, functools.partial):
+            return f"functools.partial({CallableFieldSerde._serialize_function(value.func)}, {value.args}, {value.keywords})"
+        elif callable(value):
+            return CallableFieldSerde._serialize_function(value)
         else:
-            raise ValueError(f"Unrecognized cost for serialization: {cost_value}")
+            raise ValueError(f"Unrecognized callable for serialization: {value}")
 
     @classmethod
-    def deserialize_cost(cls, value):
-        """Deserialize cost from string representation if needed."""
+    def _deserialize_callable(cls, value):
+        """Deserialize a callable from its string representation if needed."""
         if isinstance(value, str):
             if value.startswith("functools.partial"):
                 inner_func_split = "(".join(value.split("(")[1:]).split(",")
@@ -211,9 +211,22 @@ class QuantitativeModelCC(BaseModelCC, ABC):
                 return cls._deserialize_function(value)
         return value
 
+
+class QuantitativeModelCC(CallableFieldSerde, BaseModelCC, ABC):
+    """
+    Class to model quantitative action cost.
+
+    Parameters
+    ----------
+    cost: Callable[[Union[float, NonNegativeFloat]], NonNegativeFloat]
+        Cost associated to the Beta distribution.
+    """
+
+    cost: Callable[[Union[float, NonNegativeFloat]], NonNegativeFloat]
+
     @field_serializer("cost")
     def encode_cost(self, value):
-        return self.serialize_cost(value).encode("ascii")
+        return self._serialize_callable(value).encode("ascii")
 
     @field_validator("cost", mode="before")
     @classmethod
@@ -221,7 +234,32 @@ class QuantitativeModelCC(BaseModelCC, ABC):
         """
         Deserialize cost from string representation if needed.
         """
-        return cls.deserialize_cost(value)
+        return cls._deserialize_callable(value)
+
+
+class QuantitativeModelDP(CallableFieldSerde, BaseModelDP, ABC):
+    """
+    Class to model quantitative action price.
+
+    Parameters
+    ----------
+    price: Callable[[Union[float, np.ndarray]], NonNegativeFloat]
+        Price associated to the Beta distribution.
+    """
+
+    price: Callable[[Union[float, np.ndarray]], NonNegativeFloat]
+
+    @field_serializer("price")
+    def encode_price(self, value):
+        return self._serialize_callable(value).encode("ascii")
+
+    @field_validator("price", mode="before")
+    @classmethod
+    def validate_price(cls, value):
+        """
+        Deserialize price from string representation if needed.
+        """
+        return cls._deserialize_callable(value)
 
 
 class Segment(PyBanditsBaseModel):
@@ -842,6 +880,32 @@ class ZoomingCC(BaseZooming, QuantitativeModelCC):
     """
 
 
+class ZoomingDP(BaseZooming, QuantitativeModelDP):
+    """
+    Zooming model for sMAB with dynamic pricing.
+
+    Parameters
+    ----------
+    dimension: PositiveInt
+        Number of parameters of the model.
+    comparison_threshold: Float01
+        Comparison threshold.
+    segment_update_factor: Float01
+        Segment update factor. If the number of samples in a segment is more than the average number of samples in all
+        segments by this factor, the segment is considered interesting. If the number of samples in a segment is less
+        than the average number of samples in all segments by this factor, the segment is considered a nuisance.
+        Interest segments can be split, while nuisance segments can be merged.
+    n_comparison_points: PositiveInt
+        Number of comparison points.
+    n_max_segments: PositiveInt
+        Maximum number of segments.
+    sub_actions: Dict[Tuple[Tuple[Float01, Float01], ...], Optional[Beta]]
+        Mapping of segments to Beta models.
+    price: Callable[[Union[float, np.ndarray]], NonNegativeFloat]
+        Price associated to the Beta distribution.
+    """
+
+
 class BaseQuantitativeBayesianNeuralNetwork(QuantitativeModel, ABC):
     """
     A Bayesian Neural Network based QuantitativeModel.
@@ -1151,5 +1215,38 @@ class QuantitativeBayesianNeuralNetworkCC(BaseQuantitativeBayesianNeuralNetwork,
     ...     dimension=1,
     ...     hidden_dim_list=[4],
     ...     cost=lambda x: x * 0.1  # Linear cost function
+    ... )
+    """
+
+
+class QuantitativeBayesianNeuralNetworkDP(BaseQuantitativeBayesianNeuralNetwork, QuantitativeModelDP):
+    """
+    A Bayesian Neural Network based QuantitativeModel with dynamic pricing.
+
+    This class extends QuantitativeBayesianNeuralNetwork with dynamic pricing functionality,
+    allowing the model to incorporate price considerations when making decisions.
+
+    Parameters
+    ----------
+    dimension : PositiveInt
+        Number of quantity dimensions (input features for the BNN).
+    bnn : BayesianNeuralNetwork
+        The underlying Bayesian Neural Network model.
+    hidden_dim_list : Optional[List[PositiveInt]]
+        List of hidden layer dimensions for the BNN. None means no hidden layers.
+    update_method : str
+        The method used for posterior inference, either "MCMC" or "VI".
+    update_kwargs : Optional[dict]
+        Additional keyword arguments for the update method.
+    price : Callable[[Union[float, np.ndarray]], NonNegativeFloat]
+        Price function that takes a quantity value or array and returns the associated price.
+
+    Examples
+    --------
+    >>> # Create a cold start model with dynamic pricing
+    >>> model = QuantitativeBayesianNeuralNetworkDP.cold_start(
+    ...     dimension=1,
+    ...     hidden_dim_list=[4],
+    ...     price=lambda x: x * 10.0  # Linear price function
     ... )
     """

--- a/pybandits/smab.py
+++ b/pybandits/smab.py
@@ -28,6 +28,7 @@ from pydantic import PositiveInt, validate_call
 from pybandits.actions_manager import (
     SmabActionsManager,
     SmabActionsManagerCC,
+    SmabActionsManagerDP,
     SmabActionsManagerMO,
     SmabActionsManagerMOCC,
     SmabActionsManagerSO,
@@ -44,6 +45,7 @@ from pybandits.strategy import (
     BestActionIdentificationBandit,
     ClassicBandit,
     CostControlBandit,
+    DynamicPricingBandit,
     MultiObjectiveBandit,
     MultiObjectiveCostControlBandit,
 )
@@ -202,6 +204,33 @@ class SmabBernoulliCC(BaseSmabBernoulli):
 
     actions_manager: SmabActionsManagerCC
     strategy: CostControlBandit
+
+
+class SmabBernoulliDP(BaseSmabBernoulli):
+    """
+    Stochastic Bernoulli Multi-Armed Bandit with Thompson Sampling, and Dynamic Pricing strategy.
+
+    The sMAB is extended to perform price optimization. Each action is associated with a predefined
+    "price" (a scalar for discrete actions, or a callable mapping a quantity to a price for
+    quantitative actions). At prediction time, the action that maximizes the expected revenue
+    ``price * P(purchase)`` is recommended, where ``P(purchase)`` is the sampled probability of a
+    positive reward.
+
+    References
+    ----------
+    Nonparametric Pricing Analytics with Customer Covariates (Chen and Gallego, 2021)
+    https://arxiv.org/abs/1805.01136
+
+    Parameters
+    ----------
+    actions_manager: SmabActionsManagerDP
+        The manager for actions and their associated models.
+    strategy: DynamicPricingBandit
+        The strategy used to select actions.
+    """
+
+    actions_manager: SmabActionsManagerDP
+    strategy: DynamicPricingBandit
 
 
 class SmabBernoulliMO(BaseSmabBernoulli):

--- a/pybandits/strategy.py
+++ b/pybandits/strategy.py
@@ -22,7 +22,7 @@
 
 from abc import ABC, abstractmethod
 from random import random
-from typing import Any, Callable, ClassVar, Dict, Generator, List, Optional, Type, TypeVar, Union
+from typing import Any, Callable, ClassVar, Dict, Generator, List, Optional, Tuple, Type, TypeVar, Union
 
 import numpy as np
 from loguru import logger
@@ -30,7 +30,7 @@ from pydantic import PrivateAttr, field_validator, validate_call
 from typing_extensions import Self
 
 from pybandits.base import ActionId, Float01, PyBanditsBaseModel, UnifiedActionId
-from pybandits.base_model import BaseModel
+from pybandits.base_model import BaseModel, BaseModelDP
 from pybandits.quantitative_model import QuantitativeModel
 from pybandits.utils import OptimizationFailedError, maximize_by_quantity
 
@@ -424,6 +424,167 @@ class ClassicBandit(SingleObjectiveStrategy):
         if not refined_p:
             raise ValueError("Cannot select action from empty refined_p dictionary")
         best_unified_action = max(refined_p, key=refined_p.get)
+        return best_unified_action
+
+
+class DynamicPricingBandit(SingleObjectiveStrategy):
+    """
+    Dynamic pricing Thompson Sampling strategy for multi-armed bandits.
+
+    This strategy selects the action that maximizes the expected revenue, defined as the
+    product of the action ``price`` and its sampled probability of a positive reward
+    (i.e. purchase probability): ``revenue = price * P(purchase)``. Each action is associated
+    with a predefined ``price``: a scalar for discrete actions, or a callable mapping a quantity
+    vector to a price for quantitative (continuous price) actions. The probability of purchase is
+    provided by the Bayesian posterior, mirroring the demand estimate of the reference algorithm.
+
+    References
+    ----------
+    Revenue objective ``price * P(purchase)`` is inspired by the demand-times-price formulation in:
+    Nonparametric Pricing Analytics with Customer Covariates (Chen and Gallego, 2021)
+    https://arxiv.org/abs/1805.01136
+    """
+
+    def get_prerequisites(
+        self,
+        p: Dict[ActionId, Union[float, Callable[[np.ndarray], float]]],
+        actions: Dict[ActionId, BaseModelDP],
+        constraint_list: Optional[List[Callable[[np.ndarray], bool]]],
+    ) -> Dict[str, Any]:
+        """
+        Compute prerequisites for the dynamic pricing strategy.
+
+        Dynamic pricing requires no prerequisites: the revenue of each action is evaluated
+        directly during selection.
+
+        Parameters
+        ----------
+        p : Dict[ActionId, Union[float, Callable[[np.ndarray], float]]]
+            Dictionary mapping action IDs to probability functions or values.
+        actions : Dict[ActionId, BaseModel]
+            Dictionary mapping action IDs to their associated models.
+        constraint_list : Optional[List[Callable[[np.ndarray], bool]]]
+            List of constraint functions (unused in dynamic pricing).
+
+        Returns
+        -------
+        Dict[str, Any]
+            Empty dictionary as no prerequisites are needed.
+        """
+        return {}
+
+    def _verify_action(self, score: float) -> bool:
+        """
+        Verify if an action should be considered for selection.
+
+        Dynamic pricing considers all actions; revenue is evaluated during selection.
+
+        Parameters
+        ----------
+        score : float
+            The probability or score of the action (unused).
+
+        Returns
+        -------
+        bool
+            Always True - all actions are considered.
+        """
+        return True
+
+    @staticmethod
+    def _revenue(model: BaseModelDP, quantity: Optional[np.ndarray], proba: float) -> float:
+        """
+        Compute expected revenue for an action.
+
+        Parameters
+        ----------
+        model : BaseModelDP
+            The action model providing the price (scalar or callable).
+        quantity : Optional[np.ndarray]
+            Quantity vector for quantitative actions; None for discrete actions.
+        proba : float
+            Purchase probability.
+
+        Returns
+        -------
+        float
+            ``price * proba``.
+        """
+        price = model.price(quantity) if callable(model.price) else model.price
+        return price * proba
+
+    def _verify_and_select_from_quantitative_action(
+        self,
+        score_func: Callable[[np.ndarray], float],
+        model: BaseModelDP,
+        constraint_list: Optional[List[Callable[[np.ndarray], bool]]],
+    ) -> Optional[np.ndarray]:
+        """
+        Find the revenue-maximizing quantity for a quantitative action.
+
+        Maximizes ``price(quantity) * P(purchase | quantity)`` over the quantity space.
+
+        Parameters
+        ----------
+        score_func : Callable[[np.ndarray], float]
+            Function that computes the purchase probability given a quantity vector.
+        model : BaseModelDP
+            The model associated with this quantitative action (provides the ``price`` callable).
+        constraint_list : Optional[List[Callable[[np.ndarray], bool]]]
+            List of constraint functions that quantity must satisfy.
+
+        Returns
+        -------
+        Optional[np.ndarray]
+            Optimal quantity vector that maximizes revenue, or None if optimization fails.
+        """
+        try:
+            return maximize_by_quantity(
+                lambda x: self._revenue(model, x, score_func(x)),
+                model.dimension,
+                constraint_list,
+            )
+        except OptimizationFailedError as e:
+            logger.warning(f"Optimization failed: {e}")
+            return None
+
+    def _select_from_refined_actions(
+        self,
+        refined_p: Dict[UnifiedActionId, float],
+        actions: Dict[ActionId, BaseModelDP],
+        constraint: Optional[Callable[[np.ndarray], bool]] = None,
+    ) -> UnifiedActionId:
+        """
+        Select the action with the highest expected revenue.
+
+        Revenue is ``price * P(purchase)``, where the price is read from the action model
+        (a scalar for discrete actions, or ``price(quantity)`` for quantitative actions) and
+        the probability is the refined sampled value.
+
+        Parameters
+        ----------
+        refined_p : Dict[UnifiedActionId, float]
+            Dictionary of unified action IDs to their probability values.
+        actions : Dict[ActionId, BaseModelDP]
+            Dictionary mapping action IDs to their models (for price information).
+        constraint : Optional[Callable[[np.ndarray], bool]], default=None
+            Optional constraint function (unused).
+
+        Returns
+        -------
+        UnifiedActionId
+            The action with the highest expected revenue.
+        """
+        if not refined_p:
+            raise ValueError("Cannot select action from empty refined_p dictionary")
+
+        def revenue(item: Tuple[UnifiedActionId, float]) -> float:
+            action, proba = item
+            model = actions[action[0]] if isinstance(action, tuple) else actions[action]
+            quantity = np.array(action[1]) if isinstance(action, tuple) else None
+            return self._revenue(model, quantity, proba)
+
+        best_unified_action = max(refined_p.items(), key=revenue)[0]
         return best_unified_action
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybandits"
-version = "7.1.0"
+version = "7.2.0"
 description = "Python Multi-Armed Bandit Library"
 authors = [
     "Dario d'Andrea <dariod@playtika.com>",

--- a/tests/test_cmab.py
+++ b/tests/test_cmab.py
@@ -45,6 +45,7 @@ from pybandits.cmab import (
     CmabBernoulli,
     CmabBernoulliBAI,
     CmabBernoulliCC,
+    CmabBernoulliDP,
     CmabBernoulliMO,
     CmabBernoulliMOCC,
 )
@@ -53,6 +54,7 @@ from pybandits.model import (
     BaseBayesianNeuralNetworkMO,
     BayesianNeuralNetwork,
     BayesianNeuralNetworkCC,
+    BayesianNeuralNetworkDP,
     BayesianNeuralNetworkMO,
     BayesianNeuralNetworkMOCC,
     StudentTArray,
@@ -62,12 +64,14 @@ from pybandits.quantitative_model import (
     BaseQuantitativeBayesianNeuralNetwork,
     QuantitativeBayesianNeuralNetwork,
     QuantitativeBayesianNeuralNetworkCC,
+    QuantitativeBayesianNeuralNetworkDP,
     QuantitativeModel,
 )
 from pybandits.strategy import (
     BestActionIdentificationBandit,
     ClassicBandit,
     CostControlBandit,
+    DynamicPricingBandit,
     MultiObjectiveBandit,
     MultiObjectiveCostControlBandit,
 )
@@ -91,7 +95,7 @@ def diff_strategy(draw):
 
 
 @st.composite
-def cost_strategy(draw, n_actions):
+def value_strategy(draw, n_actions):
     return draw(st.lists(st.floats(min_value=0, max_value=2), min_size=n_actions, max_size=n_actions))
 
 
@@ -142,8 +146,8 @@ def mock_student_t_array(
     return label
 
 
-def _quantitative_cost(x, cost):
-    return min(sum(x) ** cost, 1000)
+def _quantitative_callable(x, value):
+    return min(sum(x) ** value, 1000)
 
 
 @dataclass
@@ -162,7 +166,7 @@ class ModelTestConfig:
     def _create_actions(
         self,
         action_ids: List[str],
-        costs: Optional[st.SearchStrategy],
+        values: Optional[st.SearchStrategy],
         n_features: PositiveInt,
         hidden_dim_list: List[int],
         update_method: UpdateMethods,
@@ -177,15 +181,25 @@ class ModelTestConfig:
             for model in model_types
         ):
             # Generate random costs
-            costs = costs.draw(cost_strategy(n_actions=len(action_ids)))
+            drawn_values = values.draw(value_strategy(n_actions=len(action_ids)))
             costs = [
-                cost
+                val
                 if model_type in [BayesianNeuralNetworkCC, BayesianNeuralNetworkMOCC]
-                else partial(_quantitative_cost, cost=cost)
-                for cost, model_type in zip(costs, model_types)
+                else partial(_quantitative_callable, value=val)
+                for val, model_type in zip(drawn_values, model_types)
             ]
+            value_field = "cost"
+        elif all(model in [BayesianNeuralNetworkDP, QuantitativeBayesianNeuralNetworkDP] for model in model_types):
+            # Generate random prices
+            drawn_values = values.draw(value_strategy(n_actions=len(action_ids)))
+            costs = [
+                val if model_type == BayesianNeuralNetworkDP else partial(_quantitative_callable, value=val)
+                for val, model_type in zip(drawn_values, model_types)
+            ]
+            value_field = "price"
         else:
             costs = None
+            value_field = None
 
         model_cold_start_kwargs = dict(update_method=update_method)
         base_model_cold_start_kwargs = dict(hidden_dim_list=hidden_dim_list, **model_cold_start_kwargs)
@@ -195,20 +209,20 @@ class ModelTestConfig:
             # Single-objective models
             if costs is not None:
                 for action_id, model_type, cost in zip(action_ids, model_types, costs):
-                    if issubclass(model_type, BayesianNeuralNetworkCC):
+                    if issubclass(model_type, (BayesianNeuralNetworkCC, BayesianNeuralNetworkDP)):
                         result[action_id] = model_type.cold_start(
                             n_features=n_features,
                             hidden_dim_list=hidden_dim_list,
-                            cost=cost,
+                            **{value_field: cost},
                             **model_cold_start_kwargs,
                         )
                     else:
-                        # QuantitativeBayesianNeuralNetworkCC
+                        # QuantitativeBayesianNeuralNetworkCC / QuantitativeBayesianNeuralNetworkDP
                         result[action_id] = model_type.cold_start(
                             dimension=1,
                             n_features=n_features,
                             base_model_cold_start_kwargs=base_model_cold_start_kwargs,
-                            cost=cost,
+                            **{value_field: cost},
                         )
             else:
                 for action_id, model_type in zip(action_ids, model_types):
@@ -251,7 +265,7 @@ class ModelTestConfig:
         action_ids: List[str],
         epsilon: Optional[Float01],
         delta: Optional[PositiveProbability],
-        costs: st.SearchStrategy,
+        values: st.SearchStrategy,
         n_objectives: st.SearchStrategy[PositiveInt],
         exploit_p: Union[st.SearchStrategy[Optional[Float01]], Optional[float]],
         subsidy_factor: Union[st.SearchStrategy[Optional[Float01]], Optional[float]],
@@ -265,7 +279,7 @@ class ModelTestConfig:
             else None
         )
         actions, base_model_cold_start_kwargs = self._create_actions(
-            action_ids, costs, n_features, hidden_dim_list, update_method, n_objectives
+            action_ids, values, n_features, hidden_dim_list, update_method, n_objectives
         )
         default_action = action_ids[0] if epsilon and not delta else None
         if default_action and isinstance(actions[default_action], QuantitativeModel):
@@ -313,6 +327,11 @@ TEST_CONFIGS = {
         CostControlBandit,
         [BayesianNeuralNetworkCC, QuantitativeBayesianNeuralNetworkCC],
     ),
+    "cmab_dp": ModelTestConfig(
+        CmabBernoulliDP,
+        DynamicPricingBandit,
+        [BayesianNeuralNetworkDP, QuantitativeBayesianNeuralNetworkDP],
+    ),
     "cmab_mo": ModelTestConfig(
         CmabBernoulliMO,
         MultiObjectiveBandit,
@@ -339,7 +358,7 @@ TEST_CONFIGS = {
     ),
     epsilon=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
     delta=st.one_of(st.none(), st.just(0.1)),
-    costs=st.data(),
+    values=st.data(),
     n_objectives=st.data(),
     n_features=st.integers(min_value=1, max_value=5),
     hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
@@ -352,7 +371,7 @@ def test_cold_start(
     action_ids: List[str],
     epsilon: Optional[float],
     delta,
-    costs,
+    values,
     n_objectives,
     n_features,
     hidden_dim_list,
@@ -365,7 +384,7 @@ def test_cold_start(
         action_ids,
         epsilon,
         delta,
-        costs,
+        values,
         n_objectives,
         exploit_p,
         subsidy_factor,
@@ -399,6 +418,17 @@ def test_cold_start(
             for action, model in actions.items()
             if isinstance(model, QuantitativeBayesianNeuralNetworkCC)
         }
+    if all(
+        isinstance(model, (BayesianNeuralNetworkDP, QuantitativeBayesianNeuralNetworkDP)) for model in actions.values()
+    ):
+        cold_start_kwargs["action_ids_price"] = {
+            action: model.price for action, model in actions.items() if isinstance(model, BayesianNeuralNetworkDP)
+        }
+        cold_start_kwargs["quantitative_action_ids_price"] = {
+            action: model.price
+            for action, model in actions.items()
+            if isinstance(model, QuantitativeBayesianNeuralNetworkDP)
+        }
     cold_start_kwargs.update(kwargs)  # Add exploit_p or subsidy_factor if needed
     cold_start_kwargs = {k: v for k, v in cold_start_kwargs.items() if v is not None}
     assert config.cmab_class.cold_start(**cold_start_kwargs) == cmab
@@ -410,7 +440,7 @@ def test_cold_start(
     action_ids=st.lists(st.text(min_size=1), min_size=2, max_size=5, unique=True),
     n_features=st.integers(min_value=1, max_value=5),
     hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
-    costs=st.data(),
+    values=st.data(),
     n_objectives=st.data(),
     subsidy_factor=st.data(),
     exploit_p=st.data(),
@@ -421,7 +451,7 @@ def test_bad_initialization(
     action_ids: List[str],
     n_features: int,
     hidden_dim_list: List[PositiveInt],
-    costs,
+    values,
     n_objectives,
     exploit_p,
     subsidy_factor,
@@ -429,7 +459,12 @@ def test_bad_initialization(
 ):
     """Test various invalid initialization scenarios for CMAB models"""
     real_n_objectives = n_objectives.draw(st.integers(min_value=1, max_value=10))
-    kwargs = {"cost": 1} if config.cmab_class in (CmabBernoulliCC, CmabBernoulliMOCC) else {}
+    if config.cmab_class in (CmabBernoulliCC, CmabBernoulliMOCC):
+        kwargs = {"cost": 1}
+    elif config.cmab_class == CmabBernoulliDP:
+        kwargs = {"price": 1}
+    else:
+        kwargs = {}
     kwargs["n_features"] = n_features
     kwargs["hidden_dim_list"] = hidden_dim_list
     if config.cmab_class in [CmabBernoulliMO, CmabBernoulliMOCC]:
@@ -502,7 +537,7 @@ def test_bad_initialization(
                 action_ids,
                 None,
                 None,
-                costs,
+                values,
                 n_objectives,
                 exploit_p.draw(st.sampled_from([-0.1, 1.1])),
                 subsidy_factor,
@@ -516,7 +551,7 @@ def test_bad_initialization(
                 action_ids,
                 None,
                 None,
-                costs,
+                values,
                 n_objectives,
                 exploit_p,
                 subsidy_factor.draw(st.sampled_from([-0.1, 1.1])),
@@ -550,7 +585,7 @@ def test_bad_initialization(
     n_samples=st.integers(min_value=1, max_value=5),
     epsilon=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
     delta=st.one_of(st.none(), st.just(0.1)),
-    costs=st.data(),
+    values=st.data(),
     n_objectives=st.data(),
     n_features=st.integers(min_value=1, max_value=3),
     hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
@@ -565,7 +600,7 @@ def test_update(
     n_samples: int,
     epsilon: Optional[float],
     delta,
-    costs,
+    values,
     n_objectives,
     n_features,
     hidden_dim_list,
@@ -579,7 +614,7 @@ def test_update(
         action_ids,
         epsilon,
         delta,
-        costs,
+        values,
         n_objectives,
         exploit_p,
         subsidy_factor,
@@ -644,7 +679,7 @@ def test_update(
     n_samples=st.integers(min_value=1, max_value=100),
     epsilon=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
     delta=st.one_of(st.none(), st.just(0.1)),
-    costs=st.data(),
+    values=st.data(),
     n_objectives=st.data(),
     n_features=st.integers(min_value=1, max_value=5),
     hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
@@ -659,7 +694,7 @@ def test_predict(
     n_samples: int,
     epsilon: Optional[float],
     delta,
-    costs,
+    values,
     n_objectives,
     n_features,
     hidden_dim_list,
@@ -692,7 +727,7 @@ def test_predict(
         action_ids,
         epsilon,
         delta,
-        costs,
+        values,
         n_objectives,
         exploit_p,
         subsidy_factor,
@@ -754,7 +789,7 @@ def test_predict(
     ),
     epsilon=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
     delta=st.one_of(st.none(), st.just(0.1)),
-    costs=st.data(),
+    values=st.data(),
     n_objectives=st.data(),
     n_features=st.integers(min_value=1, max_value=5),
     hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
@@ -768,7 +803,7 @@ def test_serialization(
     action_ids: List[str],
     epsilon: Optional[float],
     delta,
-    costs,
+    values,
     n_objectives,
     n_features,
     hidden_dim_list,
@@ -783,7 +818,7 @@ def test_serialization(
         action_ids,
         epsilon,
         delta,
-        costs,
+        values,
         n_objectives,
         exploit_p,
         subsidy_factor,
@@ -950,7 +985,7 @@ def test_cmab_update_kwargs_migration(
     ),
     epsilon=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
     delta=st.one_of(st.none(), st.just(0.1)),
-    costs=st.data(),
+    values=st.data(),
     n_objectives=st.data(),
     n_features=st.integers(min_value=1, max_value=5),
     hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
@@ -964,7 +999,7 @@ def test_pickling(
     action_ids: List[str],
     epsilon: Optional[float],
     delta,
-    costs,
+    values,
     n_objectives,
     n_features,
     hidden_dim_list,
@@ -979,7 +1014,7 @@ def test_pickling(
         action_ids,
         epsilon,
         delta,
-        costs,
+        values,
         n_objectives,
         exploit_p,
         subsidy_factor,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -41,10 +41,12 @@ from pybandits.model import (
     BaseLocationScaleArray,
     BayesianNeuralNetwork,
     BayesianNeuralNetworkCC,
+    BayesianNeuralNetworkDP,
     BayesianNeuralNetworkMO,
     BayesianNeuralNetworkMOCC,
     Beta,
     BetaCC,
+    BetaDP,
     BetaMO,
     BetaMOCC,
     CategoricalFeatureConfig,
@@ -143,6 +145,22 @@ def test_can_init_betaCC(a_float):
     else:
         b = BetaCC(cost=a_float)
         assert b.cost == a_float
+
+
+########################################################################################################################
+
+
+# BetaDP
+
+
+@given(st.floats())
+def test_can_init_betaDP(a_float):
+    if a_float < 0 or np.isnan(a_float):
+        with pytest.raises(ValidationError):
+            BetaDP(price=a_float)
+    else:
+        b = BetaDP(price=a_float)
+        assert b.price == a_float
 
 
 ########################################################################################################################
@@ -1339,9 +1357,10 @@ def test_can_init_bayesian_neural_network_cc(
     n_features=st.integers(min_value=1, max_value=3),
     hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
     cost=st.floats(allow_nan=False, allow_infinity=False),
+    n_samples=st.integers(min_value=1, max_value=100),
 )
 def test_create_default_instance_bayesian_neural_network_cc(
-    rng, activation, use_residual_connections, use_layerwise_scaling, n_features, hidden_dim_list, cost
+    rng, activation, use_residual_connections, use_layerwise_scaling, n_features, hidden_dim_list, cost, n_samples
 ):
     dim_list = [n_features] + hidden_dim_list
     if any(layer_dim <= 0 for layer_dim in dim_list) or (cost < 0):
@@ -1379,10 +1398,113 @@ def test_create_default_instance_bayesian_neural_network_cc(
         assert bnn_cold_start.use_residual_connections == use_residual_connections
 
         # Test sample_proba works
-        context = np.random.uniform(low=-1.0, high=1.0, size=(5, n_features))
+        context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
         prob_and_weighted_sum = bnn_cold_start.sample_proba(context=context, rng=rng)
         prob, weighted_sum = zip(*prob_and_weighted_sum)
-        assert len(prob) == 5
+        assert len(prob) == n_samples
+        assert all([0 <= p <= 1 for p in prob])
+
+
+########################################################################################################################
+
+
+# BayesianNeuralNetworkDP
+@given(
+    activation=st.sampled_from(["tanh", "relu", "sigmoid", "gelu"]),
+    use_residual_connections=st.booleans(),
+    use_layerwise_scaling=st.booleans(),
+    n_features=st.integers(min_value=1, max_value=3),
+    hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
+    price=st.floats(allow_nan=False, allow_infinity=False),
+)
+def test_can_init_bayesian_neural_network_dp(
+    activation, use_residual_connections, use_layerwise_scaling, n_features, hidden_dim_list, price
+):
+    # at least one beta must be specified
+    dim_list = [n_features] + hidden_dim_list
+    fc = FeaturesConfig(n_features=n_features)
+    if any(layer_dim <= 0 for layer_dim in dim_list) or (price < 0):
+        with pytest.raises((ValidationError, ValueError)):
+            model_params = BayesianNeuralNetwork.create_model_params(
+                fc, hidden_dim_list, use_layerwise_scaling=use_layerwise_scaling
+            )
+            BayesianNeuralNetworkDP(
+                model_params=model_params,
+                price=price,
+                activation=activation,
+                use_residual_connections=use_residual_connections,
+                feature_config=fc,
+            )
+    else:
+        model_params = BayesianNeuralNetwork.create_model_params(
+            fc, hidden_dim_list, use_layerwise_scaling=use_layerwise_scaling
+        )
+        bnn = BayesianNeuralNetworkDP(
+            model_params=model_params,
+            price=price,
+            activation=activation,
+            use_residual_connections=use_residual_connections,
+            feature_config=fc,
+        )
+        assert bnn.model_params == model_params
+        assert bnn.price == price
+        assert bnn.activation == activation
+        assert bnn.use_residual_connections == use_residual_connections
+
+
+@given(
+    activation=st.sampled_from(["tanh", "relu", "sigmoid", "gelu"]),
+    use_residual_connections=st.booleans(),
+    use_layerwise_scaling=st.booleans(),
+    n_features=st.integers(min_value=1, max_value=3),
+    hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
+    price=st.floats(allow_nan=False, allow_infinity=False),
+    n_samples=st.integers(min_value=1, max_value=100),
+)
+def test_create_default_instance_bayesian_neural_network_dp(
+    rng, activation, use_residual_connections, use_layerwise_scaling, n_features, hidden_dim_list, price, n_samples
+):
+    dim_list = [n_features] + hidden_dim_list
+    if any(layer_dim <= 0 for layer_dim in dim_list) or (price < 0):
+        with pytest.raises((ValidationError, ValueError)):
+            BayesianNeuralNetworkDP.cold_start(
+                n_features=n_features,
+                hidden_dim_list=hidden_dim_list,
+                price=price,
+                activation=activation,
+                use_residual_connections=use_residual_connections,
+                use_layerwise_scaling=use_layerwise_scaling,
+            )
+    else:
+        bnn_cold_start = BayesianNeuralNetworkDP.cold_start(
+            n_features=n_features,
+            hidden_dim_list=hidden_dim_list,
+            price=price,
+            activation=activation,
+            use_residual_connections=use_residual_connections,
+            use_layerwise_scaling=use_layerwise_scaling,
+        )
+        fc = FeaturesConfig(n_features=n_features)
+        model_params = BayesianNeuralNetwork.create_model_params(
+            fc, hidden_dim_list=hidden_dim_list, use_layerwise_scaling=use_layerwise_scaling
+        )
+        bnn_init = BayesianNeuralNetworkDP(
+            model_params=model_params,
+            price=price,
+            activation=activation,
+            use_residual_connections=use_residual_connections,
+            feature_config=fc,
+        )
+        assert bnn_cold_start == bnn_init
+        assert bnn_cold_start.price == price
+        assert bnn_cold_start.activation == activation
+        assert bnn_cold_start.use_residual_connections == use_residual_connections
+
+        # Test sample_proba works
+        context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
+        prob_and_weighted_sum = bnn_cold_start.sample_proba(context=context, rng=rng)
+        prob, weighted_sum = zip(*prob_and_weighted_sum)
+        assert len(prob) == n_samples
         assert all([0 <= p <= 1 for p in prob])
 
 

--- a/tests/test_quantitative_model.py
+++ b/tests/test_quantitative_model.py
@@ -38,9 +38,12 @@ from pybandits.model import Beta
 from pybandits.quantitative_model import (
     BaseZooming,
     QuantitativeBayesianNeuralNetwork,
+    QuantitativeBayesianNeuralNetworkCC,
+    QuantitativeBayesianNeuralNetworkDP,
     Segment,
     Zooming,
     ZoomingCC,
+    ZoomingDP,
 )
 from tests.utils import mock_update
 
@@ -553,6 +556,110 @@ def test_cost_serialization_deserialization(cost_function):
     deserialized_model = ZoomingCC.model_validate_json(serialized)
     # Check callable was properly restored
     assert callable(deserialized_model.cost)
+
+    reserialized = deserialized_model.model_dump_json()
+    assert reserialized == serialized
+
+
+# QuantitativeModelDP tests via ZoomingDP
+
+
+def simple_price(value: float) -> float:
+    return value * 10
+
+
+def complex_price(value: Union[float, NonNegativeFloat], factor: float = 1.0) -> NonNegativeFloat:
+    return value * factor
+
+
+partial_price = functools.partial(complex_price, factor=2.5)
+
+
+@pytest.mark.parametrize(
+    "price_function",
+    [
+        simple_price,
+        complex_price,
+        partial_price,
+    ],
+)
+def test_price_serialization_deserialization(price_function):
+    """Test serialization and deserialization of price field with different callables."""
+
+    # Create model with the test callable as price
+    model = ZoomingDP.cold_start(price=price_function)
+    serialized = model.model_dump_json()
+    serialized_dict = json.loads(serialized)
+
+    assert "price" in serialized_dict
+    assert isinstance(serialized_dict["price"], str)
+
+    deserialized_model = ZoomingDP.model_validate_json(serialized)
+    # Check callable was properly restored
+    assert callable(deserialized_model.price)
+
+    reserialized = deserialized_model.model_dump_json()
+    assert reserialized == serialized
+
+
+########################################################################################################################
+
+
+# QuantitativeBayesianNeuralNetworkCC tests
+
+
+@pytest.mark.parametrize(
+    "cost_function",
+    [
+        simple_cost,
+        complex_cost,
+        partial_cost,
+    ],
+)
+def test_bnncc_cost_serialization_deserialization(cost_function):
+    """Test serialization and deserialization of cost field in BNNCC with different callables."""
+
+    # Create model with the test callable as cost
+    model = QuantitativeBayesianNeuralNetworkCC.cold_start(dimension=1, cost=cost_function)
+    serialized = model.model_dump_json()
+    serialized_dict = json.loads(serialized)
+
+    assert "cost" in serialized_dict
+    assert isinstance(serialized_dict["cost"], str)
+
+    deserialized_model = QuantitativeBayesianNeuralNetworkCC.model_validate_json(serialized)
+    # Check callable was properly restored
+    assert callable(deserialized_model.cost)
+
+    reserialized = deserialized_model.model_dump_json()
+    assert reserialized == serialized
+
+
+# QuantitativeBayesianNeuralNetworkDP tests
+
+
+@pytest.mark.parametrize(
+    "price_function",
+    [
+        simple_price,
+        complex_price,
+        partial_price,
+    ],
+)
+def test_bnndp_price_serialization_deserialization(price_function):
+    """Test serialization and deserialization of price field in BNNDP with different callables."""
+
+    # Create model with the test callable as price
+    model = QuantitativeBayesianNeuralNetworkDP.cold_start(dimension=1, price=price_function)
+    serialized = model.model_dump_json()
+    serialized_dict = json.loads(serialized)
+
+    assert "price" in serialized_dict
+    assert isinstance(serialized_dict["price"], str)
+
+    deserialized_model = QuantitativeBayesianNeuralNetworkDP.model_validate_json(serialized)
+    # Check callable was properly restored
+    assert callable(deserialized_model.price)
 
     reserialized = deserialized_model.model_dump_json()
     assert reserialized == serialized

--- a/tests/test_smab.py
+++ b/tests/test_smab.py
@@ -35,13 +35,14 @@ import pybandits
 from pybandits.actions_manager import SmabModelType
 from pybandits.base import ActionId, Float01, PositiveProbability
 from pybandits.base_model import BaseModel
-from pybandits.model import Beta, BetaCC, BetaMO, BetaMOCC
-from pybandits.quantitative_model import QuantitativeModel, Zooming, ZoomingCC
+from pybandits.model import Beta, BetaCC, BetaDP, BetaMO, BetaMOCC
+from pybandits.quantitative_model import QuantitativeModel, Zooming, ZoomingCC, ZoomingDP
 from pybandits.smab import (
     BaseSmabBernoulli,
     SmabBernoulli,
     SmabBernoulliBAI,
     SmabBernoulliCC,
+    SmabBernoulliDP,
     SmabBernoulliMO,
     SmabBernoulliMOCC,
 )
@@ -49,6 +50,7 @@ from pybandits.strategy import (
     BestActionIdentificationBandit,
     ClassicBandit,
     CostControlBandit,
+    DynamicPricingBandit,
     MultiObjectiveBandit,
     MultiObjectiveCostControlBandit,
 )
@@ -61,7 +63,7 @@ def diff_strategy(draw):
 
 
 @st.composite
-def cost_strategy(draw, n_actions):
+def value_strategy(draw, n_actions):
     return draw(st.lists(st.floats(min_value=0, max_value=2), min_size=n_actions, max_size=n_actions))
 
 
@@ -75,8 +77,8 @@ def mock_update(models: List[SmabModelType], diff, monkeymodule, label=0):
                 mock_update(sub_models, diff, monkeymodule, label)
 
 
-def _quantitative_cost(x, cost):
-    return min(sum(x) ** cost, 1000)
+def _quantitative_callable(x, value):
+    return min(sum(x) ** value, 1000)
 
 
 @dataclass
@@ -86,7 +88,7 @@ class ModelTestConfig:
     model_types: List[Type[SmabModelType]]
 
     def _create_actions(
-        self, action_ids: List[str], costs: Optional[st.SearchStrategy], n_objectives: Optional[PositiveInt]
+        self, action_ids: List[str], values: Optional[st.SearchStrategy], n_objectives: Optional[PositiveInt]
     ) -> Dict[str, Any]:
         model_types = list(self.model_types)
         if len(model_types) < len(action_ids):
@@ -94,20 +96,30 @@ class ModelTestConfig:
             model_types = [model_types[i] for i in indices]
         if all(model in [BetaCC, ZoomingCC, BetaMOCC] for model in model_types):
             # Generate random costs
-            costs = costs.draw(cost_strategy(n_actions=len(action_ids)))
+            drawn_values = values.draw(value_strategy(n_actions=len(action_ids)))
             costs = [
-                cost if model_type in [BetaCC, BetaMOCC] else partial(_quantitative_cost, cost=cost)
-                for cost, model_type in zip(costs, model_types)
+                val if model_type in [BetaCC, BetaMOCC] else partial(_quantitative_callable, value=val)
+                for val, model_type in zip(drawn_values, model_types)
             ]
+            value_field = "cost"
+        elif all(model in [BetaDP, ZoomingDP] for model in model_types):
+            # Generate random prices
+            drawn_values = values.draw(value_strategy(n_actions=len(action_ids)))
+            costs = [
+                val if model_type == BetaDP else partial(_quantitative_callable, value=val)
+                for val, model_type in zip(drawn_values, model_types)
+            ]
+            value_field = "price"
         else:
             costs = None
+            value_field = None
 
         if n_objectives is None:
             if costs is not None:
                 return {
-                    action_id: model_type(cost=cost)
-                    if issubclass(model_type, BetaCC)
-                    else model_type.cold_start(dimension=1, cost=cost)  # ZoomingCC
+                    action_id: model_type(**{value_field: cost})
+                    if issubclass(model_type, (BetaCC, BetaDP))
+                    else model_type.cold_start(dimension=1, **{value_field: cost})  # ZoomingCC / ZoomingDP
                     for action_id, model_type, cost in zip(action_ids, model_types, costs)
                 }
             else:
@@ -134,7 +146,7 @@ class ModelTestConfig:
         action_ids: List[str],
         epsilon: Optional[Float01],
         delta: Optional[PositiveProbability],
-        costs: st.SearchStrategy,
+        values: st.SearchStrategy,
         n_objectives: st.SearchStrategy[PositiveInt],
         exploit_p: Union[st.SearchStrategy[Optional[Float01]], Optional[float]],
         subsidy_factor: Union[st.SearchStrategy[Optional[Float01]], Optional[float]],
@@ -144,7 +156,7 @@ class ModelTestConfig:
             if self.smab_class in [SmabBernoulliMO, SmabBernoulliMOCC]
             else None
         )
-        actions = self._create_actions(action_ids, costs, n_objectives)
+        actions = self._create_actions(action_ids, values, n_objectives)
         default_action = action_ids[0] if epsilon and not delta else None
         if default_action and isinstance(actions[default_action], QuantitativeModel):
             default_action = (default_action, tuple(np.random.random(actions[default_action].dimension)))
@@ -182,6 +194,11 @@ TEST_CONFIGS = {
         CostControlBandit,
         [BetaCC, ZoomingCC],
     ),
+    "smab_dp": ModelTestConfig(
+        SmabBernoulliDP,
+        DynamicPricingBandit,
+        [BetaDP, ZoomingDP],
+    ),
     "smab_mo": ModelTestConfig(SmabBernoulliMO, MultiObjectiveBandit, [BetaMO]),
     "smab_mocc": ModelTestConfig(SmabBernoulliMOCC, MultiObjectiveCostControlBandit, [BetaMOCC]),
 }
@@ -200,7 +217,7 @@ TEST_CONFIGS = {
     ),
     epsilon=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
     delta=st.one_of(st.none(), st.just(0.1)),
-    costs=st.data(),
+    values=st.data(),
     n_objectives=st.data(),
     subsidy_factor=st.data(),
     exploit_p=st.data(),
@@ -210,14 +227,14 @@ def test_cold_start(
     action_ids: List[str],
     epsilon: Optional[float],
     delta,
-    costs,
+    values,
     n_objectives,
     exploit_p,
     subsidy_factor,
 ):
     # Create SMAB instance
     smab, actions, kwargs = config.create_smab_and_actions(
-        action_ids, epsilon, delta, costs, n_objectives, exploit_p, subsidy_factor
+        action_ids, epsilon, delta, values, n_objectives, exploit_p, subsidy_factor
     )
 
     # Cold start comparison logic (modified for different model types)
@@ -234,6 +251,13 @@ def test_cold_start(
         cold_start_kwargs["quantitative_action_ids_cost"] = {
             action: model.cost for action, model in actions.items() if isinstance(model, ZoomingCC)
         }
+    if all(isinstance(model, (BetaDP, ZoomingDP)) for model in actions.values()):
+        cold_start_kwargs["action_ids_price"] = {
+            action: model.price for action, model in actions.items() if isinstance(model, BetaDP)
+        }
+        cold_start_kwargs["quantitative_action_ids_price"] = {
+            action: model.price for action, model in actions.items() if isinstance(model, ZoomingDP)
+        }
     cold_start_kwargs.update(kwargs)  # Add exploit_p or subsidy_factor if needed
     cold_start_kwargs = {k: v for k, v in cold_start_kwargs.items() if v is not None}
     assert config.smab_class.cold_start(**cold_start_kwargs) == smab
@@ -244,7 +268,7 @@ def test_cold_start(
 @given(
     action_ids=st.lists(st.text(min_size=1), min_size=2, max_size=5, unique=True),
     n_objectives=st.data(),
-    costs=st.data(),
+    values=st.data(),
     subsidy_factor=st.data(),
     exploit_p=st.data(),
 )
@@ -252,12 +276,17 @@ def test_bad_initialization(
     config: ModelTestConfig,
     action_ids: List[str],
     n_objectives,
-    costs,
+    values,
     exploit_p,
     subsidy_factor,
 ):
     real_n_objectives = n_objectives.draw(st.integers(min_value=1, max_value=10))
-    kwargs = {"cost": 1.0} if config.smab_class in (SmabBernoulliCC, SmabBernoulliMOCC) else {}
+    if config.smab_class in (SmabBernoulliCC, SmabBernoulliMOCC):
+        kwargs = {"cost": 1.0}
+    elif config.smab_class == SmabBernoulliDP:
+        kwargs = {"price": 1.0}
+    else:
+        kwargs = {}
     if config.smab_class in [SmabBernoulliMO, SmabBernoulliMOCC]:
         kwargs["models"] = [Beta() for _ in range(real_n_objectives)]
 
@@ -289,7 +318,7 @@ def test_bad_initialization(
                 action_ids,
                 None,
                 None,
-                costs,
+                values,
                 n_objectives,
                 exploit_p.draw(st.sampled_from([-0.1, 1.1])),
                 subsidy_factor,
@@ -300,7 +329,7 @@ def test_bad_initialization(
                 action_ids,
                 None,
                 None,
-                costs,
+                values,
                 n_objectives,
                 exploit_p,
                 subsidy_factor.draw(st.sampled_from([-0.1, 1.1])),
@@ -331,7 +360,7 @@ def test_bad_initialization(
     n_samples=st.integers(min_value=1, max_value=100),
     epsilon=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
     delta=st.one_of(st.none(), st.just(0.1)),
-    costs=st.data(),
+    values=st.data(),
     n_objectives=st.data(),
     subsidy_factor=st.data(),
     exploit_p=st.data(),
@@ -343,7 +372,7 @@ def test_update(
     n_samples: int,
     epsilon: Optional[float],
     delta,
-    costs,
+    values,
     n_objectives,
     exploit_p,
     subsidy_factor,
@@ -351,7 +380,7 @@ def test_update(
 ):
     # Create SMAB instance
     smab, _, kwargs = config.create_smab_and_actions(
-        action_ids, epsilon, delta, costs, n_objectives, exploit_p, subsidy_factor
+        action_ids, epsilon, delta, values, n_objectives, exploit_p, subsidy_factor
     )
     batched_smab = deepcopy(smab)
     n_objectives = kwargs.get("n_objectives")
@@ -435,7 +464,7 @@ def test_update(
     n_samples=st.integers(min_value=1, max_value=100),
     epsilon=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
     delta=st.one_of(st.none(), st.just(0.1)),
-    costs=st.data(),
+    values=st.data(),
     n_objectives=st.data(),
     subsidy_factor=st.data(),
     exploit_p=st.data(),
@@ -447,7 +476,7 @@ def test_predict(
     n_samples: int,
     epsilon: Optional[float],
     delta,
-    costs,
+    values,
     n_objectives,
     exploit_p,
     subsidy_factor,
@@ -473,7 +502,9 @@ def test_predict(
         )
 
     # Create SMAB instance
-    smab = config.create_smab_and_actions(action_ids, epsilon, delta, costs, n_objectives, exploit_p, subsidy_factor)[0]
+    smab = config.create_smab_and_actions(action_ids, epsilon, delta, values, n_objectives, exploit_p, subsidy_factor)[
+        0
+    ]
 
     # Test predictions with random forbidden actions
     forbidden = set(sample_with_replacement(action_ids, len(action_ids) // 2)) if len(action_ids) > 2 else None
@@ -517,7 +548,7 @@ def test_predict(
     ),
     epsilon=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
     delta=st.one_of(st.none(), st.just(0.1)),
-    costs=st.data(),
+    values=st.data(),
     n_objectives=st.data(),
     subsidy_factor=st.data(),
     exploit_p=st.data(),
@@ -528,7 +559,7 @@ def test_serialization(
     action_ids: List[str],
     epsilon: Optional[float],
     delta,
-    costs,
+    values,
     n_objectives,
     exploit_p,
     subsidy_factor,
@@ -536,7 +567,9 @@ def test_serialization(
     monkeymodule,
 ):
     # Create SMAB instance
-    smab = config.create_smab_and_actions(action_ids, epsilon, delta, costs, n_objectives, exploit_p, subsidy_factor)[0]
+    smab = config.create_smab_and_actions(action_ids, epsilon, delta, values, n_objectives, exploit_p, subsidy_factor)[
+        0
+    ]
 
     pre_update_state = smab.get_state()
     mock_update(list(smab.actions.values()), diff, monkeymodule)
@@ -562,7 +595,7 @@ def test_serialization(
     ),
     epsilon=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
     delta=st.one_of(st.none(), st.just(0.1)),
-    costs=st.data(),
+    values=st.data(),
     n_objectives=st.data(),
     subsidy_factor=st.data(),
     exploit_p=st.data(),
@@ -573,7 +606,7 @@ def test_pickling(
     action_ids: List[str],
     epsilon: Optional[float],
     delta,
-    costs,
+    values,
     n_objectives,
     exploit_p,
     subsidy_factor,
@@ -581,7 +614,9 @@ def test_pickling(
     monkeymodule,
 ):
     # Create SMAB instance
-    smab = config.create_smab_and_actions(action_ids, epsilon, delta, costs, n_objectives, exploit_p, subsidy_factor)[0]
+    smab = config.create_smab_and_actions(action_ids, epsilon, delta, values, n_objectives, exploit_p, subsidy_factor)[
+        0
+    ]
     to_temporary_pickle(smab)
     mock_update(list(smab.actions.values()), diff, monkeymodule)
     to_temporary_pickle(smab)

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -20,7 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Callable, Dict, List, Literal, Optional, Tuple, Union
+from math import comb
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -31,7 +32,7 @@ from pydantic import ValidationError
 from pytest_mock import MockerFixture
 
 from pybandits.base import ActionId, BaseModel, Probability, UnifiedActionId
-from pybandits.model import Beta, BetaCC, BetaMOCC
+from pybandits.model import Beta, BetaCC, BetaDP, BetaMOCC
 from pybandits.quantitative_model import QuantitativeModel
 from pybandits.strategy import (
     BaseStrategy,
@@ -39,11 +40,13 @@ from pybandits.strategy import (
     ClassicBandit,
     CostControlBandit,
     CostControlStrategy,
+    DynamicPricingBandit,
     MultiObjectiveBandit,
     MultiObjectiveCostControlBandit,
     MultiObjectiveStrategy,
     SingleObjectiveStrategy,
 )
+from pybandits.utils import OptimizationFailedError
 from tests.test_quantitative_model import DummyZooming
 
 ########################################################################################################################
@@ -52,6 +55,7 @@ from tests.test_quantitative_model import DummyZooming
 
 # Test constants
 DEFAULT_COST = 10.0
+DEFAULT_PRICE = 10.0
 DEFAULT_DIMENSION = 2
 DEFAULT_PROBABILITY = 0.5
 DEFAULT_EXPLOIT_P = 0.5
@@ -106,6 +110,58 @@ def create_mock_quantitative_model(
     else:
         raise ValueError(f"Invalid model type: {mocked_model_type}")
     model.cost = MagicMock(return_value=cost_value)
+    return model
+
+
+class DummyQuantitativeModelDP(QuantitativeModel):
+    price: Optional[Callable[[np.ndarray], float]] = None
+    models: Optional[List[BaseModel]] = None
+
+    def reset(self) -> None:
+        pass
+
+    def sample_proba(self, **kwargs) -> None:
+        pass
+
+    def update(self, **kwargs) -> None:
+        pass
+
+    def _quantitative_update(self, **kwargs) -> None:
+        pass
+
+    def _reset(self) -> None:
+        pass
+
+
+def create_mock_quantitative_dp_model(
+    dimension: int = DEFAULT_DIMENSION,
+    price_value: float = DEFAULT_PRICE,
+    mocked_model_type: Literal["MagicMock", "DummyQuantitativeModelDP"] = "MagicMock",
+) -> QuantitativeModel:
+    """Create a mock quantitative model with a price attribute for testing.
+
+    Parameters
+    ----------
+    dimension : int
+        Dimension of the quantitative model.
+    price_value : float
+        Price value to return.
+    mocked_model_type : Literal["MagicMock", "DummyQuantitativeModelDP"]
+        The type of mock to create.
+
+    Returns
+    -------
+    QuantitativeModel
+        Mock quantitative model with a price attribute.
+    """
+    if mocked_model_type == "MagicMock":
+        model = MagicMock(spec=QuantitativeModel)
+        model.dimension = dimension
+    elif mocked_model_type == "DummyQuantitativeModelDP":
+        model = DummyQuantitativeModelDP(dimension=dimension)
+    else:
+        raise ValueError(f"Invalid model type: {mocked_model_type}")
+    model.price = MagicMock(return_value=price_value)
     return model
 
 
@@ -257,7 +313,7 @@ class ConcreteSingleObjectiveStrategy(SingleObjectiveStrategy):
         p: Dict[ActionId, Union[float, Callable]],
         actions: Dict[ActionId, BaseModel],
         constraint_list: Optional[List[Callable]],
-    ) -> Dict[str, any]:
+    ) -> Dict[str, Any]:
         """Return empty prerequisites."""
         return {"test_value": 42}
 
@@ -526,6 +582,174 @@ def test_classic_bandit_mixed_actions(
             assert mock_maximize.call_count == n_quantitative, (
                 f"Expected {n_quantitative} calls but got {mock_maximize.call_count}"
             )
+
+
+########################################################################################################################
+# DynamicPricingBandit
+
+
+def test_can_init_dynamic_pricing():
+    """Test that DynamicPricingBandit can be initialized."""
+    bandit = DynamicPricingBandit()
+    assert isinstance(bandit, SingleObjectiveStrategy)
+    assert isinstance(bandit, BaseStrategy)
+
+
+@given(
+    st.lists(st.text(min_size=1, max_size=10), min_size=1, max_size=3, unique=True),
+    st.lists(st.floats(min_value=0, max_value=100, allow_infinity=False, allow_nan=False), min_size=1, max_size=3),
+)
+@settings(max_examples=10)
+def test_select_action_dp(a_list_str, a_list_float):
+    """Test DynamicPricingBandit select_action method.
+
+    Parameters
+    ----------
+    a_list_str : list
+        List of action IDs.
+    a_list_float : list
+        List of prices.
+    """
+    assume(len(a_list_str) == len(a_list_float))
+    a_list_float_0_1 = [float(i) / (sum(a_list_float) + 1) for i in a_list_float]
+
+    p = dict(zip(a_list_str, a_list_float_0_1))
+    a = dict(zip(a_list_str, [BetaDP(price=price) for price in a_list_float]))
+
+    d = DynamicPricingBandit()
+    result = d.select_action(p=p, actions=a)
+    assert result in p.keys()
+
+
+def test_dynamic_pricing_logic():
+    """Test DynamicPricingBandit selects the action with the highest revenue (price * probability)."""
+    actions_price = {"a1": 10, "a2": 30, "a3": 20, "a4": 10, "a5": 20}
+    p = {"a1": 0.1, "a2": 0.8, "a3": 0.6, "a4": 0.2, "a5": 0.65}
+
+    actions = {action_id: BetaDP(price=price) for action_id, price in actions_price.items()}
+
+    d = DynamicPricingBandit()
+    expected_action = max(p, key=lambda action_id: actions_price[action_id] * p[action_id])
+    assert d.select_action(p=p, actions=actions) == expected_action
+
+
+def test_dynamic_pricing_logic_callable_price_and_proba():
+    """Test DynamicPricingBandit select_action when price and proba are callables.
+
+    Same revenue-maximization logic as test_dynamic_pricing_logic but with quantitative actions:
+    p maps to callable proba (probability given quantity vector) and actions use quantitative
+    models with callable price (price given quantity vector).
+    """
+    actions_price = {"a1": 10, "a2": 30, "a3": 20, "a4": 10, "a5": 20}
+    proba = {"a1": 0.1, "a2": 0.8, "a3": 0.6, "a4": 0.2, "a5": 0.65}
+    p = {action_id: (lambda x, v=prob: v) for action_id, prob in proba.items()}
+    actions = {
+        action_id: create_mock_quantitative_dp_model(
+            dimension=2, price_value=price, mocked_model_type="DummyQuantitativeModelDP"
+        )
+        for action_id, price in actions_price.items()
+    }
+
+    d = DynamicPricingBandit()
+    result = d.select_action(p=p, actions=actions)
+    expected_action = max(proba, key=lambda action_id: actions_price[action_id] * proba[action_id])
+    assert result[0] == expected_action
+    assert all(0 <= quantity <= 1 for quantity in result[1])
+
+
+def test_dynamic_pricing_get_prerequisites(prob_a1: float = 0.5, prob_a2: float = 0.8, prob_a3: float = 0.3):
+    """Test DynamicPricingBandit get_prerequisites returns an empty dictionary.
+
+    Parameters
+    ----------
+    prob_a1 : float
+        Probability for action a1.
+    prob_a2 : float
+        Probability for action a2.
+    prob_a3 : float
+        Probability for action a3.
+    """
+    d = DynamicPricingBandit()
+
+    p = {"a1": prob_a1, "a2": prob_a2, "a3": prob_a3}
+    actions = {aid: BetaDP(price=DEFAULT_PRICE) for aid in p.keys()}
+
+    assert d.get_prerequisites(p, actions, None) == {}
+
+
+@pytest.mark.parametrize("score", [0.0, 0.5, 1.0])
+def test_dynamic_pricing_verify_action(score: float):
+    """Test DynamicPricingBandit considers all standard actions.
+
+    Parameters
+    ----------
+    score : float
+        Score to verify.
+    """
+    d = DynamicPricingBandit()
+    assert d._verify_action(score) is True
+
+
+@patch("pybandits.strategy.maximize_by_quantity")
+def test_dynamic_pricing_quantitative_action(
+    mock_maximize: MagicMock,
+    return_value: np.ndarray = np.array([0.3, 0.7]),
+    dimension: int = 2,
+    price_multiplier: float = 10.0,
+    probability: float = 0.4,
+    quantity: np.ndarray = np.array([0.3, 0.7]),
+):
+    """Test DynamicPricingBandit with quantitative actions optimizes revenue.
+
+    Parameters
+    ----------
+    mock_maximize : MagicMock
+        Mock for maximize_by_quantity function.
+    return_value : np.ndarray
+        Return value for mock maximize function.
+    dimension : int
+        Dimension of the quantitative model.
+    price_multiplier : float
+        Multiplier for price calculation.
+    probability : float
+        Constant purchase probability returned by the score function.
+    quantity : np.ndarray
+        Quantity at which to evaluate the optimized objective.
+    """
+    mock_maximize.return_value = return_value
+
+    d = DynamicPricingBandit()
+
+    model = create_mock_quantitative_dp_model(dimension=dimension)
+    model.price = MagicMock(side_effect=lambda x: np.sum(x) * price_multiplier)
+
+    def score_func(x: np.ndarray) -> float:
+        return probability
+
+    result = d._verify_and_select_from_quantitative_action(score_func, model, None)
+
+    assert result is not None
+    assert np.allclose(result, return_value, atol=1e-6)
+    mock_maximize.assert_called_once()
+    # The maximized objective must be revenue = price(quantity) * probability(quantity)
+    objective = mock_maximize.call_args[0][0]
+    assert objective(quantity) == pytest.approx(model.price(quantity) * score_func(quantity))
+
+
+@pytest.mark.parametrize("dimension", [1, 2])
+def test_dynamic_pricing_optimization_failure(dimension: int):
+    """Test DynamicPricingBandit returns None when maximize_by_quantity raises OptimizationFailedError.
+
+    Parameters
+    ----------
+    dimension : int
+        Dimension of the quantitative model.
+    """
+
+    model = create_mock_quantitative_dp_model(dimension=dimension)
+    d = DynamicPricingBandit()
+    with patch("pybandits.strategy.maximize_by_quantity", side_effect=OptimizationFailedError("test")):
+        assert d._verify_and_select_from_quantitative_action(sum, model, None) is None
 
 
 ########################################################################################################################
@@ -1089,7 +1313,6 @@ def test_refine_p_all_actions_filtered_raises(p_values: List[float]) -> None:
 @given(dimension=st.integers(min_value=1, max_value=5))
 def test_classic_bandit_optimization_failure(dimension: int) -> None:
     """Test ClassicBandit returns None when maximize_by_quantity raises OptimizationFailedError."""
-    from pybandits.utils import OptimizationFailedError
 
     bandit = ClassicBandit()
     model = create_mock_quantitative_model(dimension=dimension)
@@ -1528,7 +1751,6 @@ def test_das_dennis_weights(n_objectives: int, n_divisions: int):
     assert weights.shape[1] == n_objectives
 
     # Check approximate number of weights (combinatorial formula)
-    from math import comb
 
     expected_count = comb(n_divisions + n_objectives - 1, n_objectives - 1)
     assert len(weights) == expected_count


### PR DESCRIPTION
### Changes:

* Add BaseModelDP — base class for models supporting dynamic pricing
  - stores price as scalar or callable mapping quantity to price
* Add CallableFieldSerde mixin to quantitative_model.py — shared logic for serializing callables
  - extracted from QuantitativeModelCC to support both cost and price fields
  - delegates to _serialize_callable and _deserialize_callable for field-specific handling
* Add ModelDP and BetaDP to model.py — discrete models with price field
  - BetaDP extends BaseBeta with ModelDP mixin
* Add BayesianNeuralNetworkDP to model.py — BNN model with price field
  - extends BaseBayesianNeuralNetwork with ModelDP mixin for contextual pricing
* Add QuantitativeModelDP and QuantitativeBayesianNeuralNetworkDP to quantitative_model.py — continuous action spaces with dynamic pricing
  - inherits from CallableFieldSerde for price serialization
* Add ZoomingDP to quantitative_model.py — zooming model for sMAB with dynamic pricing
  - partitions action space with callable price function
* Add DynamicPricingBandit strategy to strategy.py — maximize expected revenue
  - revenue = price * P(purchase) where P(purchase) is sampled from posterior
  - supports both discrete and quantitative actions via separate verification methods
  - references Chen and Gallego (2021)
* Add SmabBernoulliDP and CmabBernoulliDP MAB variants to smab.py and cmab.py
  - sMAB and cMAB with DynamicPricingBandit strategy
* Update actions_manager.py — add SmabActionsManagerDP and CmabActionsManagerDP type aliases
  - SmabActionsManagerDP unions BetaDP and ZoomingDP
  - CmabActionsManagerDP unions BayesianNeuralNetworkDP and QuantitativeBayesianNeuralNetworkDP
* Add comprehensive test coverage to test_model.py, test_strategy.py, test_quantitative_model.py, test_smab.py, test_cmab.py
  - DynamicPricingBandit action selection and revenue maximization
  - serialization and deserialization of callable price fields
  - cold_start factories and state management for DP variants
  - integration tests for sMAB and cMAB with dynamic pricing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic pricing support: DP model variants and DP-ready SMAB/CMAB bandit classes.
  * New DynamicPricingBandit strategy that selects prices/quantities to maximize expected revenue.
  * Price/cost callables now accept array inputs and serialize/pickle reliably.

* **Tests**
  * Expanded test coverage for DP models, DP bandits, and callable (de)serialization.

* **Chores**
  * Package version bumped to 7.2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->