### PR TITLE
Add per-update decay_factor (forgetting) to bandit models

### DIFF
--- a/pybandits/base_model.py
+++ b/pybandits/base_model.py
@@ -106,8 +106,11 @@ class BaseModelSO(BaseModel, ABC):
         Counter of the number of failures.
     """
 
-    n_successes: PositiveInt = 1
-    n_failures: PositiveInt = 1
+    # Beta(1, 1) prior pseudo-count: the anchor that raw counts start from and that decay shrinks toward.
+    _prior_pseudo_count: ClassVar[int] = 1
+
+    n_successes: PositiveInt = _prior_pseudo_count
+    n_failures: PositiveInt = _prior_pseudo_count
 
     # --- Transfer learning keys (own contributions for this class) ---
     _transfer_learned_keys: ClassVar[Tuple[str, ...]] = ("n_successes", "n_failures")
@@ -181,8 +184,8 @@ class BaseModelSO(BaseModel, ABC):
         """
         Reset the model.
         """
-        self.n_successes = 1
-        self.n_failures = 1
+        self.n_successes = self._prior_pseudo_count
+        self.n_failures = self._prior_pseudo_count
         self._reset()
 
     @abstractmethod

--- a/pybandits/mab.py
+++ b/pybandits/mab.py
@@ -545,7 +545,8 @@ class BaseMab(PyBanditsBaseModel, ABC):
             Seed for the MAB's central numpy RNG (used for epsilon-greedy and Thompson sampling).
             Propagated automatically to BNN action models so the full pipeline is reproducible.
         kwargs : Dict[str, Any]
-            Additional parameters for the mab and for the action model.
+            Additional parameters for the mab and for the action model, e.g. ``decay_factor`` for
+            per-update forgetting in the action models.
 
         Returns
         -------

--- a/pybandits/model/base.py
+++ b/pybandits/model/base.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 from abc import ABC, abstractmethod
-from typing import List, Union
+from typing import List, Optional, Union
 
 import numpy as np
 from pydantic import (
@@ -30,6 +30,7 @@ from pydantic import (
 
 from pybandits.base import (
     MOProbability,
+    PositiveFloat01,
     Probability,
     ProbabilityWeight,
 )
@@ -46,7 +47,13 @@ class Model(BaseModelSO, ABC):
         Counter of the number of successes.
     n_failures: PositiveInt = 1
         Counter of the number of failures.
+    decay_factor: Optional[PositiveFloat01] = None
+        Per-update forgetting factor in (0, 1]. When set, historical evidence is discounted on each
+        update so the model adapts faster to non-stationary environments. None (default) and 1.0
+        preserve the standard, non-decaying behavior.
     """
+
+    decay_factor: Optional[PositiveFloat01] = None
 
     @abstractmethod
     def sample_proba(

--- a/pybandits/model/beta.py
+++ b/pybandits/model/beta.py
@@ -20,19 +20,22 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 from abc import ABC
-from typing import List
+from typing import ClassVar, List, Optional, Tuple
 
 import numpy as np
 from numpy import sqrt
 from pydantic import (
+    PositiveFloat,
     PositiveInt,
     conlist,
+    model_validator,
     validate_call,
 )
 from typing_extensions import Self
 
 from pybandits.base import (
     BinaryReward,
+    PositiveFloat01,
     Probability,
 )
 from pybandits.model.base import Model, ModelCC, ModelDP, ModelMO
@@ -48,29 +51,70 @@ class BaseBeta(Model, ABC):
         Counter of the number of successes.
     n_failures: PositiveInt = 1
         Counter of the number of failures.
+    decay_factor: Optional[PositiveFloat01] = None
+        Per-update forgetting factor in (0, 1] inherited from Model. When set, sampling is
+        driven by the effective (decayed) counts below instead of the raw n_successes/n_failures.
+    decayed_n_successes: Optional[PositiveFloat] = None
+        Effective number of successes after decay, used for sampling when decay_factor is set.
+        Seeded from n_successes on first use; None when decay is disabled.
+    decayed_n_failures: Optional[PositiveFloat] = None
+        Effective number of failures after decay, used for sampling when decay_factor is set.
+        Seeded from n_failures on first use; None when decay is disabled.
     """
+
+    decayed_n_successes: Optional[PositiveFloat] = None
+    decayed_n_failures: Optional[PositiveFloat] = None
+
+    # The effective decayed counts are learned state and must be transferred alongside the raw counts.
+    _transfer_learned_keys: ClassVar[Tuple[str, ...]] = ("decayed_n_successes", "decayed_n_failures")
+
+    @model_validator(mode="after")
+    def _init_decayed_counts(self) -> Self:
+        """Seed the effective decayed counts from the raw counts when decay is enabled."""
+        if self.decay_factor is not None:
+            if self.decayed_n_successes is None:
+                self.decayed_n_successes = float(self.n_successes)
+            if self.decayed_n_failures is None:
+                self.decayed_n_failures = float(self.n_failures)
+        return self
 
     @property
     def std(self) -> float:
         """
         The corrected standard deviation (Bessel's correction) of the binary distribution of successes and failures.
         """
-        return sqrt((self.n_successes * self.n_failures) / (self.count * (self.count - 1)))
+        if self.decay_factor is not None:
+            n_s, n_f = self.decayed_n_successes, self.decayed_n_failures
+        else:
+            n_s, n_f = float(self.n_successes), float(self.n_failures)
+        total = n_s + n_f
+        return sqrt((n_s * n_f) / (total * (total - 1)))
 
     @validate_call
     def _update(self, rewards: List[BinaryReward]):
         """
-        Update n_successes and n_failures.
+        Update the effective decayed counts (the raw n_successes/n_failures are updated by BaseModelSO).
+
+        When decay_factor is set, historical evidence is discounted towards the Beta(1, 1) prior
+        before the new rewards are added: ``n <- 1 + decay_factor * (n - 1) + new``. This keeps the
+        effective counts at or above the prior, so the Beta posterior stays proper.
 
         Parameters
         ----------
         rewards: List[BinaryReward]
             A list of binary rewards.
         """
-        pass
+        if self.decay_factor is not None:
+            n_successes = sum(rewards)
+            n_failures = len(rewards) - n_successes
+            prior = self._prior_pseudo_count
+            self.decayed_n_successes = prior + self.decay_factor * (self.decayed_n_successes - prior) + n_successes
+            self.decayed_n_failures = prior + self.decay_factor * (self.decayed_n_failures - prior) + n_failures
 
     def _reset(self):
-        pass
+        if self.decay_factor is not None:
+            self.decayed_n_successes = float(self._prior_pseudo_count)
+            self.decayed_n_failures = float(self._prior_pseudo_count)
 
     def sample_proba(self, n_samples: PositiveInt, rng: np.random.Generator) -> List[Probability]:
         """
@@ -88,7 +132,11 @@ class BaseBeta(Model, ABC):
         prob: Probability
             Probability of getting a positive reward.
         """
-        return list(rng.beta(self.n_successes, self.n_failures, size=n_samples))
+        if self.decay_factor is not None:
+            n_successes, n_failures = self.decayed_n_successes, self.decayed_n_failures
+        else:
+            n_successes, n_failures = self.n_successes, self.n_failures
+        return list(rng.beta(n_successes, n_failures, size=n_samples))
 
 
 class Beta(BaseBeta):
@@ -148,7 +196,7 @@ class BaseBetaMO(ModelMO, ABC):
 
     @classmethod
     @validate_call
-    def cold_start(cls, n_objectives: PositiveInt, **kwargs) -> Self:
+    def cold_start(cls, n_objectives: PositiveInt, decay_factor: Optional[PositiveFloat01] = None, **kwargs) -> Self:
         """
         Utility function to create a BetaMO or child model with cost control,
         with default parameters.
@@ -157,6 +205,8 @@ class BaseBetaMO(ModelMO, ABC):
         ----------
         n_objectives : PositiveInt
             Number of objectives (models) to create.
+        decay_factor : Optional[PositiveFloat01]
+            Per-update forgetting factor forwarded to each per-objective Beta model.
         kwargs: Dict[str, Any]
             Additional arguments for the BaseBetaMO child model.
 
@@ -165,7 +215,7 @@ class BaseBetaMO(ModelMO, ABC):
         beta_mo: BetaMO
             The multi-objective Beta model.
         """
-        models = [Beta() for _ in range(n_objectives)]
+        models = [Beta(decay_factor=decay_factor) for _ in range(n_objectives)]
         beta_mo = cls(models=models, **kwargs)
         return beta_mo
 

--- a/pybandits/model/bnn/network.py
+++ b/pybandits/model/bnn/network.py
@@ -1493,6 +1493,13 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         if self.calibrate_output_bias:
             self._calibrate_output_bias(rewards)
 
+        # Forgetting: widen the current posterior (used as the prior for this fit) before re-fitting,
+        # so fresh data dominates old evidence. No-op on the first fit (no posterior to inflate yet),
+        # and no-op when decay_factor is None or 1.
+        is_first_fit = self.n_successes == self._prior_pseudo_count and self.n_failures == self._prior_pseudo_count
+        if not is_first_fit:
+            self._inflate_prior_variance()
+
         if self.update_method == "VI":
             updated_layer_params_list = self._extract_vi_params(x_jnp, y_jnp, n_samples)
 
@@ -1505,6 +1512,30 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         self.model_params.bnn_layer_params = (
             updated_layer_params_list  # update the model_params with the new found posteriors
         )
+
+    def _inflate_prior_variance(self):
+        """
+        Inflate the stored posterior variance before re-fitting, implementing per-update forgetting.
+        Every weight, bias, and embedding ``sigma`` is multiplied
+        by ``1 / decay_factor``, widening the prior consumed by the next VI/MCMC round so that fresh
+        data dominates old evidence. The means (``mu``) and the Student-t degrees of freedom (``nu``)
+        are left untouched. No-op when ``decay_factor`` is None or 1.
+        """
+        if self.decay_factor is None or self.decay_factor == 1:
+            return
+        inflation = 1.0 / self.decay_factor
+        for layer_params in self.model_params.bnn_layer_params:
+            layer_params.weight = layer_params.weight.with_dist_parameters(
+                sigma=(np.asarray(layer_params.weight.params["sigma"]) * inflation).tolist()
+            )
+            layer_params.bias = layer_params.bias.with_dist_parameters(
+                sigma=(np.asarray(layer_params.bias.params["sigma"]) * inflation).tolist()
+            )
+        if self.model_params.embedding_params is not None:
+            self.model_params.embedding_params.embeddings = [
+                emb.with_dist_parameters(sigma=(np.asarray(emb.params["sigma"]) * inflation).tolist())
+                for emb in self.model_params.embedding_params.embeddings
+            ]
 
     @classmethod
     @validate_call
@@ -1523,6 +1554,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         categorical_features: Optional[Dict[NonNegativeInt, NonNegativeInt]] = None,
         random_seed: Optional[NonNegativeInt] = None,
         calibrate_output_bias: bool = False,
+        decay_factor: Optional[PositiveFloat01] = None,
         **kwargs,
     ) -> Self:
         """
@@ -1570,6 +1602,9 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             Seed for the JAX PRNG key. If None, a seed is drawn from OS entropy at construction time
             and stored on the instance, so the same initial key is reproduced after serialization.
             Pass an explicit integer for fully reproducible runs.
+        decay_factor : Optional[PositiveFloat01]
+            Per-update forgetting factor in (0, 1]. When set, the weight/bias/embedding posterior
+            variances are inflated by ``1 / decay_factor`` before each re-fit. Default is None.
         **kwargs
             Additional keyword arguments for the BayesianNeuralNetwork constructor.
 
@@ -1614,6 +1649,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
             feature_config=feature_config,
             random_seed=random_seed,
             calibrate_output_bias=calibrate_output_bias,
+            decay_factor=decay_factor,
             **kwargs,
         )
 
@@ -1787,6 +1823,7 @@ class BaseBayesianNeuralNetworkMO(ModelMO, ABC):
         use_residual_connections: bool = False,
         use_layerwise_scaling: bool = False,
         bias_std: Optional[PositiveFloat] = None,
+        decay_factor: Optional[PositiveFloat01] = None,
         **kwargs,
     ) -> Self:
         """
@@ -1817,6 +1854,8 @@ class BaseBayesianNeuralNetworkMO(ModelMO, ABC):
         bias_std : Optional[PositiveFloat]
             If provided, overrides ``sigma`` from ``dist_params`` for all layers' bias priors,
             leaving weight priors untouched. Default is None.
+        decay_factor : Optional[PositiveFloat01]
+            Per-update forgetting factor forwarded to each per-objective BNN.
         **kwargs
             Additional keyword arguments.
 
@@ -1838,6 +1877,7 @@ class BaseBayesianNeuralNetworkMO(ModelMO, ABC):
                 use_residual_connections=use_residual_connections,
                 use_layerwise_scaling=use_layerwise_scaling,
                 bias_std=bias_std,
+                decay_factor=decay_factor,
             )
             for _ in range(n_objectives)
         ]

--- a/pybandits/quantitative_model/base.py
+++ b/pybandits/quantitative_model/base.py
@@ -47,6 +47,12 @@ class QuantitativeModel(BaseModelSO, ABC):
     """
     Base class for quantitative models.
 
+    Each concrete model wraps an inner single-objective base model (e.g. a ``Beta`` per Zooming
+    segment, or a ``BayesianNeuralNetwork``). By convention, ``cold_start`` accepts
+    ``base_model_cold_start_kwargs``: a dict forwarded to that inner base model's constructor /
+    cold start (e.g. ``decay_factor``), since per-update behavior is an attribute of the base model
+    rather than the quantitative wrapper.
+
     Parameters
     ----------
     dimension: PositiveInt

--- a/pybandits/quantitative_model/bnn.py
+++ b/pybandits/quantitative_model/bnn.py
@@ -26,7 +26,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union, get_args
 import numpy as np
 from numpy.typing import ArrayLike
 from pydantic import (
-    Field,
     NonNegativeInt,
     PositiveInt,
     validate_call,
@@ -69,7 +68,7 @@ class BaseQuantitativeBayesianNeuralNetwork(QuantitativeModel, ABC):
         dimension: PositiveInt = 1,
         n_features: NonNegativeInt = 1,
         categorical_features: Optional[Dict[NonNegativeInt, NonNegativeInt]] = None,
-        base_model_cold_start_kwargs: Optional[Dict[str, Any]] = Field(default_factory=dict),
+        base_model_cold_start_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> Self:
         """
@@ -87,7 +86,7 @@ class BaseQuantitativeBayesianNeuralNetwork(QuantitativeModel, ABC):
         base_model_cold_start_kwargs : Optional[Dict[str, Any]], optional
             Keyword arguments passed to BayesianNeuralNetwork.cold_start. May include e.g.
             hidden_dim_list, update_method, update_kwargs, dist_type, dist_params_init,
-            activation, use_residual_connections, use_layerwise_scaling. Default is None.
+            activation, use_residual_connections, use_layerwise_scaling, decay_factor. Default is None.
         **kwargs
             Additional keyword arguments for the QuantitativeBayesianNeuralNetwork constructor.
 
@@ -104,10 +103,11 @@ class BaseQuantitativeBayesianNeuralNetwork(QuantitativeModel, ABC):
             if categorical_features
             else None
         )
+        base_model_cold_start_kwargs = dict(base_model_cold_start_kwargs or {})
         bnn = BayesianNeuralNetwork.cold_start(
             n_features=dimension + n_features,
             categorical_features=bnn_categorical,
-            **(base_model_cold_start_kwargs or {}),
+            **base_model_cold_start_kwargs,
         )
 
         return cls(

--- a/pybandits/quantitative_model/zooming.py
+++ b/pybandits/quantitative_model/zooming.py
@@ -28,8 +28,8 @@ from typing import Any, ClassVar, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 from pydantic import (
+    Field,
     PositiveInt,
-    PrivateAttr,
     field_serializer,
     field_validator,
     validate_call,
@@ -45,7 +45,7 @@ from pybandits.base import (
     PyBanditsBaseModel,
     QuantitativeProbability,
 )
-from pybandits.model import Beta, Model
+from pybandits.model import Beta
 from pybandits.quantitative_model.base import QuantitativeModel, QuantitativeModelCC, QuantitativeModelDP
 
 
@@ -215,6 +215,9 @@ class BaseZooming(QuantitativeModel, ABC):
         Maximum number of segments.
     sub_actions: Dict[Tuple[Tuple[Float01, Float01], ...], Optional[Beta]]
         Mapping of segments to Beta models.
+    base_model: Beta
+        Template Beta model copied for every new segment. Carries the per-segment configuration
+        (e.g. ``decay_factor``); built from ``base_model_cold_start_kwargs`` at cold start.
     """
 
     dimension: PositiveInt
@@ -223,7 +226,7 @@ class BaseZooming(QuantitativeModel, ABC):
     n_comparison_points: PositiveInt = 1000
     n_max_segments: Optional[PositiveInt] = 32
     sub_actions: Dict[Tuple[Tuple[Float01, Float01], ...], Optional[Beta]]
-    _base_model: Model = PrivateAttr()
+    base_model: Beta = Field(default_factory=Beta)
     _n_initial_segments: ClassVar = 4
     _transfer_learned_keys: ClassVar[Tuple[str, ...]] = ("sub_actions",)
 
@@ -266,24 +269,17 @@ class BaseZooming(QuantitativeModel, ABC):
 
     def model_post_init(self, __context: Any) -> None:
         self._validate_segments()
-        self._init_base_model()
         segment_models_types = set(type(model) if model is not None else None for model in self.sub_actions.values())
         if None in segment_models_types:
             if len(segment_models_types) > 1:
                 raise ValueError("All segments must either have a model or miss a model.")
             self.sub_actions = dict(
-                zip(self.sub_actions, [self._base_model.model_copy(deep=True) for _ in range(len(self.sub_actions))])
+                zip(self.sub_actions, [self.base_model.model_copy(deep=True) for _ in range(len(self.sub_actions))])
             )
 
     @property
     def segmented_actions(self) -> Dict[Segment, Optional[Beta]]:
         return {Segment(intervals=segment): model for segment, model in self.sub_actions.items()}
-
-    def _init_base_model(self):
-        """
-        Initialize the base model.
-        """
-        self._base_model = Beta()
 
     @classmethod
     @validate_call
@@ -293,10 +289,16 @@ class BaseZooming(QuantitativeModel, ABC):
         comparison_threshold: Float01 = 0.1,
         n_comparison_points: PositiveInt = 1000,
         n_max_segments: Optional[PositiveInt] = 32,
+        base_model_cold_start_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> Self:
         """
         Create a cold start model.
+
+        Parameters
+        ----------
+        base_model_cold_start_kwargs : Optional[Dict[str, Any]]
+            Keyword arguments forwarded to the per-segment Beta model (e.g. ``decay_factor``).
 
         Returns
         -------
@@ -310,6 +312,7 @@ class BaseZooming(QuantitativeModel, ABC):
             n_comparison_points=n_comparison_points,
             n_max_segments=n_max_segments,
             sub_actions=sub_actions,
+            base_model=Beta(**(base_model_cold_start_kwargs or {})),
             **kwargs,
         )
 
@@ -505,7 +508,7 @@ class BaseZooming(QuantitativeModel, ABC):
                     nuisance_segments.remove(segment)
                     nuisance_segments.remove(other_segment)
                     merged_segment = segment + other_segment
-                    self.sub_actions[merged_segment.intervals] = self._base_model.model_copy(deep=True)
+                    self.sub_actions[merged_segment.intervals] = self.base_model.model_copy(deep=True)
                     filtered_quantities, filtered_rewards = self._filter_by_segment(
                         [segment, other_segment], quantities, segments, rewards
                     )
@@ -542,8 +545,8 @@ class BaseZooming(QuantitativeModel, ABC):
             best_segment = interest_segments[i]
             del self.sub_actions[best_segment.intervals]
             sub_best_segments = best_segment.split()
-            self.sub_actions[sub_best_segments[0].intervals] = self._base_model.model_copy(deep=True)
-            self.sub_actions[sub_best_segments[1].intervals] = self._base_model.model_copy(deep=True)
+            self.sub_actions[sub_best_segments[0].intervals] = self.base_model.model_copy(deep=True)
+            self.sub_actions[sub_best_segments[1].intervals] = self.base_model.model_copy(deep=True)
             filtered_quantities, filtered_rewards = self._filter_by_segment(best_segment, quantities, segments, rewards)
             self._map_and_update_segment_models(filtered_quantities, filtered_rewards)
             i += 1
@@ -615,7 +618,7 @@ class BaseZooming(QuantitativeModel, ABC):
         self.sub_actions = dict(
             zip(
                 self._generate_initial_segments(self.dimension),
-                [self._base_model.model_copy(deep=True) for _ in range(self._n_initial_segments**self.dimension)],
+                [self.base_model.model_copy(deep=True) for _ in range(self._n_initial_segments**self.dimension)],
             )
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybandits"
-version = "7.3.0"
+version = "7.4.0"
 description = "Python Multi-Armed Bandit Library"
 authors = [
     "Dario d'Andrea <dariod@playtika.com>",

--- a/tests/test_cmab.py
+++ b/tests/test_cmab.py
@@ -171,6 +171,7 @@ class ModelTestConfig:
         hidden_dim_list: List[int],
         update_method: UpdateMethods,
         n_objectives: Optional[PositiveInt] = None,
+        decay_factor: Optional[Float01] = None,
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         model_types = list(self.model_types)
         if len(model_types) < len(action_ids):
@@ -202,6 +203,8 @@ class ModelTestConfig:
             value_field = None
 
         model_cold_start_kwargs = dict(update_method=update_method)
+        if decay_factor is not None:
+            model_cold_start_kwargs["decay_factor"] = decay_factor
         base_model_cold_start_kwargs = dict(hidden_dim_list=hidden_dim_list, **model_cold_start_kwargs)
 
         result: Dict[str, Any] = {}
@@ -272,6 +275,7 @@ class ModelTestConfig:
         n_features: PositiveInt,
         hidden_dim_list: List[int],
         update_method: UpdateMethods,
+        decay_factor: Optional[Float01] = None,
     ) -> Tuple[BaseCmabBernoulli, Dict[ActionId, CmabModelType], Dict[str, Any]]:
         n_objectives = (
             n_objectives.draw(st.integers(min_value=1, max_value=10))
@@ -279,7 +283,7 @@ class ModelTestConfig:
             else None
         )
         actions, base_model_cold_start_kwargs = self._create_actions(
-            action_ids, values, n_features, hidden_dim_list, update_method, n_objectives
+            action_ids, values, n_features, hidden_dim_list, update_method, n_objectives, decay_factor
         )
         default_action = action_ids[0] if epsilon and not delta else None
         if default_action and isinstance(actions[default_action], QuantitativeModel):
@@ -365,6 +369,7 @@ TEST_CONFIGS = {
     subsidy_factor=st.data(),
     exploit_p=st.data(),
     update_method=st.sampled_from(literal_update_methods),
+    decay_factor=st.one_of(st.none(), st.floats(min_value=1e-3, max_value=1)),
 )
 def test_cold_start(
     config: ModelTestConfig,
@@ -378,6 +383,7 @@ def test_cold_start(
     exploit_p,
     subsidy_factor,
     update_method,
+    decay_factor: Optional[float],
 ):
     # Create CMAB instance
     cmab, actions, kwargs = config.create_cmab_and_actions(
@@ -391,6 +397,7 @@ def test_cold_start(
         n_features,
         hidden_dim_list,
         update_method,
+        decay_factor,
     )
 
     # Cold start comparison logic (modified for different model types)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Literal, Optional, get_args
+from typing import List, Literal, Optional, Tuple, get_args
 from unittest.mock import patch
 
 import jax
@@ -132,6 +132,221 @@ def test_beta_sample_proba(rng, n_samples=100):
     prob = b.sample_proba(n_samples=n_samples, rng=rng)
     assert len(prob) == n_samples
     assert all([p >= 0 and p <= 1 for p in prob])
+
+
+# Beta / BNN decay factor (temperature scaling)
+
+
+class TestBetaDecayFactor:
+    """Per-update forgetting (decay_factor) on the Beta model: raw counts stay pristine, sampling uses
+    the separate effective counts decayed towards the Beta(1, 1) prior."""
+
+    MIN_DECAY_FACTOR = 1e-3
+    MAX_DECAY_FACTOR = 1.0
+    NO_DECAY_FACTOR = 1.0
+    PRIOR = 1.0
+    MAX_COUNT = 1000
+    MAX_EMPTY_UPDATES = 30
+    N_SAMPLES = 50
+
+    counts = st.integers(min_value=1, max_value=MAX_COUNT)
+    diverging_counts = st.integers(min_value=2, max_value=MAX_COUNT)  # > prior, so decayed != raw
+    binary_rewards = st.lists(st.integers(min_value=0, max_value=1), min_size=1)
+    decay_factors = st.floats(min_value=MIN_DECAY_FACTOR, max_value=MAX_DECAY_FACTOR)
+    forgetting_decay_factors = st.floats(min_value=MIN_DECAY_FACTOR, max_value=MAX_DECAY_FACTOR, exclude_max=True)
+
+    @given(
+        decay_factor=st.one_of(st.none(), decay_factors),
+        n_successes=counts,
+        n_failures=counts,
+    )
+    def test_seeds_effective_counts_only_when_enabled(
+        self, decay_factor: Optional[float], n_successes: int, n_failures: int
+    ) -> None:
+        """Effective counts are seeded from the raw counts only when decay is enabled."""
+        b = Beta(n_successes=n_successes, n_failures=n_failures, decay_factor=decay_factor)
+        if decay_factor is None:
+            assert b.decayed_n_successes is None and b.decayed_n_failures is None
+        else:
+            assert b.decayed_n_successes == n_successes and b.decayed_n_failures == n_failures
+
+    @given(
+        rewards=binary_rewards,
+        decay_factor=decay_factors,
+        n_successes=counts,
+        n_failures=counts,
+        prior=st.just(PRIOR),
+    )
+    def test_update_keeps_raw_counts_and_decays_effective_counts(
+        self, rewards: List[int], decay_factor: float, n_successes: int, n_failures: int, prior: float
+    ) -> None:
+        """Update accumulates raw counts unchanged and decays the effective counts towards the prior."""
+        b = Beta(n_successes=n_successes, n_failures=n_failures, decay_factor=decay_factor)
+        b.update(rewards=rewards)
+        new_successes = sum(rewards)
+        new_failures = len(rewards) - new_successes
+        assert b.n_successes == n_successes + new_successes
+        assert b.n_failures == n_failures + new_failures
+        assert b.decayed_n_successes == pytest.approx(prior + decay_factor * (n_successes - prior) + new_successes)
+        assert b.decayed_n_failures == pytest.approx(prior + decay_factor * (n_failures - prior) + new_failures)
+
+    @given(rewards=binary_rewards, decay_factor=st.just(NO_DECAY_FACTOR), n_successes=counts, n_failures=counts)
+    def test_factor_one_tracks_raw_counts(
+        self, rewards: List[int], decay_factor: float, n_successes: int, n_failures: int
+    ) -> None:
+        """With decay_factor == 1 the effective counts equal the raw counts (no forgetting)."""
+        b = Beta(n_successes=n_successes, n_failures=n_failures, decay_factor=decay_factor)
+        b.update(rewards=rewards)
+        assert b.decayed_n_successes == b.n_successes
+        assert b.decayed_n_failures == b.n_failures
+
+    @given(
+        rewards=binary_rewards,
+        decay_factor=forgetting_decay_factors,
+        n_successes=diverging_counts,
+        n_failures=diverging_counts,
+        n_samples=st.just(N_SAMPLES),
+    )
+    def test_sampling_uses_effective_counts(
+        self, rng, rewards: List[int], decay_factor: float, n_successes: int, n_failures: int, n_samples: int
+    ) -> None:
+        """Sampling draws from the effective counts, not the raw counts, when decay is enabled."""
+        b = Beta(n_successes=n_successes, n_failures=n_failures, decay_factor=decay_factor)
+        b.update(rewards=rewards)  # effective counts diverge from raw counts
+        state = rng.bit_generator.state
+        samples = b.sample_proba(n_samples=n_samples, rng=rng)
+        rng.bit_generator.state = state
+        from_effective = list(rng.beta(b.decayed_n_successes, b.decayed_n_failures, size=n_samples))
+        rng.bit_generator.state = state
+        from_raw = list(rng.beta(b.n_successes, b.n_failures, size=n_samples))
+        assert samples == from_effective
+        assert samples != from_raw
+
+    @given(
+        decay_factor=decay_factors,
+        count=counts,
+        n_updates=st.integers(min_value=1, max_value=MAX_EMPTY_UPDATES),
+        prior=st.just(PRIOR),
+    )
+    def test_empty_updates_decay_effective_counts_geometrically(
+        self, decay_factor: float, count: int, n_updates: int, prior: float
+    ) -> None:
+        """With no new data, the effective counts decay geometrically: prior + decay**k * (count - prior)."""
+        b = Beta(n_successes=count, n_failures=count, decay_factor=decay_factor)
+        for _ in range(n_updates):
+            b.update(rewards=[])
+        expected = prior + decay_factor**n_updates * (count - prior)
+        assert b.decayed_n_successes == pytest.approx(expected)
+        assert b.decayed_n_failures == pytest.approx(expected)
+
+    @given(
+        rewards=binary_rewards,
+        decay_factor=decay_factors,
+        n_successes=counts,
+        n_failures=counts,
+        prior=st.just(PRIOR),
+    )
+    def test_reset_restores_prior_effective_counts(
+        self, rewards: List[int], decay_factor: float, n_successes: int, n_failures: int, prior: float
+    ) -> None:
+        """Resetting the model restores both the raw and effective counts to the prior."""
+        b = Beta(n_successes=n_successes, n_failures=n_failures, decay_factor=decay_factor)
+        b.update(rewards=rewards)
+        b.reset()
+        assert (b.n_successes, b.n_failures) == (int(prior), int(prior))
+        assert (b.decayed_n_successes, b.decayed_n_failures) == (prior, prior)
+
+    @given(rewards=binary_rewards, decay_factor=decay_factors, n_successes=counts, n_failures=counts)
+    def test_serialization_roundtrip(
+        self, rewards: List[int], decay_factor: float, n_successes: int, n_failures: int
+    ) -> None:
+        """get_state/from_state preserves the decay factor and the (non-recomputable) effective counts."""
+        b = Beta(n_successes=n_successes, n_failures=n_failures, decay_factor=decay_factor)
+        b.update(rewards=rewards)
+        assert Beta.model_validate_json(b.model_dump_json()) == b
+
+    @given(n_successes=counts, n_failures=counts)
+    def test_state_without_decay_fields_loads_with_decay_disabled(self, n_successes: int, n_failures: int) -> None:
+        """A serialized state predating the decay feature loads with decay disabled."""
+        b = Beta.model_validate({"n_successes": n_successes, "n_failures": n_failures})
+        assert b.decay_factor is None
+        assert b.decayed_n_successes is None and b.decayed_n_failures is None
+
+    @given(
+        decay_factor=st.one_of(
+            st.floats(max_value=0), st.floats(min_value=MAX_DECAY_FACTOR, exclude_min=True), st.just(float("nan"))
+        )
+    )
+    def test_factor_out_of_range_raises(self, decay_factor: float) -> None:
+        """decay_factor must lie in (0, 1]."""
+        with pytest.raises(ValidationError):
+            Beta(decay_factor=decay_factor)
+
+
+class TestBnnDecayFactor:
+    """Per-update prior-variance inflation (decay_factor) on the BayesianNeuralNetwork: weight, bias, and
+    embedding sigmas are scaled by 1 / decay_factor before each re-fit, while means stay untouched.
+
+    These build a network per case, so they stay plain (no @given) with a single representative factor."""
+
+    DECAY_FACTOR = 0.5
+    N_FEATURES = 2
+    HIDDEN = (3,)
+    CAT_COLUMN = 0
+    CARDINALITY = 4
+
+    def test_inflates_weight_and_bias_variance(
+        self,
+        decay_factor: float = DECAY_FACTOR,
+        n_features: int = N_FEATURES,
+        hidden_dim_list: Tuple[int, ...] = HIDDEN,
+    ) -> None:
+        """Weight/bias sigma are scaled by 1 / decay_factor while the means (mu) are left unchanged."""
+        bnn = BayesianNeuralNetwork.cold_start(
+            n_features=n_features, hidden_dim_list=list(hidden_dim_list), decay_factor=decay_factor
+        )
+        before = [
+            (np.array(lp.weight.params["sigma"]), np.array(lp.bias.params["sigma"]), np.array(lp.weight.params["mu"]))
+            for lp in bnn.model_params.bnn_layer_params
+        ]
+        bnn._inflate_prior_variance()
+        for (w_sigma, b_sigma, w_mu), lp in zip(before, bnn.model_params.bnn_layer_params):
+            assert np.allclose(np.array(lp.weight.params["sigma"]), w_sigma / decay_factor)
+            assert np.allclose(np.array(lp.bias.params["sigma"]), b_sigma / decay_factor)
+            assert np.allclose(np.array(lp.weight.params["mu"]), w_mu)
+
+    def test_disabled_leaves_variance_unchanged(
+        self,
+        make_bnn,
+        n_features: int = N_FEATURES,
+        hidden_dim_list: Tuple[int, ...] = HIDDEN,
+    ) -> None:
+        """With decay disabled, _inflate_prior_variance is a no-op."""
+        bnn = make_bnn(n_features=n_features, hidden_dim_list=list(hidden_dim_list))
+        before = [np.array(lp.weight.params["sigma"]) for lp in bnn.model_params.bnn_layer_params]
+        bnn._inflate_prior_variance()
+        for w_sigma, lp in zip(before, bnn.model_params.bnn_layer_params):
+            assert np.allclose(np.array(lp.weight.params["sigma"]), w_sigma)
+
+    def test_inflates_embedding_variance(
+        self,
+        decay_factor: float = DECAY_FACTOR,
+        n_features: int = N_FEATURES,
+        hidden_dim_list: Tuple[int, ...] = HIDDEN,
+        cat_column: int = CAT_COLUMN,
+        cardinality: int = CARDINALITY,
+    ) -> None:
+        """Categorical-embedding sigma is scaled by 1 / decay_factor."""
+        bnn = BayesianNeuralNetwork.cold_start(
+            n_features=n_features,
+            hidden_dim_list=list(hidden_dim_list),
+            categorical_features={cat_column: cardinality},
+            decay_factor=decay_factor,
+        )
+        before = [np.array(emb.params["sigma"]) for emb in bnn.model_params.embedding_params.embeddings]
+        bnn._inflate_prior_variance()
+        for emb_sigma, emb in zip(before, bnn.model_params.embedding_params.embeddings):
+            assert np.allclose(np.array(emb.params["sigma"]), emb_sigma / decay_factor)
 
 
 ########################################################################################################################

--- a/tests/test_smab.py
+++ b/tests/test_smab.py
@@ -88,12 +88,19 @@ class ModelTestConfig:
     model_types: List[Type[SmabModelType]]
 
     def _create_actions(
-        self, action_ids: List[str], values: Optional[st.SearchStrategy], n_objectives: Optional[PositiveInt]
-    ) -> Dict[str, Any]:
+        self,
+        action_ids: List[str],
+        values: Optional[st.SearchStrategy],
+        n_objectives: Optional[PositiveInt],
+        decay_factor: Optional[Float01] = None,
+    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         model_types = list(self.model_types)
         if len(model_types) < len(action_ids):
             indices = np.random.randint(0, len(model_types), len(action_ids))
             model_types = [model_types[i] for i in indices]
+        base_model_cold_start_kwargs: Dict[str, Any] = {}
+        if decay_factor is not None:
+            base_model_cold_start_kwargs["decay_factor"] = decay_factor
         if all(model in [BetaCC, ZoomingCC, BetaMOCC] for model in model_types):
             # Generate random costs
             drawn_values = values.draw(value_strategy(n_actions=len(action_ids)))
@@ -117,29 +124,35 @@ class ModelTestConfig:
         if n_objectives is None:
             if costs is not None:
                 return {
-                    action_id: model_type(**{value_field: cost})
+                    action_id: model_type(decay_factor=decay_factor, **{value_field: cost})
                     if issubclass(model_type, (BetaCC, BetaDP))
-                    else model_type.cold_start(dimension=1, **{value_field: cost})  # ZoomingCC / ZoomingDP
+                    else model_type.cold_start(
+                        dimension=1, base_model_cold_start_kwargs=base_model_cold_start_kwargs, **{value_field: cost}
+                    )  # ZoomingCC / ZoomingDP
                     for action_id, model_type, cost in zip(action_ids, model_types, costs)
-                }
+                }, base_model_cold_start_kwargs
             else:
                 return {
-                    action_id: model_type()
+                    action_id: model_type(decay_factor=decay_factor)
                     if issubclass(model_type, Beta)
-                    else model_type.cold_start(dimension=1)  # Zooming
+                    else model_type.cold_start(
+                        dimension=1, base_model_cold_start_kwargs=base_model_cold_start_kwargs
+                    )  # Zooming
                     for action_id, model_type in zip(action_ids, model_types)
-                }
+                }, base_model_cold_start_kwargs
         else:
             if costs is not None:
                 return {
-                    action_id: model_type(models=[Beta()] * n_objectives, cost=cost)
+                    action_id: model_type(
+                        models=[Beta(decay_factor=decay_factor) for _ in range(n_objectives)], cost=cost
+                    )
                     for action_id, model_type, cost in zip(action_ids, model_types, costs)
-                }
+                }, base_model_cold_start_kwargs
             else:
                 return {
-                    action_id: model_type(models=[Beta()] * n_objectives)
+                    action_id: model_type(models=[Beta(decay_factor=decay_factor) for _ in range(n_objectives)])
                     for action_id, model_type in zip(action_ids, model_types)
-                }
+                }, base_model_cold_start_kwargs
 
     def create_smab_and_actions(
         self,
@@ -150,13 +163,14 @@ class ModelTestConfig:
         n_objectives: st.SearchStrategy[PositiveInt],
         exploit_p: Union[st.SearchStrategy[Optional[Float01]], Optional[float]],
         subsidy_factor: Union[st.SearchStrategy[Optional[Float01]], Optional[float]],
+        decay_factor: Optional[Float01] = None,
     ) -> Tuple[BaseSmabBernoulli, Dict[ActionId, SmabModelType], Dict[str, Any]]:
         n_objectives = (
             n_objectives.draw(st.integers(min_value=1, max_value=10))
             if self.smab_class in [SmabBernoulliMO, SmabBernoulliMOCC]
             else None
         )
-        actions = self._create_actions(action_ids, values, n_objectives)
+        actions, base_model_cold_start_kwargs = self._create_actions(action_ids, values, n_objectives, decay_factor)
         default_action = action_ids[0] if epsilon and not delta else None
         if default_action and isinstance(actions[default_action], QuantitativeModel):
             default_action = (default_action, tuple(np.random.random(actions[default_action].dimension)))
@@ -183,6 +197,10 @@ class ModelTestConfig:
         # For cold start test
         if self.smab_class in [SmabBernoulliMO, SmabBernoulliMOCC]:
             kwargs["n_objectives"] = n_objectives
+        if any(isinstance(model, QuantitativeModel) for model in actions.values()):
+            kwargs["base_model_cold_start_kwargs"] = base_model_cold_start_kwargs
+        if decay_factor is not None:
+            kwargs["decay_factor"] = decay_factor
         return smab, actions, kwargs
 
 
@@ -221,6 +239,7 @@ TEST_CONFIGS = {
     n_objectives=st.data(),
     subsidy_factor=st.data(),
     exploit_p=st.data(),
+    decay_factor=st.one_of(st.none(), st.floats(min_value=1e-3, max_value=1)),
 )
 def test_cold_start(
     config: ModelTestConfig,
@@ -231,10 +250,11 @@ def test_cold_start(
     n_objectives,
     exploit_p,
     subsidy_factor,
+    decay_factor: Optional[float],
 ):
     # Create SMAB instance
     smab, actions, kwargs = config.create_smab_and_actions(
-        action_ids, epsilon, delta, values, n_objectives, exploit_p, subsidy_factor
+        action_ids, epsilon, delta, values, n_objectives, exploit_p, subsidy_factor, decay_factor
     )
 
     # Cold start comparison logic (modified for different model types)


### PR DESCRIPTION
### Changes:

* Add decay_factor field to Model in pybandits/model/base.py — per-update forgetting factor in (0, 1]; a leaf-model attribute (Beta, BayesianNeuralNetwork), absent on quantitative wrappers
* Add _prior_pseudo_count ClassVar to BaseModelSO in pybandits/base_model.py — Beta(1, 1) anchor reused for n_successes/n_failures defaults and reset()
* Add decay logic to BaseBeta in pybandits/model/beta.py — decayed_n_successes/decayed_n_failures effective counts seeded by _init_decayed_counts validator; _update() discounts toward the prior (n <- 1 + decay_factor*(n-1) + new); sample_proba() draws from the effective counts when decay is enabled
  - register decayed counts in _transfer_learned_keys so they transfer alongside the raw counts
* Add decay_factor param to BaseBetaMO.cold_start() — forwarded to each per-objective Beta
* Add _inflate_prior_variance() to BaseBayesianNeuralNetwork in pybandits/model/bnn/network.py — scales weight/bias/embedding sigma by 1/decay_factor before each re-fit so fresh data dominates; leaves means (mu) and Student-t nu untouched
  - add decay_factor param to BaseBayesianNeuralNetwork.cold_start() and BaseBayesianNeuralNetworkMO.cold_start()
* Refactor BaseZooming in pybandits/quantitative_model/zooming.py — replace private _base_model/_init_base_model with a serialized base_model: Beta field built from base_model_cold_start_kwargs
* Update BaseQuantitativeBayesianNeuralNetwork.cold_start() in pybandits/quantitative_model/bnn.py — forward decay via base_model_cold_start_kwargs and default it to None
* Update QuantitativeModel docstring in pybandits/quantitative_model/base.py — document the shared base_model_cold_start_kwargs contract
* Update BaseMab.cold_start() docstring in pybandits/mab.py — note decay_factor is a forwardable action-model kwarg
* Add TestBetaDecayFactor to tests/test_model.py — seeding, raw counts stay pristine, decay toward prior, factor==1 tracks raw, sampling from effective counts, geometric decay on empty updates, reset, serialization round-trip, pre-decay state loads disabled, out-of-range rejection
* Add TestBnnDecayFactor to tests/test_model.py — weight/bias/embedding sigma scaled by 1/decay_factor with means unchanged
* Update tests/test_cmab.py — route decay_factor for BNN (top-level) and QuantitativeBNN (via base_model_cold_start_kwargs)
* Update tests/test_smab.py — route Zooming decay_factor through base_model_cold_start_kwargs; thread decay_factor through the create/cold-start helpers

### Changes:
* Feature or fix description
* Tests added or updated
* Documentation updated (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `decay_factor` parameter to cold-start for supported models (including Beta-based, Bayesian neural network, and multi-objective/quantitative wrappers), enabling per-update forgetting that gradually shifts effective evidence back toward the prior.
* **Tests**
  * Expanded coverage for decay behavior, edge cases (e.g., `decay_factor=1`), reset/serialization compatibility, and invalid `decay_factor` validation.
* **Documentation / Chores**
  * Improved parameter documentation and bumped package version to 7.4.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->