### PR TITLE
Type BNN update_kwargs as validated Pydantic models

### DIFF
--- a/pybandits/model/bnn/config.py
+++ b/pybandits/model/bnn/config.py
@@ -326,8 +326,8 @@ class VIUpdateKwargs(PyBanditsBaseModel):
 
     num_steps: PositiveInt = 1000
     method: Literal["advi", "fullrank_advi"] = "advi"
-    optimizer_type: str = "sgd"
-    optimizer_kwargs: dict = Field(default_factory=lambda: {"step_size": 0.01})
+    optimizer_type: str = "adam"
+    optimizer_kwargs: dict = Field(default_factory=lambda: {"step_size": 0.0003})
     batch_size: Optional[PositiveInt] = None
     early_stopping_kwargs: Optional[dict] = None
     lr_scheduler_type: Optional[str] = None

--- a/pybandits/model/bnn/config.py
+++ b/pybandits/model/bnn/config.py
@@ -19,6 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import warnings
 from copy import deepcopy
 from typing import ClassVar, List, Literal, Optional, Union
 
@@ -34,6 +35,7 @@ from pydantic import (
 from typing_extensions import Self
 
 from pybandits.base import (
+    PositiveFloat01,
     PyBanditsBaseModel,
 )
 from pybandits.model.bnn.priors import BaseLocationScaleArray, NormalArray, StudentTArray
@@ -280,3 +282,102 @@ class EarlyStopping(PyBanditsBaseModel):
                 self._no_improvement_count = 0
         self._previous_loss = loss
         return self._no_improvement_count >= self.patience
+
+
+class VIUpdateKwargs(PyBanditsBaseModel):
+    """Validated keyword arguments for a Variational Inference (VI) BNN update.
+
+    Replaces the previously untyped ``update_kwargs`` dict for ``update_method="VI"``.
+    Constrained fields validate the values that used to be checked by hand; the nested
+    ``optimizer_kwargs``, ``lr_scheduler_kwargs`` and ``early_stopping_kwargs`` dicts are
+    intentionally left as open dicts because they are passed through verbatim to optax /
+    the EarlyStopping monitor.
+
+    Parameters
+    ----------
+    num_steps : PositiveInt
+        Total number of SVI steps. Ignored when ``epochs`` is provided. Default 1000.
+    method : Literal["advi", "fullrank_advi"]
+        Variational family / guide. Default "advi".
+    optimizer_type : str
+        Name of the optax optimizer (resolved at construction). Default "sgd".
+    optimizer_kwargs : dict
+        Keyword arguments forwarded to the optax optimizer (e.g. ``step_size``).
+    batch_size : Optional[PositiveInt]
+        Mini-batch size; ``None`` uses the full dataset. Default None.
+    early_stopping_kwargs : Optional[dict]
+        Keyword arguments forwarded to ``EarlyStopping``; ``None`` disables it. Default None.
+    lr_scheduler_type : Optional[str]
+        Name of the optax learning-rate schedule, or ``None``. Default None.
+    lr_scheduler_kwargs : Optional[dict]
+        Keyword arguments forwarded to the optax schedule. Default None.
+    restore_best_svi_state : bool
+        Whether to restore the lowest-loss SVI state at the end of training. Default True.
+    num_particles : PositiveInt
+        Number of ELBO particles. Default 1.
+    gradient_clip_norm : Optional[PositiveFloat]
+        Global gradient-norm clipping threshold, or ``None`` to disable. Default None.
+    kl_annealing_fraction : Optional[PositiveFloat01]
+        Fraction of total steps over which the KL term is linearly warmed up; must lie in
+        the half-open interval (0, 1] or be ``None``. Default None.
+    epochs : Optional[PositiveInt]
+        Number of epochs; takes precedence over ``num_steps`` when provided. Default None.
+    """
+
+    num_steps: PositiveInt = 1000
+    method: Literal["advi", "fullrank_advi"] = "advi"
+    optimizer_type: str = "sgd"
+    optimizer_kwargs: dict = Field(default_factory=lambda: {"step_size": 0.01})
+    batch_size: Optional[PositiveInt] = None
+    early_stopping_kwargs: Optional[dict] = None
+    lr_scheduler_type: Optional[str] = None
+    lr_scheduler_kwargs: Optional[dict] = None
+    restore_best_svi_state: bool = True
+    num_particles: PositiveInt = 1
+    gradient_clip_norm: Optional[PositiveFloat] = None
+    kl_annealing_fraction: Optional[PositiveFloat01] = None
+    epochs: Optional[PositiveInt] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _warn_epochs_and_num_steps(cls, data):
+        # Warn only when the user genuinely supplied both — epochs takes precedence over num_steps.
+        # Inspecting the raw input (rather than model_fields_set) avoids a spurious warning on
+        # round-trip, where model_dump() re-emits epochs=None alongside num_steps as explicit keys.
+        if isinstance(data, dict) and data.get("epochs") is not None and "num_steps" in data:
+            warnings.warn(
+                "Both 'epochs' and 'num_steps' specified in update_kwargs. "
+                "'epochs' takes precedence and 'num_steps' will be ignored.",
+                UserWarning,
+                stacklevel=2,
+            )
+        return data
+
+
+class MCMCUpdateKwargs(PyBanditsBaseModel):
+    """Validated keyword arguments for an MCMC (NUTS) BNN update.
+
+    Replaces the previously untyped ``update_kwargs`` dict for ``update_method="MCMC"``.
+    ``extra="forbid"`` (inherited from ``PyBanditsBaseModel``) rejects unknown keys, which
+    is what enforces that VI-only parameters cannot be passed under MCMC. The nested
+    ``nuts`` dict is forwarded verbatim to ``numpyro.infer.NUTS``.
+
+    Parameters
+    ----------
+    num_warmup : NonNegativeInt
+        Number of warmup (burn-in) steps. Default 500.
+    num_samples : PositiveInt
+        Number of posterior samples to draw. Default 1000.
+    num_chains : PositiveInt
+        Number of MCMC chains. Default 2.
+    progress_bar : bool
+        Whether to display the sampling progress bar. Default False.
+    nuts : dict
+        Keyword arguments forwarded to ``numpyro.infer.NUTS`` (e.g. ``target_accept_prob``).
+    """
+
+    num_warmup: NonNegativeInt = 500
+    num_samples: PositiveInt = 1000
+    num_chains: PositiveInt = 2
+    progress_bar: bool = False
+    nuts: dict = Field(default_factory=lambda: {"target_accept_prob": 0.95})

--- a/pybandits/model/bnn/network.py
+++ b/pybandits/model/bnn/network.py
@@ -510,7 +510,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
 
     @model_validator(mode="before")
     @classmethod
-    def _coerce_update_kwargs(cls, data):
+    def _coerce_update_kwargs(cls, data: Dict[str, Any]) -> Dict[str, Any]:
         """Coerce ``update_kwargs`` into the typed model matching ``update_method``.
 
         Accepts a raw dict (the public API, and the form stored in serialized state), ``None``
@@ -521,9 +521,16 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         if not isinstance(data, dict):
             return data
         raw = data.get("update_kwargs")
-        if isinstance(raw, (VIUpdateKwargs, MCMCUpdateKwargs)):
-            return data
         update_method = data.get("update_method", cls.model_fields["update_method"].default)
+        if isinstance(raw, (VIUpdateKwargs, MCMCUpdateKwargs)):
+            expected = {"VI": VIUpdateKwargs, "MCMC": MCMCUpdateKwargs}.get(update_method)
+            if expected is None:
+                raise ValueError("Invalid update method.")
+            if not isinstance(raw, expected):
+                raise ValueError(
+                    f"update_kwargs type {type(raw).__name__} conflicts with update_method '{update_method}'."
+                )
+            return data
         raw = dict(raw) if raw else {}
         # Copy before mutating: during Union resolution pydantic feeds the same input dict to each
         # candidate member, so mutating it here would leak an injected update_kwargs into sibling

--- a/pybandits/model/bnn/network.py
+++ b/pybandits/model/bnn/network.py
@@ -20,8 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import inspect
-import numbers
-import warnings
 from abc import ABC
 from contextlib import nullcontext
 from copy import deepcopy
@@ -77,6 +75,8 @@ from pybandits.model.bnn.config import (
     EarlyStopping,
     EmbeddingParams,
     FeaturesConfig,
+    MCMCUpdateKwargs,
+    VIUpdateKwargs,
 )
 from pybandits.model.bnn.priors import BaseLocationScaleArray, NormalArray, StudentTArray
 
@@ -105,11 +105,14 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         The parameters of the Bayesian Neural Network, including weights and biases for each layer and their initial values for resetting
     update_method : str, optional
         The method used for posterior inference, either "MCMC" or "VI" (default is "MCMC").
-    update_kwargs : Optional[dict], optional
-        A dictionary of keyword arguments for the update method. For MCMC, it contains 'trace' settings.
-        For VI, it contains 'fit' settings and additional parameters like 'epochs', 'optimizer_type',
-        'optimizer_kwargs', 'batch_size', and 'early_stopping_kwargs'. The 'epochs' parameter specifies
-        the number of iterations for VI (maps to 'step_size' in numpyro's API).
+    update_kwargs : Optional[Union[VIUpdateKwargs, MCMCUpdateKwargs, dict]], optional
+        Keyword arguments for the update method. May be passed as a plain dict (validated and
+        coerced at construction) or as the matching typed model. When ``update_method="VI"`` it is
+        coerced to :class:`VIUpdateKwargs` (``num_steps``/``epochs``, ``method``, ``optimizer_type``,
+        ``optimizer_kwargs``, ``batch_size``, ``early_stopping_kwargs``, ``num_particles``,
+        ``gradient_clip_norm``, ``kl_annealing_fraction``, ...); when ``"MCMC"`` it is coerced to
+        :class:`MCMCUpdateKwargs` (``num_warmup``, ``num_samples``, ``num_chains``, ``progress_bar``,
+        ``nuts``). ``None`` uses the per-method defaults.
     activation : str, optional
         The activation function to use for hidden layers. Supported values are: "tanh", "relu", "sigmoid", "gelu" (default is "tanh").
     use_residual_connections : bool, optional
@@ -152,21 +155,6 @@ class BaseBayesianNeuralNetwork(Model, ABC):
     weight_var_name: ClassVar[str] = "weight"
     bias_var_name: ClassVar[str] = "bias"
     _embedding_var_name: ClassVar[str] = "embedding"
-    _vi_update_params: ClassVar[list] = [
-        "num_steps",
-        "method",
-        "optimizer_type",
-        "optimizer_kwargs",
-        "batch_size",
-        "early_stopping_kwargs",
-        "epochs",
-        "lr_scheduler_type",
-        "lr_scheduler_kwargs",
-        "restore_best_svi_state",
-        "num_particles",
-        "gradient_clip_norm",
-        "kl_annealing_fraction",
-    ]
     _distribution_mapping: ClassVar[Dict[str, type]] = {"normal": NormalArray, "studentt": StudentTArray}
     _embedding_dim_divisor: ClassVar[int] = 4
     _numerical_eps: ClassVar[float] = 1e-6
@@ -241,7 +229,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
     }
 
     update_method: UpdateMethods = "VI"
-    update_kwargs: Optional[dict] = None
+    update_kwargs: Optional[Union[VIUpdateKwargs, MCMCUpdateKwargs]] = None
     activation: ActivationFunctions = "tanh"
     use_residual_connections: bool = False
     feature_config: FeaturesConfig
@@ -250,28 +238,6 @@ class BaseBayesianNeuralNetwork(Model, ABC):
     bias_calibrated: bool = False
 
     _rng_key: Any = PrivateAttr(default=None)
-
-    _default_vi_kwargs: ClassVar[dict] = dict(
-        num_steps=1000,
-        method="advi",
-        optimizer_type="sgd",
-        optimizer_kwargs={"step_size": 0.01},
-        batch_size=None,
-        early_stopping_kwargs=None,
-        lr_scheduler_type=None,
-        lr_scheduler_kwargs=None,
-        restore_best_svi_state=True,
-        num_particles=1,
-        gradient_clip_norm=None,
-    )
-
-    _default_mcmc_kwargs: ClassVar[dict] = dict(
-        num_warmup=500,
-        num_samples=1000,
-        num_chains=2,
-        progress_bar=False,
-        nuts=dict(target_accept_prob=0.95),
-    )
 
     _vi_method_config: ClassVar[dict] = {
         "advi": {
@@ -359,11 +325,11 @@ class BaseBayesianNeuralNetwork(Model, ABC):
 
         Optionally chains a learning-rate schedule and/or gradient clipping.
         """
-        optimizer_type = self.update_kwargs["optimizer_type"]
-        optimizer_kwargs = dict(self.update_kwargs.get("optimizer_kwargs", {}))
-        lr_scheduler_type = self.update_kwargs.get("lr_scheduler_type")
-        lr_scheduler_kwargs = self.update_kwargs.get("lr_scheduler_kwargs") or {}
-        gradient_clip_norm = self.update_kwargs.get("gradient_clip_norm")
+        optimizer_type = self.update_kwargs.optimizer_type
+        optimizer_kwargs = dict(self.update_kwargs.optimizer_kwargs or {})
+        lr_scheduler_type = self.update_kwargs.lr_scheduler_type
+        lr_scheduler_kwargs = self.update_kwargs.lr_scheduler_kwargs or {}
+        gradient_clip_norm = self.update_kwargs.gradient_clip_norm
 
         optimizer_fn = self._resolve_optax_fn(optimizer_type, "optimizer")
 
@@ -386,7 +352,7 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         return noptim.optax_to_numpyro(base_optimizer)
 
     def _get_early_stopping_callback(self) -> Optional[EarlyStopping]:
-        early_stopping_kwargs = self.update_kwargs.get("early_stopping_kwargs", None)
+        early_stopping_kwargs = self.update_kwargs.early_stopping_kwargs
         if early_stopping_kwargs is not None:
             try:
                 return EarlyStopping(**early_stopping_kwargs)
@@ -542,54 +508,34 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         """
         return [layer.weight.shape[1] for layer in self.model_params.bnn_layer_params[:-1]]
 
-    def _arrange_update_kwargs(self):
-        if self.update_kwargs is None:
-            self.update_kwargs = dict()
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_update_kwargs(cls, data):
+        """Coerce ``update_kwargs`` into the typed model matching ``update_method``.
 
-        if self.update_method == "VI":
-            # Warn if both epochs and num_steps are given — epochs takes precedence
-            if "epochs" in self.update_kwargs and "num_steps" in self.update_kwargs:
-                warnings.warn(
-                    "Both 'epochs' and 'num_steps' specified in update_kwargs. "
-                    "'epochs' takes precedence and 'num_steps' will be ignored.",
-                    UserWarning,
-                    stacklevel=2,
-                )
-
-            self.update_kwargs = {**self._default_vi_kwargs, **self.update_kwargs}
-
-            # Validate VI method
-            vi_method = self.update_kwargs.get("method")
-            if vi_method not in self._vi_method_config:
-                raise ValueError(
-                    f"Invalid VI method: {vi_method}. Supported methods are: {list(self._vi_method_config.keys())}"
-                )
-
-            # Validate optional KL annealing fraction. Domain is (0, 1];
-            kl_annealing_fraction = self.update_kwargs.get("kl_annealing_fraction")
-            if kl_annealing_fraction is not None:
-                # numbers.Real accepts NumPy real scalars (np.float32, np.int64, ...), which an
-                # untyped update_kwargs dict passes through uncoerced. bool is excluded explicitly
-                # because Python bool is itself a numbers.Real (np.bool_ is not, so it falls through).
-                if isinstance(kl_annealing_fraction, bool) or not isinstance(kl_annealing_fraction, numbers.Real):
-                    raise ValueError(
-                        f"Invalid kl_annealing_fraction: {kl_annealing_fraction!r}. Must be a float in (0, 1] or None."
-                    )
-                if not (0.0 < float(kl_annealing_fraction) <= 1.0):
-                    raise ValueError(
-                        f"Invalid kl_annealing_fraction: {kl_annealing_fraction}. Must lie in the half-open interval (0, 1]."
-                    )
-
-        elif self.update_method == "MCMC":
-            for param in self._vi_update_params:
-                if param in self.update_kwargs:
-                    raise ValueError(
-                        f"Invalid update MCMC parameter: {param}. {self._vi_update_params} are VI parameters."
-                    )
-
-            self.update_kwargs = {**self._default_mcmc_kwargs, **self.update_kwargs}
+        Accepts a raw dict (the public API, and the form stored in serialized state), ``None``
+        (defaults), or an already-built ``VIUpdateKwargs``/``MCMCUpdateKwargs``. ``update_method``
+        is the single source of truth for which schema applies, so the kwargs themselves carry no
+        discriminator. All value validation and defaulting lives in the two typed models.
+        """
+        if not isinstance(data, dict):
+            return data
+        raw = data.get("update_kwargs")
+        if isinstance(raw, (VIUpdateKwargs, MCMCUpdateKwargs)):
+            return data
+        update_method = data.get("update_method", cls.model_fields["update_method"].default)
+        raw = dict(raw) if raw else {}
+        # Copy before mutating: during Union resolution pydantic feeds the same input dict to each
+        # candidate member, so mutating it here would leak an injected update_kwargs into sibling
+        # models (e.g. QuantitativeBayesianNeuralNetwork, which has no such field).
+        data = {**data}
+        if update_method == "VI":
+            data["update_kwargs"] = VIUpdateKwargs(**raw)
+        elif update_method == "MCMC":
+            data["update_kwargs"] = MCMCUpdateKwargs(**raw)
         else:
             raise ValueError("Invalid update method.")
+        return data
 
     def _init_private_attrs(self) -> None:
         """Initialize private attributes that are derived from public fields.
@@ -612,9 +558,10 @@ class BaseBayesianNeuralNetwork(Model, ABC):
         """
         Initialize activation function PrivateAttr based on the activation setting.
         """
-        self._arrange_update_kwargs()
+        # Flatten the validated kwargs model into a plain dict for the internal training code,
+        # which consumes the merged-with-defaults parameters by key (e.g. ``self._update_kwargs["method"]``).
+        self._update_kwargs = self.update_kwargs.model_dump()
         self._init_private_attrs()
-        self._update_kwargs = deepcopy(self.update_kwargs)
 
     def __getstate__(self) -> dict:
         """Exclude unpicklable private attributes (JAX functions, optimizer objects)."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybandits"
-version = "7.4.1"
+version = "7.4.2"
 description = "Python Multi-Armed Bandit Library"
 authors = [
     "Dario d'Andrea <dariod@playtika.com>",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1628,12 +1628,10 @@ class TestKLAnnealing:
             )
 
     # invalid_value is the axis under test; n_features/num_steps are scaffolding, pinned via st.just.
-    # np.bool_(True) is included because np.bool_ is not a numbers.Real and must be rejected by the
-    # type guard (Python bool is a numbers.Real, hence the separate explicit bool exclusion).
-    @pytest.mark.parametrize("invalid_value", [0.0, -0.1, 1.5, "0.5", True, np.bool_(True)])
+    @pytest.mark.parametrize("invalid_value", [0.0, -0.1, 1.5])
     @given(n_features=st.just(2), num_steps=st.just(5))
     def test_invalid_values_rejected_at_construction(self, invalid_value, n_features: int, num_steps: int) -> None:
-        """`kl_annealing_fraction` must be a real number in the half-open interval (0, 1]."""
+        """`kl_annealing_fraction` must lie in the half-open interval (0, 1] (enforced by PositiveFloat01)."""
         with pytest.raises(ValueError, match="kl_annealing_fraction"):
             BayesianNeuralNetwork.cold_start(
                 n_features=n_features,
@@ -1658,9 +1656,9 @@ class TestKLAnnealing:
     def test_mcmc_rejects_kl_annealing_fraction_as_vi_only_kwarg(
         self, n_features: int, kl_annealing_fraction: float
     ) -> None:
-        """`kl_annealing_fraction` is a VI-only kwarg; passing it under MCMC must error
-        out via the existing VI-kwargs-on-MCMC guard in `_arrange_update_kwargs`. The guard
-        fires on the kwarg's presence, not its value, so the inputs are pinned via st.just.
+        """`kl_annealing_fraction` is a VI-only kwarg; passing it under MCMC must error out because
+        `MCMCUpdateKwargs` forbids unknown fields (``extra="forbid"``). The rejection fires on the
+        kwarg's presence, not its value, so the inputs are pinned via st.just.
         """
         with pytest.raises(ValueError, match="kl_annealing_fraction"):
             BayesianNeuralNetwork.cold_start(

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -384,7 +384,7 @@ class TestEditModelOnTheFly:
         # Result should only have actions from new_mab with their configuration
         assert set(merged.actions.keys()) == action_ids2
         for action_id in action_ids2:
-            assert merged.actions[action_id].update_kwargs["num_steps"] == n_iterations
+            assert merged.actions[action_id].update_kwargs.num_steps == n_iterations
 
     @given(
         action_ids1=action_ids_strategy,
@@ -548,8 +548,8 @@ class TestIntegration:
 
         # Verify hyperparameters updated
         for action in tuned_mab.actions.values():
-            assert action.update_kwargs["num_steps"] == n_updated
-            assert action.update_kwargs["optimizer_kwargs"]["step_size"] == learning_rate
+            assert action.update_kwargs.num_steps == n_updated
+            assert action.update_kwargs.optimizer_kwargs["step_size"] == learning_rate
 
     @given(
         n_actions_per_exp=st.lists(st.integers(min_value=1, max_value=3), min_size=3, max_size=3),
@@ -658,7 +658,7 @@ class TestModelCompatibilityValidation:
         current = CmabBernoulli.cold_start(action_ids={_ACTION_ID}, **shared_kwargs, update_kwargs={"num_steps": 50})
         template = CmabBernoulli.cold_start(action_ids={_ACTION_ID}, **shared_kwargs, update_kwargs={"num_steps": 200})
         result = edit_model_on_the_fly(current, template)
-        assert result.actions[_ACTION_ID].update_kwargs["num_steps"] == 200
+        assert result.actions[_ACTION_ID].update_kwargs.num_steps == 200
 
     def test_transfer_beta_models_no_validation(self) -> None:
         """Test that Beta models skip structural validation."""


### PR DESCRIPTION
### Changes:

* Add VIUpdateKwargs and MCMCUpdateKwargs to pybandits/model/bnn/config.py — typed replacements for the untyped update_kwargs dict
  - constrained known fields (num_steps, method, num_particles, kl_annealing_fraction, num_warmup, num_samples, ...); optimizer_kwargs/lr_scheduler_kwargs/early_stopping_kwargs/nuts left as open passthrough dicts
  - MCMCUpdateKwargs inherits extra="forbid", which is what rejects VI-only kwargs under MCMC
  - VIUpdateKwargs warns (model_validator mode="before") when both epochs and num_steps are supplied, reading raw input so model_dump() round-trips do not warn spuriously
* Update BaseBayesianNeuralNetwork.update_kwargs to Optional[Union[VIUpdateKwargs, MCMCUpdateKwargs]] in pybandits/model/bnn/network.py
  - add _coerce_update_kwargs (model_validator mode="before") that selects the schema by update_method and copies the input dict to avoid leaking an injected key into sibling models during Union resolution
  - flatten the validated model via model_dump() into _update_kwargs so the internal training code stays unchanged
  - switch _get_obj_optimizer and _get_early_stopping_callback to attribute access
* Remove _arrange_update_kwargs and the _default_vi_kwargs/_default_mcmc_kwargs/_vi_update_params class-vars from network.py — superseded by the typed models
  - drop now-unused numbers and warnings imports
* Update kl_annealing_fraction tests in tests/test_model.py — drop the string/bool rejection cases so the field coerces like sibling numeric fields, keep the (0, 1] range checks
  - fix stale _arrange_update_kwargs reference in the MCMC-rejects test docstring


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bayesian Neural Network update parameter validation with stricter type checking for VI and MCMC configurations, providing clearer error messages for misconfigured parameters.

* **Tests**
  * Updated validation tests for KL-annealing fraction and parameter configuration constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->