### PR TITLE
Add KL annealing to BNN VI training

### DIFF
--- a/pybandits/model.py
+++ b/pybandits/model.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import inspect
+import numbers
 import warnings
 from abc import ABC, abstractmethod
 from contextlib import ExitStack, nullcontext
@@ -1218,8 +1219,7 @@ def _wrap_guide_with_kl_scale(guide: Callable) -> Callable:
     scale uniformly. The wrapper extracts the factor from the SVI call signature (the third
     positional argument, or the ``kl_annealing_factor`` keyword), defaulting to ``1.0``.
 
-    Kept as a module-level helper (not an inline closure) so tests can bind to the exact
-    production wrapper instead of a hand-copied mirror that can silently drift.
+    Exposed at module level so tests can exercise the exact production wrapper.
 
     Parameters
     ----------
@@ -1725,7 +1725,10 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             # Validate optional KL annealing fraction. Domain is (0, 1];
             kl_annealing_fraction = self.update_kwargs.get("kl_annealing_fraction")
             if kl_annealing_fraction is not None:
-                if isinstance(kl_annealing_fraction, bool) or not isinstance(kl_annealing_fraction, (int, float)):
+                # numbers.Real accepts NumPy real scalars (np.float32, np.int64, ...), which an
+                # untyped update_kwargs dict passes through uncoerced. bool is excluded explicitly
+                # because Python bool is itself a numbers.Real (np.bool_ is not, so it falls through).
+                if isinstance(kl_annealing_fraction, bool) or not isinstance(kl_annealing_fraction, numbers.Real):
                     raise ValueError(
                         f"Invalid kl_annealing_fraction: {kl_annealing_fraction!r}. Must be a float in (0, 1] or None."
                     )
@@ -2376,11 +2379,8 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             # fullrank_advi needs a scalar init_scale; use the avg sigma via the unknown-site fallback.
             guide = method_config["guide"](_model, init_loc_fn=init_loc_fn, init_scale=init_scale_fn(""))
 
-        # Wrap the guide so the per-step kl_annealing_factor scales its sample sites
-        # symmetrically with the model's prior sites. The wrapper is registered with SVI;
-        # the underlying `guide` is preserved for downstream `.median(...)` extraction.
-        # See `_wrap_guide_with_kl_scale` for the full rationale; it lives at module level
-        # so the test suite can trace the exact production wrapper instead of a copy.
+        # Scale-wrap the guide for symmetric KL annealing; `guide` stays unwrapped for
+        # downstream `.median(...)` extraction. See `_wrap_guide_with_kl_scale`.
         scaled_guide = _wrap_guide_with_kl_scale(guide)
 
         num_particles = self._update_kwargs["num_particles"]

--- a/pybandits/model.py
+++ b/pybandits/model.py
@@ -1208,6 +1208,39 @@ class ParameterizedScaleAutoNormal(AutoNormal):
         return result
 
 
+def _wrap_guide_with_kl_scale(guide: Callable) -> Callable:
+    """Wrap a guide so the per-step ``kl_annealing_factor`` scales its sample sites.
+
+    The returned closure registers a ``numpyro.handlers.scale`` context around the guide
+    so that ``log q(z)`` is scaled by the same factor the model applies to ``log p(z)``.
+    Without this, ``handlers.scale`` on the model alone would scale ``log p(z)`` but leave
+    ``log q(z)`` untouched, so the per-site KL contribution (``log p - log q``) would not
+    scale uniformly. The wrapper extracts the factor from the SVI call signature (the third
+    positional argument, or the ``kl_annealing_factor`` keyword), defaulting to ``1.0``.
+
+    Kept as a module-level helper (not an inline closure) so tests can bind to the exact
+    production wrapper instead of a hand-copied mirror that can silently drift.
+
+    Parameters
+    ----------
+    guide : Callable
+        The guide callable to wrap (e.g. an ``AutoNormal`` / ``ParameterizedScaleAutoNormal``
+        instance). It is preserved unmodified for downstream ``.median(...)`` extraction.
+
+    Returns
+    -------
+    Callable
+        A ``scaled_guide(*args, **kwargs)`` closure suitable for passing to ``SVI(...)``.
+    """
+
+    def scaled_guide(*args: Any, **kwargs: Any):
+        kl_annealing_factor = args[2] if len(args) > 2 else kwargs.get("kl_annealing_factor", 1.0)
+        with numpyro.handlers.scale(scale=kl_annealing_factor):
+            return guide(*args, **kwargs)
+
+    return scaled_guide
+
+
 class BaseBayesianNeuralNetwork(Model, ABC):
     """Bayesian Neural Network model for binary classification.
 
@@ -2344,19 +2377,15 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             guide = method_config["guide"](_model, init_loc_fn=init_loc_fn, init_scale=init_scale_fn(""))
 
         # Wrap the guide so the per-step kl_annealing_factor scales its sample sites
-        # symmetrically with the model's prior sites. Without this wrap, handlers.scale
-        # on the model alone would multiply log p(z) but leave log q(z) untouched, so the
-        # per-site KL contribution (log p - log q) would not scale uniformly. The closure
-        # is registered with SVI; the underlying `guide` is preserved for downstream
-        # `.median(...)` extraction.
-        def guide_with_scale(*args: Any, **kwargs: Any):
-            kl_annealing_factor = args[2] if len(args) > 2 else kwargs.get("kl_annealing_factor", 1.0)
-            with numpyro.handlers.scale(scale=kl_annealing_factor):
-                return guide(*args, **kwargs)
+        # symmetrically with the model's prior sites. The wrapper is registered with SVI;
+        # the underlying `guide` is preserved for downstream `.median(...)` extraction.
+        # See `_wrap_guide_with_kl_scale` for the full rationale; it lives at module level
+        # so the test suite can trace the exact production wrapper instead of a copy.
+        scaled_guide = _wrap_guide_with_kl_scale(guide)
 
         num_particles = self._update_kwargs["num_particles"]
         loss = method_config["loss"](num_particles=num_particles)
-        svi = SVI(_model, guide_with_scale, self._obj_optimizer, loss=loss)
+        svi = SVI(_model, scaled_guide, self._obj_optimizer, loss=loss)
 
         # Run the SVI loop via jax.lax.scan to keep the iteration inside XLA.
         # A Python for-loop leaks host-side dispatch/compilation metadata on

--- a/pybandits/model.py
+++ b/pybandits/model.py
@@ -63,7 +63,14 @@ from scipy.special import erf
 from tqdm import trange
 from typing_extensions import Self
 
-from pybandits.base import BinaryReward, MOProbability, Probability, ProbabilityWeight, PyBanditsBaseModel
+from pybandits.base import (
+    BinaryReward,
+    MOProbability,
+    PositiveFloat01,
+    Probability,
+    ProbabilityWeight,
+    PyBanditsBaseModel,
+)
 from pybandits.base_model import BaseModelCC, BaseModelMO, BaseModelSO
 
 _Array = Union[np.ndarray, jax.Array]
@@ -1257,6 +1264,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         "restore_best_svi_state",
         "num_particles",
         "gradient_clip_norm",
+        "kl_annealing_fraction",
     ]
     _distribution_mapping: ClassVar[Dict[str, type]] = {"normal": NormalArray, "studentt": StudentTArray}
     _embedding_dim_divisor: ClassVar[int] = 4
@@ -1365,8 +1373,14 @@ class BaseBayesianNeuralNetwork(Model, ABC):
     )
 
     _vi_method_config: ClassVar[dict] = {
-        "advi": {"guide": ParameterizedScaleAutoNormal, "loss": TraceMeanField_ELBO},
-        "fullrank_advi": {"guide": AutoMultivariateNormal, "loss": Trace_ELBO},
+        "advi": {
+            "guide": ParameterizedScaleAutoNormal,
+            "loss": TraceMeanField_ELBO,
+        },  # assumes weights are independent; loss is the ELBO
+        "fullrank_advi": {
+            "guide": AutoMultivariateNormal,
+            "loss": Trace_ELBO,
+        },  # assumes weights are dependent, for full rank covariance matrix
     }
 
     _approx_history: np.ndarray = PrivateAttr(None)
@@ -1647,6 +1661,18 @@ class BaseBayesianNeuralNetwork(Model, ABC):
                     f"Invalid VI method: {vi_method}. Supported methods are: {list(self._vi_method_config.keys())}"
                 )
 
+            # Validate optional KL annealing fraction. Domain is (0, 1];
+            kl_annealing_fraction = self.update_kwargs.get("kl_annealing_fraction")
+            if kl_annealing_fraction is not None:
+                if isinstance(kl_annealing_fraction, bool) or not isinstance(kl_annealing_fraction, (int, float)):
+                    raise ValueError(
+                        f"Invalid kl_annealing_fraction: {kl_annealing_fraction!r}. Must be a float in (0, 1] or None."
+                    )
+                if not (0.0 < float(kl_annealing_fraction) <= 1.0):
+                    raise ValueError(
+                        f"Invalid kl_annealing_fraction: {kl_annealing_fraction}. Must lie in the half-open interval (0, 1]."
+                    )
+
         elif self.update_method == "MCMC":
             for param in self._vi_update_params:
                 if param in self.update_kwargs:
@@ -1756,27 +1782,39 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         """
         Create a NumPyro model function for Bayesian Neural Network.
 
-        This method builds a NumPyro model function with the network architecture specified in model_params.
-        Data is passed as arguments to the returned model function. Minibatching is handled via numpyro.plate
-        with subsample_size.
+        Reads ``self.model_params.bnn_layer_params`` (the posteriors from the previous update
+        round) and feeds them to ``numpyro.sample`` as the priors for this round. The model
+        function is consumed by both the VI training loop (via ``svi.update``) and the MCMC
+        path (via ``mcmc.run``).
 
-        Numerical columns are passed through as-is. Categorical columns (identified by their
-        ``column_index`` in ``feature_config``) are modeled with Bayesian embedding matrices
-        sampled as NumPyro random variables.
+        Data is passed as arguments to the returned model function. Minibatching is handled via
+        ``numpyro.plate`` with ``subsample_size``. Numerical columns are passed through as-is;
+        categorical columns (identified by their ``column_index`` in ``feature_config``) are
+        modeled with Bayesian embedding matrices sampled as NumPyro random variables.
 
         Returns
         -------
         Callable
-            NumPyro model function with the specified neural network architecture
+            NumPyro model function ``model(x, y, kl_annealing_factor=1.0)``. The
+            ``kl_annealing_factor`` argument scales the prior (and embedding-prior) ``sample``
+            sites' log-probabilities; the likelihood ``out`` site sits outside the scale
+            context and is unaffected. The default ``1.0`` makes the scale a numerical no-op,
+            preserving the MCMC call path which passes only ``(x, y)``.
 
         Notes
         -----
         The model structure follows these steps:
-        1. For each layer, create weight and bias variables from prior distributions.
+
+        1. For each layer, create weight and bias variables from prior distributions
+           (current posteriors used as new priors).
         2. Sample embedding matrices for categorical features (if any).
         3. Apply linear transformations and activations through the layers.
-        4. Apply sigmoid activation at the output
+        4. Apply sigmoid activation at the output.
         5. Use Bernoulli likelihood for binary classification
+
+        Steps 1-2 happen inside ``numpyro.handlers.scale(scale=kl_annealing_factor)`` so that
+        the KL portion of the ELBO can be scheduled across training steps. Step 5 stays outside
+        that context so the likelihood term is not scaled.
         """
 
         batch_size = self._update_kwargs.get("batch_size")
@@ -1784,23 +1822,27 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         cat_configs = self.feature_config.categorical_features_configs
         has_embeddings = self.model_params.embedding_params is not None and len(cat_configs) > 0
 
-        def model(x: jax.Array, y: jax.Array):
+        def model(x: jax.Array, y: jax.Array, kl_annealing_factor: Union[PositiveFloat01, jax.Array] = 1.0):
             n_samples = x.shape[0]
 
-            # Sample all weights (global parameters, outside plate)
+            # Sample all weights and embeddings (global parameters, outside plate).
+            # Wrapped in handlers.scale so the per-step KL annealing factor scales the
+            # prior-site log-probabilities; combined with the symmetric guide wrap in
+            # _run_svi_training_loop, this scales the full per-site KL contribution
+            # (log p - log q).
             weights_biases = []
-            for layer_ind, layer_params in enumerate(self.model_params.bnn_layer_params):
-                weight_name, bias_name = self.get_layer_params_name(layer_ind)
-                w = numpyro.sample(weight_name, layer_params.weight.to_numpyro_distribution())
-                b = numpyro.sample(bias_name, layer_params.bias.to_numpyro_distribution())
-                weights_biases.append((w, b))
-
-            # Sample embedding matrices (global parameters, outside plate)
             embedding_matrices = []
-            if has_embeddings:
-                for i, emb_dist in enumerate(self.model_params.embedding_params.embeddings):
-                    emb = numpyro.sample(self.get_embedding_var_name(i), emb_dist.to_numpyro_distribution())
-                    embedding_matrices.append(emb)
+            with numpyro.handlers.scale(scale=kl_annealing_factor):
+                for layer_ind, layer_params in enumerate(self.model_params.bnn_layer_params):
+                    weight_name, bias_name = self.get_layer_params_name(layer_ind)
+                    w = numpyro.sample(weight_name, layer_params.weight.to_numpyro_distribution())
+                    b = numpyro.sample(bias_name, layer_params.bias.to_numpyro_distribution())
+                    weights_biases.append((w, b))
+
+                if has_embeddings:
+                    for i, emb_dist in enumerate(self.model_params.embedding_params.embeddings):
+                        emb = numpyro.sample(self.get_embedding_var_name(i), emb_dist.to_numpyro_distribution())
+                        embedding_matrices.append(emb)
 
             # Data plate with optional minibatching
             if batch_size is not None and batch_size < n_samples:
@@ -1838,7 +1880,9 @@ class BaseBayesianNeuralNetwork(Model, ABC):
                     self._logit_var_name,
                     linear_transform.squeeze(-1),
                 )
-                numpyro.sample("out", NumpyroBernoulli(logits=logit), obs=y_batch)
+                numpyro.sample(
+                    "out", NumpyroBernoulli(logits=logit), obs=y_batch
+                )  # "The observed reward follows a Bernoulli distribution given the network output"
 
         return model
 
@@ -2165,9 +2209,57 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         init_scale_fn = lambda name: site_sigmas.get(name, avg_sigma)  # noqa: E731
         return init_loc_fn, init_scale_fn
 
+    def _build_kl_annealing_factors(self, epoch_steps_list: List[int]) -> List[jnp.ndarray]:
+        """Build the per-step KL annealing factor schedule, split into per-epoch chunks.
+
+        The factor ``β(step)`` multiplies the KL portion of the ELBO at each SVI step:
+
+        - Inactive (``kl_annealing_fraction is None``): every factor is ``1.0``, making the
+          ``handlers.scale`` wrap a numerical no-op. The same code path runs in both active
+          and inactive cases so there is no feature-gate branching in the training loop.
+        - Active: linear ramp ``β(step) = min(1, (step + 1) / W)`` where
+          ``W = max(1, ceil(kl_annealing_fraction * total_steps))``. The ``+1`` ensures
+          ``β(0) = 1/W > 0`` so the KL term is never fully switched off at the first step.
+          The effective domain is the half-open interval ``(0, 1]``, not ``[0, 1]``.
+
+        Parameters
+        ----------
+        epoch_steps_list : List[int]
+            Number of SVI steps per epoch. Their sum is the total number of training steps.
+
+        Returns
+        -------
+        List[jnp.ndarray]
+            One 1-D ``jnp.ndarray`` per epoch, fed as the ``xs`` argument of ``jax.lax.scan``
+            in the training loop. Each element holds the per-step factor for that epoch.
+        """
+        kl_annealing_fraction = self._update_kwargs.get("kl_annealing_fraction")
+        total_steps = int(sum(epoch_steps_list))
+
+        if kl_annealing_fraction is None:
+            factor_array = jnp.ones(total_steps)
+        else:
+            warmup_steps = max(1, ceil(float(kl_annealing_fraction) * total_steps))
+            factor_array = jnp.minimum(1.0, (jnp.arange(total_steps) + 1) / warmup_steps)
+
+        # Split into per-epoch slices using cumulative epoch boundaries.
+        split_points = np.cumsum(epoch_steps_list)[:-1].tolist()
+        return list(jnp.split(factor_array, split_points))
+
     def _run_svi_training_loop(self, x_jnp: jnp.ndarray, y_jnp: jnp.ndarray, n_samples: int) -> tuple:
         """
-        Set up and run the SVI training loop, returning ``(svi, params)``.
+        Set up and run the SVI training loop (the per-update VI optimization), returning ``(svi, guide, params)``.
+
+        Each SVI step:
+        (1) samples weights from the GUIDE (current approximate posterior),
+        (2) runs the forward pass with those weights,
+        (3) computes ELBO =
+        ``log_likelihood(data | sampled_weights) - KL(guide || prior)`` — where the KL term
+        may be scaled by the per-step ``kl_annealing_factor`` when annealing is active,
+        (4) computes gradients of ``-ELBO`` w.r.t. the guide's mu/sigma,
+        (5) lets the optimizer update them.
+        All of (1)-(5) happen inside one ``svi.update()`` call, with
+        the loop body wrapped in ``jax.lax.scan`` for speed.
 
         Parameters
         ----------
@@ -2181,8 +2273,11 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         Returns
         -------
         tuple
-            ``(svi, guide, params)`` where *svi* is the configured :class:`SVI` object,
-            *guide* is the fitted variational guide, and *params* are the final variational parameters.
+            ``(svi, guide, params)`` where *svi* is the configured :class:`SVI` object
+            (built against a scale-wrapped guide closure that is a numerical no-op when
+            ``kl_annealing_fraction`` is ``None``), *guide* is the underlying ``AutoGuide``
+            instance (returned unwrapped so that downstream ``guide.median(...)`` extraction
+            keeps working), and *params* are the final variational parameters.
         """
         if self._early_stopping_callback is not None:
             self._early_stopping_callback.reset()
@@ -2202,23 +2297,38 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             if not epoch_steps_list:
                 epoch_steps_list = [1]
 
+        # Build the per-step KL-annealing factor schedule for the entire run
+        epoch_factor_arrays = self._build_kl_annealing_factors(epoch_steps_list)
+
         # Set up VI method (guide + loss) dynamically
         vi_method = self._update_kwargs["method"]
         method_config = self._vi_method_config[vi_method]
         init_loc_fn, init_scale_fn = self._build_svi_guide_init()
         if vi_method == "advi":
+            # Posterior initialization: mu=median of prior (per-site), sigma=per-site init_scale.
             guide = ParameterizedScaleAutoNormal(
                 _model,
                 init_loc_fn=init_loc_fn,
                 init_scale_fn=init_scale_fn,
             )
         else:
-            # fullrank_advi needs a scalar; use the avg sigma via the unknown-site fallback
+            # fullrank_advi needs a scalar init_scale; use the avg sigma via the unknown-site fallback.
             guide = method_config["guide"](_model, init_loc_fn=init_loc_fn, init_scale=init_scale_fn(""))
+
+        # Wrap the guide so the per-step kl_annealing_factor scales its sample sites
+        # symmetrically with the model's prior sites. Without this wrap, handlers.scale
+        # on the model alone would multiply log p(z) but leave log q(z) untouched, so the
+        # per-site KL contribution (log p - log q) would not scale uniformly. The closure
+        # is registered with SVI; the underlying `guide` is preserved for downstream
+        # `.median(...)` extraction.
+        def guide_with_scale(*args: Any, **kwargs: Any):
+            kl_annealing_factor = args[2] if len(args) > 2 else kwargs.get("kl_annealing_factor", 1.0)
+            with numpyro.handlers.scale(scale=kl_annealing_factor):
+                return guide(*args, **kwargs)
 
         num_particles = self._update_kwargs["num_particles"]
         loss = method_config["loss"](num_particles=num_particles)
-        svi = SVI(_model, guide, self._obj_optimizer, loss=loss)
+        svi = SVI(_model, guide_with_scale, self._obj_optimizer, loss=loss)
 
         # Run the SVI loop via jax.lax.scan to keep the iteration inside XLA.
         # A Python for-loop leaks host-side dispatch/compilation metadata on
@@ -2226,20 +2336,27 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         # a fixed step count regardless of batch size or FP precision.
         # lax.scan compiles the loop body once and runs it entirely in XLA.
         self._rng_key, subkey = jax.random.split(self._rng_key)
-        svi_state = svi.init(subkey, x_jnp, y_jnp)
+        # Initialize the variational parameters (the mu/sigma values that will be optimized).
+        # The kl_annealing_factor=1.0 passed here is a no-op for init but matches the
+        # signature SVI will use during svi.update calls in the scan body.
+        svi_state = svi.init(subkey, x_jnp, y_jnp, 1.0)
 
         # Pass x/y as explicit JIT arguments (not closure captures) so JAX treats
         # them as abstract buffers rather than embedding them as XLA constants.
         # Closing over large arrays causes "Failed to allocate N bytes for new constant"
         # at compile time when the dataset is large.
-        def _run_epoch(state, x, y, n):
-            def _svi_body(s, _):
-                s, loss = svi.update(s, x, y)
+        # The per-step factor array is fed as the scan's `xs`; its length determines
+        # the number of scan iterations, so no `length=` or `static_argnums` is needed.
+        # `state` is a numpyro `SVIState`; annotated as `Any` to avoid pulling its private
+        # import path into the module-level surface.
+        def _run_epoch(state: Any, x: jax.Array, y: jax.Array, factors: jnp.ndarray) -> Tuple[Any, jax.Array]:
+            def _svi_body(s: Any, factor: Union[PositiveFloat01, jax.Array]) -> Tuple[Any, jax.Array]:
+                s, loss = svi.update(s, x, y, factor)
                 return s, loss
 
-            return jax.lax.scan(_svi_body, state, None, length=n)
+            return jax.lax.scan(_svi_body, state, factors)
 
-        _run_epoch = jax.jit(_run_epoch, static_argnums=(3,))
+        _run_epoch = jax.jit(_run_epoch)
 
         restore_best = self._update_kwargs.get("restore_best_svi_state", True)
         all_losses = []
@@ -2248,8 +2365,8 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         pbar = trange(len(epoch_steps_list), desc="SVI", leave=False)
 
         try:
-            for epoch_idx, epoch_steps in enumerate(epoch_steps_list):
-                svi_state, epoch_losses = _run_epoch(svi_state, x_jnp, y_jnp, epoch_steps)
+            for epoch_idx, epoch_factors in enumerate(epoch_factor_arrays):
+                svi_state, epoch_losses = _run_epoch(svi_state, x_jnp, y_jnp, epoch_factors)
 
                 epoch_np = np.array(epoch_losses)
                 epoch_loss = float(np.mean(epoch_np))
@@ -2485,7 +2602,9 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         else:
             raise ValueError("Invalid update method.")
 
-        self.model_params.bnn_layer_params = updated_layer_params_list
+        self.model_params.bnn_layer_params = (
+            updated_layer_params_list  # update the model_params with the new found posteriors
+        )
 
     @classmethod
     def cold_start(

--- a/pybandits/model.py
+++ b/pybandits/model.py
@@ -63,7 +63,14 @@ from scipy.special import erf
 from tqdm import trange
 from typing_extensions import Self
 
-from pybandits.base import BinaryReward, PositiveFloat01, MOProbability, Probability, ProbabilityWeight, PyBanditsBaseModel
+from pybandits.base import (
+    BinaryReward,
+    MOProbability,
+    PositiveFloat01,
+    Probability,
+    ProbabilityWeight,
+    PyBanditsBaseModel,
+)
 from pybandits.base_model import BaseModelCC, BaseModelDP, BaseModelMO, BaseModelSO
 
 _Array = Union[np.ndarray, jax.Array]

--- a/pybandits/model.py
+++ b/pybandits/model.py
@@ -19,7 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
+import inspect
 import warnings
 from abc import ABC, abstractmethod
 from contextlib import ExitStack, nullcontext
@@ -34,6 +34,7 @@ import numpy as np
 import numpyro
 import numpyro.distributions as npdist
 import numpyro.optim as noptim
+import optax
 from loguru import logger
 from numpy import sqrt
 from numpyro.distributions import Bernoulli as NumpyroBernoulli
@@ -70,6 +71,7 @@ _Array = Union[np.ndarray, jax.Array]
 UpdateMethods = Literal["VI", "MCMC"]
 VIMethods = Literal["advi", "fullrank_advi"]
 ActivationFunctions = Literal["tanh", "relu", "sigmoid", "gelu"]
+OptaxKind = Literal["optimizer", "lr_scheduler"]
 
 _LOGIT_CLIPPING_THRESHOLD = 15
 
@@ -989,12 +991,12 @@ class EarlyStopping(PyBanditsBaseModel):
         """Check if training should stop based on loss convergence."""
         if self._previous_loss is not None:
             if self.diff_type == "relative":
-                change = (self._previous_loss - loss) / (abs(self._previous_loss) + self._epsilon)
+                change = abs((loss - self._previous_loss) / (abs(self._previous_loss) + self._epsilon))
             elif self.diff_type == "absolute":
-                change = self._previous_loss - loss
+                change = abs(loss - self._previous_loss)
             else:
                 raise ValueError(f"Unknown diff {self.diff_type}")
-            logger.info(str((loss, change, self._no_improvement_count)))
+
             if change < self.tolerance:
                 self._no_improvement_count += 1
             else:
@@ -1250,17 +1252,72 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         "batch_size",
         "early_stopping_kwargs",
         "epochs",
+        "lr_scheduler_type",
+        "lr_scheduler_kwargs",
+        "restore_best_svi_state",
+        "num_particles",
+        "gradient_clip_norm",
     ]
     _distribution_mapping: ClassVar[Dict[str, type]] = {"normal": NormalArray, "studentt": StudentTArray}
     _embedding_dim_divisor: ClassVar[int] = 4
     _numerical_eps: ClassVar[float] = 1e-6
-    _supported_optimizers: ClassVar[dict] = {
-        "sgd": noptim.SGD,
-        "momentum": noptim.Momentum,
-        "adagrad": noptim.Adagrad,
-        "adam": noptim.Adam,
-        "clipped_adam": noptim.ClippedAdam,
+    _optax_return_types: ClassVar[dict] = {
+        "optimizer": optax.GradientTransformation,
+        "lr_scheduler": optax.Schedule,
     }
+    _optax_required_kwargs: ClassVar[dict] = {
+        "optimizer": "learning_rate",
+        "lr_scheduler": "init_value",
+    }
+
+    def _resolve_optax_fn(self, name: str, kind: OptaxKind) -> Any:
+        """Look up an optax function by name using getattr and validate its return type annotation
+        and required keyword argument.
+
+        Parameters
+        ----------
+        name : str
+            Name of the optax attribute (e.g. ``"adam"``, ``"exponential_decay"``).
+        kind : OptaxKind
+            Key into ``_optax_return_types`` (``"optimizer"`` or ``"lr_scheduler"``).
+
+        Returns
+        -------
+        Any
+            The callable found on the ``optax`` module.
+
+        Raises
+        ------
+        ValueError
+            If ``name`` is not a callable attribute of ``optax``, its return-type
+            annotation does not match the expected type for ``kind``, or its signature
+            does not accept the required keyword argument for ``kind``.
+        """
+        fn = getattr(optax, name, None)
+        if fn is None or not callable(fn):
+            raise ValueError(f"Invalid {kind}: '{name}' is not a callable attribute of optax.")
+        expected = self._optax_return_types[kind]
+        sig = inspect.signature(fn)
+        return_annotation = sig.return_annotation
+        if isinstance(expected, type) and not hasattr(expected, "__origin__"):
+            # e.g. GradientTransformation (plain class) — check via issubclass
+            valid = isinstance(return_annotation, type) and issubclass(return_annotation, expected)
+        else:
+            # e.g. optax.Schedule (parameterized generic) — check for equality
+            valid = return_annotation == expected
+        if not valid:
+            raise ValueError(
+                f"Invalid {kind}: '{name}' does not return {expected} (got return annotation: {return_annotation})."
+            )
+        required_kwarg = self._optax_required_kwargs[kind]
+        params = sig.parameters
+        has_required = required_kwarg in params or any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
+        if not has_required:
+            raise ValueError(
+                f"Invalid {kind}: '{name}' does not accept the required keyword argument '{required_kwarg}'."
+            )
+        return fn
+
     _jax_activations: ClassVar[dict] = {
         "tanh": jax.nn.tanh,
         "relu": jax.nn.relu,
@@ -1292,7 +1349,11 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         optimizer_kwargs={"step_size": 0.01},
         batch_size=None,
         early_stopping_kwargs=None,
+        lr_scheduler_type=None,
+        lr_scheduler_kwargs=None,
         restore_best_svi_state=True,
+        num_particles=1,
+        gradient_clip_norm=None,
     )
 
     _default_mcmc_kwargs: ClassVar[dict] = dict(
@@ -1379,19 +1440,35 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         return numerical_arr, cat_indices_dict
 
     def _get_obj_optimizer(self) -> Any:
-        """Build the optimizer from update_kwargs. Always returns an optimizer (uses default if not specified)."""
+        """Build an optax optimizer from update_kwargs, wrapped via ``optax_to_numpyro``.
+
+        Optionally chains a learning-rate schedule and/or gradient clipping.
+        """
         optimizer_type = self.update_kwargs["optimizer_type"]
-        if optimizer_type not in self._supported_optimizers:
-            raise ValueError(
-                f"Invalid optimizer type: {optimizer_type}. "
-                f"Supported optimizers are: {list(self._supported_optimizers.keys())}"
-            )
-        cls_ = self._supported_optimizers[optimizer_type]
-        optimizer_kwargs = self.update_kwargs.get("optimizer_kwargs", {})
+        optimizer_kwargs = dict(self.update_kwargs.get("optimizer_kwargs", {}))
+        lr_scheduler_type = self.update_kwargs.get("lr_scheduler_type")
+        lr_scheduler_kwargs = self.update_kwargs.get("lr_scheduler_kwargs") or {}
+        gradient_clip_norm = self.update_kwargs.get("gradient_clip_norm")
+
+        optimizer_fn = self._resolve_optax_fn(optimizer_type, "optimizer")
+
+        # Resolve learning rate (possibly a schedule)
+        learning_rate = optimizer_kwargs.pop("step_size", 0.01)
+        if lr_scheduler_type is not None:
+            scheduler_fn = self._resolve_optax_fn(lr_scheduler_type, "lr_scheduler")
+            try:
+                learning_rate = scheduler_fn(init_value=learning_rate, **lr_scheduler_kwargs)
+            except (TypeError, ValueError) as e:
+                raise e.__class__(f"Invalid lr_scheduler_kwargs: {lr_scheduler_kwargs}.\n{e}") from e
+
         try:
-            return cls_(**optimizer_kwargs)
+            base_optimizer = optimizer_fn(learning_rate=learning_rate, **optimizer_kwargs)
         except (TypeError, ValueError, KeyError) as e:
-            raise e.__class__(f"Invalid optimizer kwargs: {optimizer_kwargs}.\n{e}")
+            raise e.__class__(f"Invalid optimizer kwargs: {optimizer_kwargs}.\n{e}") from e
+
+        if gradient_clip_norm is not None:
+            return noptim.optax_to_numpyro(optax.chain(optax.clip_by_global_norm(gradient_clip_norm), base_optimizer))
+        return noptim.optax_to_numpyro(base_optimizer)
 
     def _get_early_stopping_callback(self) -> Optional[EarlyStopping]:
         early_stopping_kwargs = self.update_kwargs.get("early_stopping_kwargs", None)
@@ -1675,7 +1752,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
 
         return linear_transform
 
-    def create_update_model(self, batch_size: Optional[PositiveInt] = None) -> Callable:
+    def _create_update_model(self) -> Callable:
         """
         Create a NumPyro model function for Bayesian Neural Network.
 
@@ -1684,13 +1761,8 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         with subsample_size.
 
         Numerical columns are passed through as-is. Categorical columns (identified by their
-        ``column_index`` in ``feature_config``) are modelled with Bayesian embedding matrices
+        ``column_index`` in ``feature_config``) are modeled with Bayesian embedding matrices
         sampled as NumPyro random variables.
-
-        Parameters
-        ----------
-        batch_size : Optional[PositiveInt]
-            If provided, use minibatching with this batch size via numpyro.plate.
 
         Returns
         -------
@@ -1707,12 +1779,13 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         5. Use Bernoulli likelihood for binary classification
         """
 
+        batch_size = self._update_kwargs.get("batch_size")
         numerical_indices = self.feature_config.numerical_indices
         cat_configs = self.feature_config.categorical_features_configs
         has_embeddings = self.model_params.embedding_params is not None and len(cat_configs) > 0
 
         def model(x: jax.Array, y: jax.Array):
-            N = x.shape[0]
+            n_samples = x.shape[0]
 
             # Sample all weights (global parameters, outside plate)
             weights_biases = []
@@ -1730,8 +1803,8 @@ class BaseBayesianNeuralNetwork(Model, ABC):
                     embedding_matrices.append(emb)
 
             # Data plate with optional minibatching
-            if batch_size is not None and batch_size < N:
-                plate_ctx = numpyro.plate("data", size=N, subsample_size=batch_size)
+            if batch_size is not None and batch_size < n_samples:
+                plate_ctx = numpyro.plate("data", size=n_samples, subsample_size=batch_size)
             else:
                 plate_ctx = nullcontext()
 
@@ -2113,10 +2186,9 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         """
         if self._early_stopping_callback is not None:
             self._early_stopping_callback.reset()
-        batch_size = self._update_kwargs["batch_size"]
-        _model = self.create_update_model(batch_size=batch_size)
+        _model = self._create_update_model()
 
-        effective_batch_size = batch_size if batch_size is not None else n_samples
+        effective_batch_size = self._update_kwargs.get("batch_size") or n_samples
         steps_per_epoch = max(1, n_samples // effective_batch_size)
 
         if self._update_kwargs.get("epochs") is not None:
@@ -2143,7 +2215,9 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         else:
             # fullrank_advi needs a scalar; use the avg sigma via the unknown-site fallback
             guide = method_config["guide"](_model, init_loc_fn=init_loc_fn, init_scale=init_scale_fn(""))
-        loss = method_config["loss"]()
+
+        num_particles = self._update_kwargs["num_particles"]
+        loss = method_config["loss"](num_particles=num_particles)
         svi = SVI(_model, guide, self._obj_optimizer, loss=loss)
 
         # Run the SVI loop via jax.lax.scan to keep the iteration inside XLA.
@@ -2154,14 +2228,18 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         self._rng_key, subkey = jax.random.split(self._rng_key)
         svi_state = svi.init(subkey, x_jnp, y_jnp)
 
-        def _svi_body(state, _):
-            state, loss = svi.update(state, x_jnp, y_jnp)
-            return state, loss
+        # Pass x/y as explicit JIT arguments (not closure captures) so JAX treats
+        # them as abstract buffers rather than embedding them as XLA constants.
+        # Closing over large arrays causes "Failed to allocate N bytes for new constant"
+        # at compile time when the dataset is large.
+        def _run_epoch(state, x, y, n):
+            def _svi_body(s, _):
+                s, loss = svi.update(s, x, y)
+                return s, loss
 
-        _run_epoch = jax.jit(
-            lambda state, n: jax.lax.scan(_svi_body, state, None, length=n),
-            static_argnums=(1,),
-        )
+            return jax.lax.scan(_svi_body, state, None, length=n)
+
+        _run_epoch = jax.jit(_run_epoch, static_argnums=(3,))
 
         restore_best = self._update_kwargs.get("restore_best_svi_state", True)
         all_losses = []
@@ -2169,38 +2247,38 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         best_svi_state = svi_state
         pbar = trange(len(epoch_steps_list), desc="SVI", leave=False)
 
-        for epoch_idx, epoch_steps in enumerate(epoch_steps_list):
-            svi_state, epoch_losses = _run_epoch(svi_state, epoch_steps)
+        try:
+            for epoch_idx, epoch_steps in enumerate(epoch_steps_list):
+                svi_state, epoch_losses = _run_epoch(svi_state, x_jnp, y_jnp, epoch_steps)
 
-            epoch_np = np.array(epoch_losses)
-            epoch_loss = float(np.mean(epoch_np))
-            all_losses.append(epoch_np)
-            pbar.update(1)
-            pbar.set_postfix(loss=f"{epoch_loss:.4f}")
+                epoch_np = np.array(epoch_losses)
+                epoch_loss = float(np.mean(epoch_np))
+                all_losses.append(epoch_np)
+                pbar.update(1)
+                pbar.set_postfix(loss=f"{epoch_loss:.4f}")
 
-            if np.isnan(epoch_loss):
-                pbar.close()
-                raise ValueError(
-                    f"SVI training diverged: loss is NaN at epoch {epoch_idx + 1}/{len(epoch_steps_list)}. "
-                    "Consider reducing the learning rate or checking your data for invalid values."
-                )
-
-            if restore_best and epoch_loss < best_loss:
-                best_loss = epoch_loss
-                best_svi_state = svi_state
-
-            if self._early_stopping_callback is not None:
-                if self._early_stopping_callback.should_stop(epoch_loss):
-                    logger.info(
-                        f"Early stopping at epoch {epoch_idx + 1}/{len(epoch_steps_list)}: "
-                        f"loss change below {self._early_stopping_callback.tolerance} "
-                        f"({self._early_stopping_callback.diff_type}) for "
-                        f"{self._early_stopping_callback.patience} consecutive epochs. "
-                        f"Best loss: {best_loss:.6f}, last loss: {epoch_loss:.6f}."
+                if np.isnan(epoch_loss):
+                    raise ValueError(
+                        f"SVI training diverged: loss is NaN at epoch {epoch_idx + 1}/{len(epoch_steps_list)}. "
+                        "Consider reducing the learning rate or checking your data for invalid values."
                     )
-                    break
 
-        pbar.close()
+                if restore_best and epoch_loss < best_loss:
+                    best_loss = epoch_loss
+                    best_svi_state = svi_state
+
+                if self._early_stopping_callback is not None:
+                    if self._early_stopping_callback.should_stop(epoch_loss):
+                        logger.info(
+                            f"Early stopping at epoch {epoch_idx + 1}/{len(epoch_steps_list)}: "
+                            f"loss change below {self._early_stopping_callback.tolerance} "
+                            f"({self._early_stopping_callback.diff_type}) for "
+                            f"{self._early_stopping_callback.patience} consecutive epochs. "
+                            f"Best loss: {best_loss:.6f}, last loss: {epoch_loss:.6f}."
+                        )
+                        break
+        finally:
+            pbar.close()
         self._approx_history = np.concatenate(all_losses) if all_losses else np.array([])
         final_state = best_svi_state if restore_best else svi_state
         params = svi.get_params(final_state)
@@ -2337,7 +2415,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         List
             Updated ``BnnLayerParams`` list (embeddings are updated in-place as a side-effect).
         """
-        _model = self.create_update_model()
+        _model = self._create_update_model()
         nuts_kwargs = self._update_kwargs["nuts"]
         # All top-level keys except 'nuts' are MCMC kwargs
         mcmc_kwargs = {k: v for k, v in self._update_kwargs.items() if k != "nuts"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybandits"
-version = "7.2.1"
+version = "7.2.2"
 description = "Python Multi-Armed Bandit Library"
 authors = [
     "Dario d'Andrea <dariod@playtika.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybandits"
-version = "7.1.0"
+version = "7.1.1"
 description = "Python Multi-Armed Bandit Library"
 authors = [
     "Dario d'Andrea <dariod@playtika.com>",
@@ -46,6 +46,7 @@ numpyro = [
     { version = "^0.16", python = ">=3.9,<3.11" },
     { version = "^0.20", python = ">=3.11" },
 ]
+optax = "^0.1"
 scikit-learn = "^1.1"
 optuna = "^3.6"
 tqdm = "^4"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -58,6 +58,7 @@ from pybandits.model import (
     OptaxKind,
     StudentTArray,
     UpdateMethods,
+    _wrap_guide_with_kl_scale,
 )
 
 
@@ -1357,20 +1358,25 @@ class TestKLAnnealing:
             f"likelihood site expected scale=None (outside annealing context), got {out_site['scale']!r}"
         )
 
-    @pytest.mark.parametrize("kl_annealing_factor", [0.1, 0.5, 1.0])
-    @pytest.mark.parametrize("n_features, n_samples", [(1, 3), (3, 7)])
+    @settings(deadline=None, max_examples=5)
+    @given(
+        n_features=st.integers(min_value=1, max_value=5),
+        n_samples=st.integers(min_value=2, max_value=8),
+        kl_annealing_factor=st.floats(
+            min_value=0.0, max_value=1.0, exclude_min=True, allow_nan=False, allow_infinity=False
+        ),
+    )
     def test_symmetric_guide_wrap_scales_guide_sample_sites(
         self, n_features: int, n_samples: int, kl_annealing_factor: float
     ) -> None:
         """The guide wrap installed in `_run_svi_training_loop` must scale the guide's sample
         sites symmetrically with the model's prior sites. Without it the per-site KL contribution
-        (log p - log q) would not scale uniformly. This test mirrors the closure built in
-        `_run_svi_training_loop` and traces it directly.
+        (log p - log q) would not scale uniformly.
 
-        NOTE: `guide_with_scale` below is a **structural mirror** of the closure in
-        `BaseBayesianNeuralNetwork._run_svi_training_loop`. If you change the production
-        closure's signature, factor-extraction logic, or wrap location, update this test in
-        lockstep — otherwise the test silently keeps passing while production behavior drifts.
+        This traces the **production** wrapper (`_wrap_guide_with_kl_scale`) directly, so the
+        test cannot drift from `_run_svi_training_loop`'s behavior. The asserted `scale == factor`
+        identity holds for any factor in (0, 1], so the factor and the model shape are drawn from
+        Hypothesis strategies rather than a fixed grid.
         """
         # The BNN's kl_annealing_fraction is irrelevant here: this test does not run SVI and
         # never consults the schedule. The factor under test is fed directly to get_trace(...)
@@ -1379,19 +1385,15 @@ class TestKLAnnealing:
         model_fn = bnn._create_update_model()
 
         # Build a bare AutoNormal guide over the same model (matches the advi setup in
-        # `_run_svi_training_loop`) without relying on the per-site init_scale_fn details.
+        # `_run_svi_training_loop`) without relying on the per-site init_scale_fn details,
+        # then wrap it with the exact production helper.
         guide = AutoNormal(model_fn)
-
-        # Structural mirror of `_run_svi_training_loop`'s `guide_with_scale` closure.
-        def guide_with_scale(*args, **kwargs):
-            factor = args[2] if len(args) > 2 else kwargs.get("kl_annealing_factor", 1.0)
-            with numpyro.handlers.scale(scale=factor):
-                return guide(*args, **kwargs)
+        scaled_guide = _wrap_guide_with_kl_scale(guide)
 
         x = jnp.asarray(np.random.rand(n_samples, n_features).astype(np.float32))
         y = jnp.asarray(_make_random_rewards(n_samples), dtype=jnp.int32)
 
-        tr = numpyro.handlers.trace(numpyro.handlers.seed(guide_with_scale, rng_seed=0)).get_trace(
+        tr = numpyro.handlers.trace(numpyro.handlers.seed(scaled_guide, rng_seed=0)).get_trace(
             x, y, kl_annealing_factor
         )
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1288,6 +1288,11 @@ class TestKLAnnealing:
         total_steps = sum(epoch_steps_list)
         bnn = self._build_bnn(kl_annealing_fraction=None, num_steps=total_steps)
         epoch_chunks = bnn._build_kl_annealing_factors(epoch_steps_list)
+        # Assert the per-epoch split contract directly: one chunk per epoch, each chunk
+        # holding exactly that epoch's step count. The flattened check below cannot catch a
+        # regression that splits at the wrong boundaries (lax.scan consumes one chunk per epoch).
+        assert len(epoch_chunks) == len(epoch_steps_list)
+        assert [len(chunk) for chunk in epoch_chunks] == epoch_steps_list
         factor_array = np.concatenate([np.asarray(chunk) for chunk in epoch_chunks])
         assert factor_array.shape == (total_steps,)
         np.testing.assert_allclose(factor_array, np.ones(total_steps), rtol=0, atol=0)
@@ -1308,6 +1313,9 @@ class TestKLAnnealing:
         total_steps = sum(epoch_steps_list)
         bnn = self._build_bnn(kl_annealing_fraction=kl_annealing_fraction, num_steps=total_steps)
         epoch_chunks = bnn._build_kl_annealing_factors(epoch_steps_list)
+        # Assert the per-epoch split contract directly (see the inactive-schedule test)
+        assert len(epoch_chunks) == len(epoch_steps_list)
+        assert [len(chunk) for chunk in epoch_chunks] == epoch_steps_list
         actual = np.concatenate([np.asarray(chunk) for chunk in epoch_chunks])
 
         warmup_steps = max(1, int(np.ceil(kl_annealing_fraction * total_steps)))
@@ -1373,10 +1381,9 @@ class TestKLAnnealing:
         sites symmetrically with the model's prior sites. Without it the per-site KL contribution
         (log p - log q) would not scale uniformly.
 
-        This traces the **production** wrapper (`_wrap_guide_with_kl_scale`) directly, so the
-        test cannot drift from `_run_svi_training_loop`'s behavior. The asserted `scale == factor`
-        identity holds for any factor in (0, 1], so the factor and the model shape are drawn from
-        Hypothesis strategies rather than a fixed grid.
+        Traces the production wrapper (`_wrap_guide_with_kl_scale`) directly. The asserted
+        `scale == factor` identity holds for any factor in (0, 1], so the factor and model
+        shape are drawn from Hypothesis strategies.
         """
         # The BNN's kl_annealing_fraction is irrelevant here: this test does not run SVI and
         # never consults the schedule. The factor under test is fed directly to get_trace(...)
@@ -1405,24 +1412,46 @@ class TestKLAnnealing:
                 f"guide site {name!r} expected scale={kl_annealing_factor}, got {site['scale']!r}"
             )
 
-    @pytest.mark.parametrize("invalid_value", [0.0, -0.1, 1.5, "0.5", True])
-    def test_invalid_values_rejected_at_construction(self, invalid_value) -> None:
+    # invalid_value is the axis under test; n_features/num_steps are scaffolding, pinned via st.just.
+    # np.bool_(True) is included because np.bool_ is not a numbers.Real and must be rejected by the
+    # type guard (Python bool is a numbers.Real, hence the separate explicit bool exclusion).
+    @pytest.mark.parametrize("invalid_value", [0.0, -0.1, 1.5, "0.5", True, np.bool_(True)])
+    @given(n_features=st.just(2), num_steps=st.just(5))
+    def test_invalid_values_rejected_at_construction(self, invalid_value, n_features: int, num_steps: int) -> None:
         """`kl_annealing_fraction` must be a real number in the half-open interval (0, 1]."""
         with pytest.raises(ValueError, match="kl_annealing_fraction"):
             BayesianNeuralNetwork.cold_start(
-                n_features=2,
+                n_features=n_features,
                 update_method="VI",
-                update_kwargs={"num_steps": 5, "kl_annealing_fraction": invalid_value},
+                update_kwargs={"num_steps": num_steps, "kl_annealing_fraction": invalid_value},
             )
 
-    def test_mcmc_rejects_kl_annealing_fraction_as_vi_only_kwarg(self) -> None:
+    @given(
+        n_features=st.just(2),
+        valid_numpy_fraction=st.sampled_from([np.float64(0.5), np.float32(0.5), np.int64(1), np.int32(1)]),
+    )
+    def test_valid_numpy_scalar_fractions_accepted_at_construction(self, n_features: int, valid_numpy_fraction) -> None:
+        """A NumPy real scalar in (0, 1] is a valid `kl_annealing_fraction` and must construct."""
+        bnn = BayesianNeuralNetwork.cold_start(
+            n_features=n_features,
+            update_method="VI",
+            update_kwargs={"num_steps": 5, "kl_annealing_fraction": valid_numpy_fraction},
+        )
+        assert bnn is not None
+
+    @given(n_features=st.just(2), kl_annealing_fraction=st.just(0.5))
+    def test_mcmc_rejects_kl_annealing_fraction_as_vi_only_kwarg(
+        self, n_features: int, kl_annealing_fraction: float
+    ) -> None:
         """`kl_annealing_fraction` is a VI-only kwarg; passing it under MCMC must error
-        out via the existing VI-kwargs-on-MCMC guard in `_arrange_update_kwargs`."""
+        out via the existing VI-kwargs-on-MCMC guard in `_arrange_update_kwargs`. The guard
+        fires on the kwarg's presence, not its value, so the inputs are pinned via st.just.
+        """
         with pytest.raises(ValueError, match="kl_annealing_fraction"):
             BayesianNeuralNetwork.cold_start(
-                n_features=2,
+                n_features=n_features,
                 update_method="MCMC",
-                update_kwargs={"kl_annealing_fraction": 0.5},
+                update_kwargs={"kl_annealing_fraction": kl_annealing_fraction},
             )
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -33,6 +33,7 @@ from hypothesis import strategies as st
 from numpyro.distributions import Normal as NumpyroNormal
 from numpyro.distributions import StudentT as NumpyroStudentT
 from numpyro.infer import Predictive
+from numpyro.infer.autoguide import AutoNormal
 from pydantic import ValidationError
 from utils import make_binary_rewards
 
@@ -1173,6 +1174,7 @@ def test_lr_scheduler_invalid_type_or_kwargs(
     num_particles=st.sampled_from((1, 2)),
     gradient_clip_norm=st.one_of(st.none(), st.floats(min_value=0.1, max_value=10.0)),
     lr_scheduler_type=st.sampled_from((None, "exponential_decay")),
+    kl_annealing_fraction=st.one_of(st.none(), st.floats(min_value=0.05, max_value=1.0)),
     num_steps=st.just(5),
     n_features=st.just(2),
     update_method=st.just("VI"),
@@ -1186,6 +1188,7 @@ def test_vi_training_options(
     num_particles: int,
     gradient_clip_norm: Optional[float],
     lr_scheduler_type: Optional[str],
+    kl_annealing_fraction: Optional[float],
     num_steps: int,
     n_features: int,
     update_method: UpdateMethods,
@@ -1193,7 +1196,7 @@ def test_vi_training_options(
     decay_rate: float,
     transition_steps_factor: int,
 ) -> None:
-    """Test that VI training options (num_particles, gradient_clip_norm, lr_scheduler) compose correctly."""
+    """Test that VI training options (num_particles, gradient_clip_norm, lr_scheduler, kl_annealing_fraction) compose correctly."""
     update_kwargs: dict = {
         "num_steps": num_steps,
         "optimizer_type": optimizer_type,
@@ -1207,6 +1210,8 @@ def test_vi_training_options(
             "transition_steps": num_steps // transition_steps_factor,
             "decay_rate": decay_rate,
         }
+    if kl_annealing_fraction is not None:
+        update_kwargs["kl_annealing_fraction"] = kl_annealing_fraction
 
     bnn = BayesianNeuralNetwork.cold_start(
         n_features=n_features,
@@ -1220,6 +1225,185 @@ def test_vi_training_options(
     assert len(result) == n_samples
     assert all(0 <= p[0] <= 1 for p in result), f"Probabilities out of [0,1]: {result}"
     assert all(np.isfinite(p[1]) for p in result), f"Non-finite weights: {result}"
+
+
+# ---------------------------------------------------------------------------
+# KL annealing
+# ---------------------------------------------------------------------------
+
+
+class TestKLAnnealing:
+    """Tests for the optional `kl_annealing_fraction` VI training kwarg.
+
+    The feature is implemented by wrapping the prior sample sites in
+    ``numpyro.handlers.scale(scale=kl_annealing_factor)`` and threading a per-step
+    factor array through ``svi.update``. These tests verify the handler-level
+    annotation (which is what the feature actually controls) via trace introspection,
+    plus the schedule formula at the helper level. The likelihood ``out`` site must
+    remain unscaled in every case.
+    """
+
+    @staticmethod
+    def _build_bnn(kl_annealing_fraction: Optional[float], num_steps: int = 4, n_features: int = 2):
+        update_kwargs: dict = {"num_steps": num_steps}
+        if kl_annealing_fraction is not None:
+            update_kwargs["kl_annealing_fraction"] = kl_annealing_fraction
+        return BayesianNeuralNetwork.cold_start(
+            n_features=n_features,
+            update_method="VI",
+            update_kwargs=update_kwargs,
+        )
+
+    @pytest.mark.parametrize(
+        "epoch_steps_list",
+        [
+            [1],
+            [5],
+            [3, 3, 1],
+            [2, 2, 2, 2],
+        ],
+    )
+    def test_inactive_factor_array_is_all_ones(self, epoch_steps_list: list) -> None:
+        """With no kl_annealing_fraction the per-step factor schedule is a neutral all-ones array,
+        regardless of how the total steps are split into epochs."""
+        total_steps = sum(epoch_steps_list)
+        bnn = self._build_bnn(kl_annealing_fraction=None, num_steps=total_steps)
+        epoch_chunks = bnn._build_kl_annealing_factors(epoch_steps_list)
+        factor_array = np.concatenate([np.asarray(chunk) for chunk in epoch_chunks])
+        assert factor_array.shape == (total_steps,)
+        np.testing.assert_allclose(factor_array, np.ones(total_steps), rtol=0, atol=0)
+
+    @pytest.mark.parametrize(
+        "kl_annealing_fraction, epoch_steps_list",
+        [
+            (0.5, [10]),
+            (0.25, [4, 4, 4]),
+            (1.0, [5, 5]),
+            (0.1, [3, 3, 3, 1]),
+        ],
+    )
+    def test_active_factor_array_matches_linear_ramp_formula(
+        self, kl_annealing_fraction: float, epoch_steps_list: list
+    ) -> None:
+        """The active schedule is min(1, (step+1)/W) with W = max(1, ceil(fraction * total_steps))."""
+        total_steps = sum(epoch_steps_list)
+        bnn = self._build_bnn(kl_annealing_fraction=kl_annealing_fraction, num_steps=total_steps)
+        epoch_chunks = bnn._build_kl_annealing_factors(epoch_steps_list)
+        actual = np.concatenate([np.asarray(chunk) for chunk in epoch_chunks])
+
+        warmup_steps = max(1, int(np.ceil(kl_annealing_fraction * total_steps)))
+        # Match JAX's default float32 dtype so identity-level comparison stays exact.
+        expected = np.minimum(1.0, (np.arange(total_steps, dtype=np.float32) + 1.0) / warmup_steps)
+
+        assert actual.shape == (total_steps,)
+        assert actual.dtype == np.float32
+        np.testing.assert_allclose(actual, expected, rtol=0, atol=0)
+        # Endpoint sanity: strictly positive at step 0, exactly 1.0 by the last warmup step.
+        assert actual[0] > 0.0
+        assert actual[warmup_steps - 1] == pytest.approx(1.0)
+
+    @pytest.mark.parametrize("kl_annealing_factor", [1.0, 0.3])
+    @pytest.mark.parametrize("n_features, n_samples", [(1, 3), (3, 7)])
+    def test_model_trace_scale_annotation_on_priors_and_not_on_likelihood(
+        self, n_features: int, n_samples: int, kl_annealing_factor: float
+    ) -> None:
+        """Tracing the inner model surfaces handlers.scale on every prior sample site (weights, biases)
+        with the supplied factor, while the likelihood ``out`` site is left unscaled.
+
+        This is a pure-trace assertion: it does not run SVI, so it is deterministic and
+        independent of XLA layout. It tests the actual surface (handler-level scale annotation)
+        the feature controls.
+        """
+        bnn = self._build_bnn(kl_annealing_fraction=None, n_features=n_features)
+        model_fn = bnn._create_update_model()
+
+        x = jnp.asarray(np.random.rand(n_samples, n_features).astype(np.float32))
+        y = jnp.asarray(_make_random_rewards(n_samples), dtype=jnp.int32)
+
+        tr = numpyro.handlers.trace(numpyro.handlers.seed(model_fn, rng_seed=0)).get_trace(x, y, kl_annealing_factor)
+
+        prior_site_names = [name for name in tr if name.startswith(("weight_", "bias_"))]
+        assert prior_site_names, "expected at least one prior site in the model trace"
+        for name in prior_site_names:
+            site = tr[name]
+            assert site["type"] == "sample"
+            assert site["scale"] == kl_annealing_factor, (
+                f"prior site {name!r} expected scale={kl_annealing_factor}, got {site['scale']!r}"
+            )
+
+        out_site = tr["out"]
+        assert out_site["type"] == "sample"
+        # The likelihood site must remain outside the scale context. handlers.scale leaves
+        # site["scale"] as None when no wrap is in effect.
+        assert out_site["scale"] is None, (
+            f"likelihood site expected scale=None (outside annealing context), got {out_site['scale']!r}"
+        )
+
+    @pytest.mark.parametrize("kl_annealing_factor", [0.1, 0.5, 1.0])
+    @pytest.mark.parametrize("n_features, n_samples", [(1, 3), (3, 7)])
+    def test_symmetric_guide_wrap_scales_guide_sample_sites(
+        self, n_features: int, n_samples: int, kl_annealing_factor: float
+    ) -> None:
+        """The guide wrap installed in `_run_svi_training_loop` must scale the guide's sample
+        sites symmetrically with the model's prior sites. Without it the per-site KL contribution
+        (log p - log q) would not scale uniformly. This test mirrors the closure built in
+        `_run_svi_training_loop` and traces it directly.
+
+        NOTE: `guide_with_scale` below is a **structural mirror** of the closure in
+        `BaseBayesianNeuralNetwork._run_svi_training_loop`. If you change the production
+        closure's signature, factor-extraction logic, or wrap location, update this test in
+        lockstep — otherwise the test silently keeps passing while production behavior drifts.
+        """
+        # The BNN's kl_annealing_fraction is irrelevant here: this test does not run SVI and
+        # never consults the schedule. The factor under test is fed directly to get_trace(...)
+        # via the kl_annealing_factor parameter below.
+        bnn = self._build_bnn(kl_annealing_fraction=None, n_features=n_features)
+        model_fn = bnn._create_update_model()
+
+        # Build a bare AutoNormal guide over the same model (matches the advi setup in
+        # `_run_svi_training_loop`) without relying on the per-site init_scale_fn details.
+        guide = AutoNormal(model_fn)
+
+        # Structural mirror of `_run_svi_training_loop`'s `guide_with_scale` closure.
+        def guide_with_scale(*args, **kwargs):
+            factor = args[2] if len(args) > 2 else kwargs.get("kl_annealing_factor", 1.0)
+            with numpyro.handlers.scale(scale=factor):
+                return guide(*args, **kwargs)
+
+        x = jnp.asarray(np.random.rand(n_samples, n_features).astype(np.float32))
+        y = jnp.asarray(_make_random_rewards(n_samples), dtype=jnp.int32)
+
+        tr = numpyro.handlers.trace(numpyro.handlers.seed(guide_with_scale, rng_seed=0)).get_trace(
+            x, y, kl_annealing_factor
+        )
+
+        guide_sample_sites = [name for name, site in tr.items() if site["type"] == "sample"]
+        assert guide_sample_sites, "expected at least one sample site in the guide trace"
+        for name in guide_sample_sites:
+            site = tr[name]
+            assert site["scale"] == kl_annealing_factor, (
+                f"guide site {name!r} expected scale={kl_annealing_factor}, got {site['scale']!r}"
+            )
+
+    @pytest.mark.parametrize("invalid_value", [0.0, -0.1, 1.5, "0.5", True])
+    def test_invalid_values_rejected_at_construction(self, invalid_value) -> None:
+        """`kl_annealing_fraction` must be a real number in the half-open interval (0, 1]."""
+        with pytest.raises(ValueError, match="kl_annealing_fraction"):
+            BayesianNeuralNetwork.cold_start(
+                n_features=2,
+                update_method="VI",
+                update_kwargs={"num_steps": 5, "kl_annealing_fraction": invalid_value},
+            )
+
+    def test_mcmc_rejects_kl_annealing_fraction_as_vi_only_kwarg(self) -> None:
+        """`kl_annealing_fraction` is a VI-only kwarg; passing it under MCMC must error
+        out via the existing VI-kwargs-on-MCMC guard in `_arrange_update_kwargs`."""
+        with pytest.raises(ValueError, match="kl_annealing_fraction"):
+            BayesianNeuralNetwork.cold_start(
+                n_features=2,
+                update_method="MCMC",
+                update_kwargs={"kl_annealing_fraction": 0.5},
+            )
 
 
 @given(

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Literal, Optional
+from typing import Literal, Optional, get_args
 from unittest.mock import patch
 
 import jax
@@ -52,6 +52,7 @@ from pybandits.model import (
     EmbeddingParams,
     FeaturesConfig,
     NormalArray,
+    OptaxKind,
     StudentTArray,
     UpdateMethods,
 )
@@ -797,7 +798,7 @@ def test_bnn_vi_update(
             assert isinstance(bnn.model_params.bnn_layer_params[layer_ind].weight, expected_array)
             assert isinstance(bnn.model_params.bnn_layer_params[layer_ind].bias, expected_array)
 
-    rewards = np.random.choice([0, 1], size=n_samples).tolist()
+    rewards = _make_random_rewards(n_samples)
 
     # context is numpy array
     context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
@@ -887,7 +888,7 @@ def test_bnn_vi_update_parameters(
         update_kwargs=update_kwargs,
     )
 
-    model_fn = bnn.create_update_model()
+    model_fn = bnn._create_update_model()
     assert callable(model_fn)
 
     # Optimizer is always set for VI (built from defaults or user override)
@@ -907,13 +908,11 @@ def test_bnn_vi_update_parameters(
 @given(
     n_features=st.just(2),
     hidden_dim_list=st.just([1]),
-    n_samples=st.just(5),
     update_method=st.just("MCMC"),
 )
 def test_bnn_mcmc_update_parameters(
     n_features: int,
     hidden_dim_list: list[int],
-    n_samples: int,
     update_method: UpdateMethods,
 ) -> None:
     """Test BNN MCMC update with valid parameters (no batch_size, optimizer, or early_stopping)."""
@@ -925,7 +924,7 @@ def test_bnn_mcmc_update_parameters(
         update_kwargs={},
     )
 
-    model_fn = bnn.create_update_model()
+    model_fn = bnn._create_update_model()
     assert callable(model_fn)
 
 
@@ -1037,6 +1036,46 @@ def test_invalid_optimizer_kwargs(
         )
 
 
+def test_optax_kind_literal_matches_optax_return_types_keys() -> None:
+    """Verify that OptaxKind Literal values exactly match _optax_return_types keys."""
+
+    literal_values = set(get_args(OptaxKind))
+    classvar_keys = set(BayesianNeuralNetwork._optax_return_types.keys())
+    assert literal_values == classvar_keys, (
+        f"OptaxKind Literal {literal_values} does not match _optax_return_types keys {classvar_keys}"
+    )
+
+
+def test_optax_kind_literal_matches_optax_required_kwargs_keys() -> None:
+    """Verify that OptaxKind Literal values exactly match _optax_required_kwargs keys."""
+
+    literal_values = set(get_args(OptaxKind))
+    classvar_keys = set(BayesianNeuralNetwork._optax_required_kwargs.keys())
+    assert literal_values == classvar_keys, (
+        f"OptaxKind Literal {literal_values} does not match _optax_required_kwargs keys {classvar_keys}"
+    )
+
+
+@pytest.mark.parametrize(
+    "kind,fn_name",
+    [
+        # optax.scale returns GradientTransformation but accepts step_size, not learning_rate
+        ("optimizer", "scale"),
+        # optax.constant_schedule returns Schedule but accepts value, not init_value
+        ("lr_scheduler", "constant_schedule"),
+    ],
+)
+def test_resolve_optax_fn_rejects_missing_required_kwarg(
+    kind: str,
+    fn_name: str,
+    n_features: int = 2,
+) -> None:
+    """Test that _resolve_optax_fn raises ValueError when the required kwarg is absent."""
+    bnn = BayesianNeuralNetwork.cold_start(n_features=n_features)
+    with pytest.raises(ValueError, match="does not accept the required keyword argument"):
+        bnn._resolve_optax_fn(fn_name, kind)
+
+
 @pytest.mark.parametrize(
     "early_stopping_kwargs",
     [
@@ -1059,6 +1098,130 @@ def test_invalid_early_stopping_kwargs(
         )
 
 
+@pytest.mark.parametrize(
+    "optimizer_type,optimizer_kwargs,lr_scheduler_type,lr_scheduler_kwargs",
+    [
+        ("sgd", {"step_size": 0.01}, "exponential_decay", {"transition_steps": 100, "decay_rate": 0.9}),
+        ("adam", {"step_size": 0.01}, "exponential_decay", {"transition_steps": 50, "decay_rate": 0.95}),
+        ("sgd", {"step_size": 0.01, "momentum": 0.9}, "cosine_decay_schedule", {"decay_steps": 100}),
+        (
+            "adam",
+            {"step_size": 0.01},
+            "exponential_decay",
+            {"transition_steps": 100, "decay_rate": 0.9, "staircase": True},
+        ),
+        (
+            "sgd",
+            {"step_size": 0.01},
+            "warmup_cosine_decay_schedule",
+            {"peak_value": 0.05, "warmup_steps": 10, "decay_steps": 100},
+        ),
+        ("adam", {"step_size": 0.01}, "linear_schedule", {"end_value": 1e-5, "transition_steps": 200}),
+    ],
+)
+def test_lr_scheduler_valid(
+    optimizer_type: str,
+    optimizer_kwargs: dict,
+    lr_scheduler_type: str,
+    lr_scheduler_kwargs: dict,
+    n_features: int = 2,
+) -> None:
+    """Test that valid lr_scheduler_type/lr_scheduler_kwargs build an optimizer successfully."""
+    bnn = BayesianNeuralNetwork.cold_start(
+        n_features=n_features,
+        update_method="VI",
+        update_kwargs={
+            "optimizer_type": optimizer_type,
+            "optimizer_kwargs": optimizer_kwargs,
+            "lr_scheduler_type": lr_scheduler_type,
+            "lr_scheduler_kwargs": lr_scheduler_kwargs,
+        },
+    )
+    assert bnn._obj_optimizer is not None
+
+
+@pytest.mark.parametrize(
+    "lr_scheduler_type,lr_scheduler_kwargs",
+    [
+        (
+            "dummy_scheduler",
+            {},
+        ),
+        ("exponential_decay", {"invalid_kwarg": 1}),
+    ],
+)
+def test_lr_scheduler_invalid_type_or_kwargs(
+    lr_scheduler_type: str,
+    lr_scheduler_kwargs: dict,
+    n_features: int = 2,
+) -> None:
+    """Test that invalid lr_scheduler_type or lr_scheduler_kwargs raise ValueError."""
+    with pytest.raises((TypeError, ValueError)):
+        BayesianNeuralNetwork.cold_start(
+            n_features=n_features,
+            update_method="VI",
+            update_kwargs={
+                "lr_scheduler_type": lr_scheduler_type,
+                "lr_scheduler_kwargs": lr_scheduler_kwargs,
+            },
+        )
+
+
+@settings(max_examples=20)
+@given(
+    optimizer_type=st.sampled_from(("sgd", "adam")),
+    num_particles=st.sampled_from((1, 2)),
+    gradient_clip_norm=st.one_of(st.none(), st.floats(min_value=0.1, max_value=10.0)),
+    lr_scheduler_type=st.sampled_from((None, "exponential_decay")),
+    num_steps=st.just(5),
+    n_features=st.just(2),
+    update_method=st.just("VI"),
+    n_samples=st.just(5),
+    decay_rate=st.just(0.9),
+    transition_steps_factor=st.just(2),
+)
+def test_vi_training_options(
+    rng,
+    optimizer_type: str,
+    num_particles: int,
+    gradient_clip_norm: Optional[float],
+    lr_scheduler_type: Optional[str],
+    num_steps: int,
+    n_features: int,
+    update_method: UpdateMethods,
+    n_samples: int,
+    decay_rate: float,
+    transition_steps_factor: int,
+) -> None:
+    """Test that VI training options (num_particles, gradient_clip_norm, lr_scheduler) compose correctly."""
+    update_kwargs: dict = {
+        "num_steps": num_steps,
+        "optimizer_type": optimizer_type,
+        "num_particles": num_particles,
+    }
+    if gradient_clip_norm is not None:
+        update_kwargs["gradient_clip_norm"] = gradient_clip_norm
+    if lr_scheduler_type is not None:
+        update_kwargs["lr_scheduler_type"] = lr_scheduler_type
+        update_kwargs["lr_scheduler_kwargs"] = {
+            "transition_steps": num_steps // transition_steps_factor,
+            "decay_rate": decay_rate,
+        }
+
+    bnn = BayesianNeuralNetwork.cold_start(
+        n_features=n_features,
+        update_method=update_method,
+        update_kwargs=update_kwargs,
+    )
+    context = np.random.rand(n_samples, n_features).astype(np.float32)
+    rewards = _make_random_rewards(n_samples)
+    bnn.update(context=context, rewards=rewards)
+    result = bnn.sample_proba(context=context, rng=rng)
+    assert len(result) == n_samples
+    assert all(0 <= p[0] <= 1 for p in result), f"Probabilities out of [0,1]: {result}"
+    assert all(np.isfinite(p[1]) for p in result), f"Non-finite weights: {result}"
+
+
 @given(
     n_features=st.just(2),
     update_method=st.just("VI"),
@@ -1077,13 +1240,10 @@ def test_epochs_and_num_steps_warns(n_features: int, update_method: UpdateMethod
 
 @pytest.mark.parametrize("n_features", [1, 2])
 def test_bnn_mcmc_update(
-    n_features,
-    hidden_dim_list=(1,),
-    n_samples=3,
-    update_method="MCMC",
-    update_kwargs={"num_warmup": 2, "num_samples": 2, "num_chains": 1},
+    n_features, hidden_dim_list=(1,), n_samples=3, update_method="MCMC", num_warmup=1, mcmc_num_samples=2, num_chains=1
 ):
     hidden_dim_list = list(hidden_dim_list)
+    update_kwargs = {"num_warmup": num_warmup, "num_samples": mcmc_num_samples, "num_chains": num_chains}
 
     def update(context: np.ndarray, rewards: list):
         bnn = BayesianNeuralNetwork.cold_start(
@@ -1117,7 +1277,7 @@ def test_bnn_mcmc_update(
                 assert layer_w.params[param].tolist() == getattr(layer_w, param)
                 assert layer_b.params[param].tolist() == getattr(layer_b, param)
 
-    rewards = np.random.choice([0, 1], size=n_samples).tolist()
+    rewards = _make_random_rewards(n_samples)
     context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
     update(context=context, rewards=rewards)
 
@@ -1168,7 +1328,7 @@ def test_bnn_fullrank_advi_update(n_features, hidden_dim_list=(1,), n_samples=5,
                 assert layer_w.params[param].tolist() == getattr(layer_w, param)
                 assert layer_b.params[param].tolist() == getattr(layer_b, param)
 
-    rewards = np.random.choice([0, 1], size=n_samples).tolist()
+    rewards = _make_random_rewards(n_samples)
     context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
     update(context=context, rewards=rewards)
 
@@ -1731,13 +1891,18 @@ def test_embedding_params_init_is_frozen_copy(n_features, cardinality, embedding
 # ---------------------------------------------------------------------------
 
 
-def _make_bnn_with_categoricals(n_features=2, categorical_features=None, dist_type="studentt", hidden_dim_list=None):
+def _make_bnn_with_categoricals(
+    n_features=2, categorical_features=None, dist_type="studentt", hidden_dim_list=None, update_kwargs=None
+):
+    kwargs = {"epochs": 1}
+    if update_kwargs:
+        kwargs.update(update_kwargs)
     return BayesianNeuralNetwork.cold_start(
         n_features=n_features,
         categorical_features=categorical_features or {1: 3},
         hidden_dim_list=hidden_dim_list or [8],
         dist_type=dist_type,
-        update_kwargs={"epochs": 1},
+        update_kwargs=kwargs,
     )
 
 
@@ -1868,12 +2033,11 @@ def test_sample_proba_with_feature_config(rng, dist_type, n_samples, n_features,
 )
 def test_create_update_model_contains_embedding_variable(n_features, cardinality, n_samples):
     """Verify the NumPyro model function samples embedding variables."""
-    import jax.numpy as jnp
 
     cat_col = n_features - 1
     categorical_features = {cat_col: cardinality}
     bnn = _make_bnn_with_categoricals(n_features=n_features, categorical_features=categorical_features)
-    model_fn = bnn.create_update_model()
+    model_fn = bnn._create_update_model()
     context = jnp.array(_make_categorical_context(n_samples, n_features, categorical_features), dtype=jnp.float32)
     rewards = jnp.array(_make_random_rewards(n_samples), dtype=jnp.int32)
     trace = numpyro.handlers.trace(numpyro.handlers.seed(model_fn, rng_seed=0)).get_trace(context, rewards)
@@ -1889,12 +2053,13 @@ def test_create_update_model_contains_embedding_variable(n_features, cardinality
 )
 def test_create_update_model_minibatch_with_categoricals(n_features, cardinality, n_samples, batch_size):
     """Verify the NumPyro model function with minibatching samples embedding variables."""
-    import jax.numpy as jnp
 
     cat_col = n_features - 1
     categorical_features = {cat_col: cardinality}
-    bnn = _make_bnn_with_categoricals(n_features=n_features, categorical_features=categorical_features)
-    model_fn = bnn.create_update_model(batch_size=batch_size)
+    bnn = _make_bnn_with_categoricals(
+        n_features=n_features, categorical_features=categorical_features, update_kwargs={"batch_size": batch_size}
+    )
+    model_fn = bnn._create_update_model()
     context = jnp.array(_make_categorical_context(n_samples, n_features, categorical_features), dtype=jnp.float32)
     rewards = jnp.array(_make_random_rewards(n_samples), dtype=jnp.int32)
     trace = numpyro.handlers.trace(numpyro.handlers.seed(model_fn, rng_seed=0)).get_trace(context, rewards)
@@ -1935,7 +2100,7 @@ def test_reset_restores_embedding_params(n_features, cardinality):
 # ---------------------------------------------------------------------------
 
 
-@settings(deadline=None, max_examples=5)
+@settings(max_examples=20)
 @given(
     dist_type=st.sampled_from(["studentt", "normal"]),
     n_features=st.integers(min_value=2, max_value=4),


### PR DESCRIPTION
## Summary

Adds optional `kl_annealing_fraction` to BNN VI `update_kwargs`. When set, the KL term of the ELBO is linearly ramped from `1/W` at step 0 up to `1.0` over the first `W = max(1, ceil(kl_annealing_fraction * total_steps))` steps, then stays at `1.0`. `None` (default) preserves existing behavior; MCMC is unaffected.

## Implementation

`numpyro.handlers.scale` wraps both the model's prior sample sites and the guide's variational sample sites symmetrically (so `log p − log q` is scaled uniformly, not just `log p`). The per-step factor is precomputed once as a flat `jnp.ndarray` and fed to `lax.scan` via `xs`, which keeps the SVI loop compile-once and unifies the active/inactive code paths (the inactive schedule is all-ones — a numerical no-op).

## Test plan

- [ ] `poetry run pytest -vv tests/test_model.py::TestKLAnnealing`
- [ ] `poetry run pytest -vv tests/test_model.py::test_vi_training_options`
- [ ] `poetry run pytest -vv tests/test_model.py::test_bnn_mcmc_update`
- [ ] `poetry run pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable KL annealing for Variational Inference training to ramp KL weighting across training epochs.

* **Tests**
  * Extended VI tests to accept the new KL annealing option and added a suite validating schedule behavior, symmetric model/guide scaling during annealing, and input validation.

* **Chores**
  * Bumped package version to 7.2.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->