### PR TITLE
Add subsidy factor auto tuning

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -23,6 +23,10 @@
   > - {mod}`pybandits.offline_policy_evaluator`
   > - {mod}`pybandits.offline_policy_estimator`
 
+- `pybandits` provides utilities for cost-control bandit tuning and transfer learning.
+  > - {mod}`pybandits.subsidy_factor`
+  > - {mod}`pybandits.transfer`
+
 ## API
 
 Please visit the full [API](fullapi.md) for details.

--- a/pybandits/subsidy_factor.py
+++ b/pybandits/subsidy_factor.py
@@ -1,0 +1,312 @@
+# MIT License
+#
+# Copyright (c) 2024 Playtika Ltd.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Automatic discovery of the cost-control ``subsidy_factor``.
+
+A :class:`~pybandits.strategy.single_objective.CostControlBandit` selects, per round, the
+cheapest action whose sampled reward is within ``(1 - subsidy_factor)`` of the best sampled
+reward. ``subsidy_factor`` therefore trades reward for cost: ``0`` behaves like a classic bandit
+(maximum reward), ``1`` minimises cost. Picking it by hand means sweeping the factor on the
+current model and eyeballing the knee of the mean-reward curve - the point past which reward
+damage accelerates. This module automates that eyeball.
+
+The mean reward as a function of ``subsidy_factor`` is estimated by replaying the fitted
+posterior: for every candidate factor each Monte-Carlo draw is fed to the strategy's own
+``select_action``, and the selection is credited with an *independent* posterior draw of its
+expected reward. Using an independent draw for the credit (rather than the draw that drove the
+selection) removes Thompson-sampling optimism bias and yields a single code path that works for
+discrete, quantitative, and mixed action sets - cost only ever enters through ``select_action``,
+never the decision. The knee of that curve is then located robustly by bootstrapping the draws
+and taking the median knee.
+"""
+
+from typing import Callable, Dict, List, NamedTuple, Optional, Tuple, Union
+
+import numpy as np
+import pandas as pd
+from pydantic import NonNegativeInt, PositiveInt, confloat, validate_call
+
+from pybandits.base import ActionId, UnifiedActionId
+from pybandits.cmab import BaseCmabBernoulli
+from pybandits.mab import BaseMab
+from pybandits.strategy import CostControlBandit, MultiObjectiveCostControlBandit
+
+# A single Monte-Carlo draw maps each action to its sampled reward: a scalar for discrete actions
+# or a callable ``quantity -> reward`` for quantitative actions.
+ProbDraw = Dict[ActionId, Union[float, Callable[[np.ndarray], float]]]
+
+
+class SubsidyFactorTuningResult(NamedTuple):
+    """
+    Result of :func:`tune_subsidy_factor`.
+
+    Attributes
+    ----------
+    subsidy_factor : float
+        The discovered subsidy factor (bootstrap-median knee of the mean-reward curve).
+    subsidy_factor_ci : Tuple[float, float]
+        Bootstrap confidence interval for the knee, at the requested confidence level.
+    mab : BaseMab
+        A copy of the input bandit with ``strategy.with_subsidy_factor(subsidy_factor)`` applied.
+    frontier : pd.DataFrame
+        The full sweep, one row per candidate factor, with columns ``subsidy_factor``,
+        ``mean_reward``, ``mean_reward_pct`` (reward as a percentage of the ``subsidy_factor=0``
+        reward) and one ``p_select[<action_id>]`` column per action giving its selection
+        frequency. Lets the caller reproduce the wiki-style plot and override the auto-pick.
+    """
+
+    subsidy_factor: float
+    subsidy_factor_ci: Tuple[float, float]
+    mab: BaseMab
+    frontier: pd.DataFrame
+
+
+def _detect_knee(subsidy_factors: np.ndarray, rewards: np.ndarray) -> float:
+    """
+    Locate the knee of a reward-vs-subsidy_factor curve (Kneedle, distance-from-chord variant).
+
+    Both axes are normalised to ``[0, 1]`` and the knee is the point of maximum distance *above*
+    the chord joining the curve's endpoints - the corner of the flat-then-declining reward curve.
+
+    Parameters
+    ----------
+    subsidy_factors : np.ndarray
+        Candidate subsidy factors, ascending.
+    rewards : np.ndarray
+        Mean reward at each subsidy factor.
+
+    Returns
+    -------
+    float
+        The subsidy factor at the knee. Falls back to ``subsidy_factors[0]`` for a flat curve.
+    """
+    x = np.asarray(subsidy_factors, dtype=float)
+    y = np.asarray(rewards, dtype=float)
+    x_range = x[-1] - x[0]
+    y_range = y.max() - y.min()
+    if x_range == 0 or y_range == 0:  # degenerate / flat reward - no knee to speak of
+        return float(x[0])
+    x_n = (x - x[0]) / x_range
+    y_n = (y - y.min()) / y_range
+    chord = y_n[0] + (y_n[-1] - y_n[0]) * x_n
+    distance = y_n - chord
+    return float(x[int(np.argmax(distance))])
+
+
+def _sample_prob_draws(mab: BaseMab, context: Optional[np.ndarray], n_samples: int, contextual: bool) -> List[ProbDraw]:
+    """
+    Draw Monte-Carlo posterior samples as a flat list of per-action reward dicts.
+
+    For a non-contextual bandit this is ``n_samples`` draws. For a contextual bandit each posterior
+    pass produces one draw per context row, so the result holds ``n_samples * len(context)`` draws;
+    the contextual ``(probability, weight)`` tuples are reduced to the probability element, matching
+    what ``predict`` feeds to the strategy.
+
+    Parameters
+    ----------
+    mab : BaseMab
+        The bandit to sample from (its ``_rng`` is advanced).
+    context : Optional[np.ndarray]
+        Context matrix for contextual bandits; ignored otherwise.
+    n_samples : int
+        Number of posterior draws (contextual: posterior passes over the whole context).
+    contextual : bool
+        Whether ``mab`` is contextual.
+
+    Returns
+    -------
+    List[ProbDraw]
+        One dict per draw mapping each action to its sampled reward (scalar or callable).
+    """
+    valid_actions = set(mab.actions.keys())
+    if not contextual:
+        return list(mab._get_action_probabilities(valid_actions=valid_actions, n_samples=n_samples))
+    draws: List[ProbDraw] = []
+    for _ in range(n_samples):
+        for row in mab._get_action_probabilities(valid_actions=valid_actions, context=context):
+            draws.append({a: (v[0] if isinstance(v, tuple) else v) for a, v in row.items()})
+    return draws
+
+
+def _credit(p_cred_draw: ProbDraw, selected: UnifiedActionId) -> float:
+    """
+    Evaluate the reward credited to a selection using an independent posterior draw.
+
+    Parameters
+    ----------
+    p_cred_draw : ProbDraw
+        An independent posterior draw (not the one used to make the selection).
+    selected : UnifiedActionId
+        The selected action: an ``ActionId`` for discrete actions or an ``(ActionId, quantity)``
+        tuple for quantitative actions.
+
+    Returns
+    -------
+    float
+        The independent draw's reward for the selection.
+    """
+    if isinstance(selected, tuple):
+        action_id, quantity = selected[0], np.asarray(selected[1])
+        return float(p_cred_draw[action_id](quantity))
+    return float(p_cred_draw[selected])
+
+
+@validate_call(config=dict(arbitrary_types_allowed=True))
+def tune_subsidy_factor(
+    mab: BaseMab,
+    context: Optional[np.ndarray] = None,
+    n_samples: PositiveInt = 1000,
+    n_points: PositiveInt = 100,
+    n_bootstrap: PositiveInt = 1000,
+    confidence_level: confloat(gt=0, lt=1) = 0.9,
+    random_seed: Optional[NonNegativeInt] = None,
+) -> SubsidyFactorTuningResult:
+    """
+    Discover a cost-control ``subsidy_factor`` from a fitted cost-control bandit.
+
+    Sweeps ``subsidy_factor`` over ``[0, 1]``, estimates the mean reward of the resulting policy at
+    each value by replaying the posterior through the strategy's ``select_action``, and returns the
+    knee of that curve (the operating point past which reward damage accelerates). The knee is
+    stabilised by bootstrapping the Monte-Carlo draws and taking the median knee.
+
+    Parameters
+    ----------
+    mab : BaseMab
+        A fitted cost-control bandit (``strategy`` must be a ``CostControlBandit``), e.g.
+        ``SmabBernoulliCC`` or ``CmabBernoulliCC``. Discrete, quantitative and mixed action sets
+        are supported. The input bandit is not modified.
+    context : Optional[np.ndarray], default=None
+        Context matrix of shape ``(n_rows, n_features)``. Required for contextual bandits and must
+        be ``None`` otherwise. The mean reward is averaged over these rows, so they should be
+        representative of the target population.
+    n_samples : PositiveInt, default=1000
+        Number of posterior draws used to estimate the reward curve. For a contextual bandit this is
+        the number of posterior passes over ``context``; the total number of draws is
+        ``n_samples * len(context)`` and the selection cost scales with ``draws * n_points``, so use
+        a modest value (e.g. 20-100) with a representative context.
+    n_points : PositiveInt, default=100
+        Number of subsidy-factor grid points over ``[0, 1]``. Must be at least 3.
+    n_bootstrap : PositiveInt, default=1000
+        Number of bootstrap replicates used to stabilise the knee and form its confidence interval.
+    confidence_level : float, default=0.9
+        Confidence level (in ``(0, 1)``) for the knee's bootstrap interval.
+    random_seed : Optional[NonNegativeInt], default=None
+        Seed for the sampling and bootstrap generators. With a seed the result is reproducible.
+
+    Returns
+    -------
+    SubsidyFactorTuningResult
+        The discovered subsidy factor, its confidence interval, a bandit copy with the factor
+        applied, and the full sweep as a DataFrame.
+
+    Raises
+    ------
+    TypeError
+        If ``mab`` is not a cost-control bandit.
+    NotImplementedError
+        If ``mab`` uses a multi-objective cost-control strategy (the knee needs reward
+        scalarisation, which is not defined here).
+    ValueError
+        If ``n_points < 3``, or ``context`` is missing for a contextual bandit / provided for a
+        non-contextual one.
+    """
+    if isinstance(mab.strategy, MultiObjectiveCostControlBandit):
+        raise NotImplementedError(
+            "Multi-objective cost control is not supported: the reward is a vector, so the knee "
+            "needs a reward scalarisation choice. Use a single-objective CostControlBandit."
+        )
+    if not isinstance(mab.strategy, CostControlBandit):
+        raise TypeError(
+            "tune_subsidy_factor requires a cost-control bandit (strategy=CostControlBandit), "
+            "e.g. SmabBernoulliCC or CmabBernoulliCC."
+        )
+    if n_points < 3:
+        raise ValueError("n_points must be at least 3 to detect a knee.")
+    contextual = isinstance(mab, BaseCmabBernoulli)
+    if contextual and context is None:
+        raise ValueError("context is required for a contextual (cMAB) bandit.")
+    if not contextual and context is not None:
+        raise ValueError("context must be None for a non-contextual (sMAB) bandit.")
+    if contextual and context is not None and len(context) == 0:
+        raise ValueError("context must not be empty for a contextual (cMAB) bandit.")
+
+    # Analyse the pure strategy selection on an isolated copy: disable epsilon-greedy exploration
+    # and use a dedicated rng so the input bandit (and its rng state) is left untouched.
+    working = mab.model_copy(
+        update={"epsilon": None, "default_action": None, "default_action_fraction": None}, deep=True
+    )
+    if random_seed is not None:
+        working._rng = np.random.default_rng(random_seed)
+    actions = working.actions
+
+    # Two independent posterior sample sets: one drives the selection, the other credits it. The
+    # independent credit makes the reward an unbiased estimate of the selection's expected reward.
+    p_sel = _sample_prob_draws(working, context, n_samples, contextual)
+    p_cred = _sample_prob_draws(working, context, n_samples, contextual)
+    n_draws = min(len(p_sel), len(p_cred))
+
+    subsidy_factors = np.linspace(0.0, 1.0, n_points)
+    action_ids = list(actions.keys())
+    credit = np.empty((n_draws, n_points))
+    selection_counts = {action_id: np.zeros(n_points) for action_id in action_ids}
+    for j, subsidy_factor in enumerate(subsidy_factors):
+        strategy = working.strategy.with_subsidy_factor(float(subsidy_factor))
+        for d in range(n_draws):
+            selected = strategy.select_action(p_sel[d], actions)
+            base_action = selected[0] if isinstance(selected, tuple) else selected
+            selection_counts[base_action][j] += 1
+            credit[d, j] = _credit(p_cred[d], selected)
+
+    mean_reward = credit.mean(axis=0)
+
+    # Bootstrap the draws and take the median knee for a stable, noise-robust pick.
+    boot_rng = np.random.default_rng(random_seed)
+    knees = np.array(
+        [
+            _detect_knee(subsidy_factors, credit[boot_rng.integers(0, n_draws, n_draws)].mean(axis=0))
+            for _ in range(n_bootstrap)
+        ]
+    )
+    subsidy_factor = float(np.median(knees))
+    lower = (1 - confidence_level) / 2 * 100
+    upper = (1 + confidence_level) / 2 * 100
+    subsidy_factor_ci = (float(np.percentile(knees, lower)), float(np.percentile(knees, upper)))
+
+    reference = mean_reward[0] if mean_reward[0] != 0 else np.nan
+    frontier = pd.DataFrame(
+        {
+            "subsidy_factor": subsidy_factors,
+            "mean_reward": mean_reward,
+            "mean_reward_pct": mean_reward / reference * 100,
+        }
+    )
+    for action_id in action_ids:
+        frontier[f"p_select[{action_id}]"] = selection_counts[action_id] / n_draws
+
+    tuned_mab = mab.model_copy(update={"strategy": mab.strategy.with_subsidy_factor(subsidy_factor)}, deep=True)
+    return SubsidyFactorTuningResult(
+        subsidy_factor=subsidy_factor,
+        subsidy_factor_ci=subsidy_factor_ci,
+        mab=tuned_mab,
+        frontier=frontier,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybandits"
-version = "7.5.1"
+version = "7.5.2"
 description = "Python Multi-Armed Bandit Library"
 authors = [
     "Dario d'Andrea <dariod@playtika.com>",

--- a/tests/test_cmab.py
+++ b/tests/test_cmab.py
@@ -672,7 +672,7 @@ def test_update(
     )
     reward_data = reward_data.tolist()
     # Test updates with generated data
-    actions_to_update = sample_with_replacement(action_ids, n_samples)
+    actions_to_update = sample_with_replacement(action_ids, n_samples, rng=rng)
     # Generate quantities only if there are any QuantitativeModel actions
     # Handle multi-objective rewards for MO models
 
@@ -783,9 +783,13 @@ def test_predict(
         context = rng.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
 
         # Test predictions with random forbidden actions
-        forbidden = set(sample_with_replacement(action_ids, len(action_ids) // 2)) if len(action_ids) > 2 else None
-        if cmab.default_action is not None and forbidden is not None and cmab.default_action in forbidden:
-            forbidden.remove(cmab.default_action)
+        forbidden = (
+            set(sample_with_replacement(action_ids, len(action_ids) // 2, rng=rng)) if len(action_ids) > 2 else None
+        )
+        if cmab.default_action is not None and forbidden is not None:
+            da_id = cmab.default_action[0] if isinstance(cmab.default_action, tuple) else cmab.default_action
+            if da_id in forbidden:
+                forbidden.discard(da_id)
         apply_mock_update(list(cmab.actions.values()))
         best_actions, probs, weights = cmab.predict(context=context, forbidden_actions=forbidden)
         assert len(best_actions) == n_samples

--- a/tests/test_smab.py
+++ b/tests/test_smab.py
@@ -454,7 +454,7 @@ def test_update(
     reward_data = reward_data.tolist()
     # Test updates with generated data
     actions_to_update = sample_with_replacement(
-        action_ids, n_samples
+        action_ids, n_samples, rng=rng
     )  # Generate quantities only if there are any QuantitativeModel actions
     if any(isinstance(model, QuantitativeModel) for model in smab.actions.values()):
         quantity_data = rng.random(size=n_samples).tolist()
@@ -581,9 +581,13 @@ def test_predict(
         )[0]
 
         # Test predictions with random forbidden actions
-        forbidden = set(sample_with_replacement(action_ids, len(action_ids) // 2)) if len(action_ids) > 2 else None
-        if smab.default_action is not None and forbidden is not None and smab.default_action in forbidden:
-            forbidden.remove(smab.default_action)
+        forbidden = (
+            set(sample_with_replacement(action_ids, len(action_ids) // 2, rng=rng)) if len(action_ids) > 2 else None
+        )
+        if smab.default_action is not None and forbidden is not None:
+            da_id = smab.default_action[0] if isinstance(smab.default_action, tuple) else smab.default_action
+            if da_id in forbidden:
+                forbidden.discard(da_id)
 
         mock_update(list(smab.actions.values()), diff, monkeymodule)
         best_actions, probs = smab.predict(n_samples=n_samples, forbidden_actions=forbidden)

--- a/tests/test_subsidy_factor.py
+++ b/tests/test_subsidy_factor.py
@@ -1,0 +1,336 @@
+# MIT License
+#
+# Copyright (c) 2024 Playtika Ltd.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from typing import Callable, Dict, List, Tuple, Type, Union
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+import pybandits.strategy.single_objective
+from pybandits.cmab import CmabBernoulliCC
+from pybandits.mab import BaseMab
+from pybandits.smab import SmabBernoulli, SmabBernoulliCC, SmabBernoulliMOCC
+from pybandits.subsidy_factor import SubsidyFactorTuningResult, _detect_knee, tune_subsidy_factor
+
+# Three actions with a reward/cost trade-off: the priciest action is best, a much cheaper action is
+# almost as good (creates an early knee), and the free action is poor.
+ACTION_COSTS: Dict[str, float] = {"best": 3.0, "cheap_good": 1.0, "cheap_bad": 0.0}
+# action_id -> (n_successes, n_failures) fed via update, so the posteriors differ markedly.
+ACTION_REWARDS: Dict[str, Tuple[int, int]] = {"best": (60, 40), "cheap_good": (55, 45), "cheap_bad": (20, 80)}
+DEFAULT_SUBSIDY_FACTOR: float = 0.5
+
+N_SAMPLES: int = 10
+N_POINTS: int = 5
+N_BOOTSTRAP: int = 3
+RANDOM_SEED: int = 123
+DETERMINISM_SEED: int = 7
+
+SF_MIN: float = 0.0
+SF_MAX: float = 1.0
+FULL_PCT: float = 100.0
+UNIT_SUM: float = 1.0
+REWARD_GAP_MIN: float = 0.1
+EDGE_WINDOW: int = 3
+
+# Analytic flat-then-declining reward curve used to probe the knee detector.
+PLATEAU_REWARD: float = 1.0
+FLOOR_REWARD: float = 0.0
+KNEE_MIN: float = 0.1
+KNEE_MAX: float = 0.9
+EPS: float = 1e-9
+
+# Hypothesis ranges for the knee detector: vary grid size and reward scale.
+# PLATEAU_MIN must exceed FLOOR_REWARD so the curve has non-zero y_range.
+N_POINTS_MIN: int = 10
+N_POINTS_MAX: int = 50
+PLATEAU_MIN: float = 0.1
+PLATEAU_MAX: float = 2.0
+
+# Cheap configuration for guard / smoke tests that must not pay for a full sweep.
+CC_COSTS_AB: Dict[str, float] = {"a": 1.0, "b": 2.0}
+NON_CC_ACTION_IDS = {"a", "b"}
+N_OBJECTIVES: int = 2
+CMAB_N_FEATURES: int = 2
+CMAB_CONTEXT_ROWS: int = 4
+CMAB_SAMPLES: int = 3
+CMAB_POINTS: int = 5
+CMAB_BOOTSTRAP: int = 10
+CMAB_SEED: int = 0
+FAST_TUNE_KWARGS: Dict[str, int] = {"n_samples": 10, "n_points": 5, "n_bootstrap": 5}
+MIN_POINTS_INVALID: int = 2
+MISUSE_CONTEXT = np.zeros((3, CMAB_N_FEATURES))
+
+# Quantitative action smoke-test constants.
+# QUANT_SEGMENT_QUANTITIES covers all 4 initial ZoomingCC segments so failures suppress the whole space.
+QUANT_ACTION_ID: str = "q"
+QUANT_SEGMENT_QUANTITIES: List[float] = [0.1, 0.3, 0.5, 0.7, 0.9]
+QUANT_N_FAILURES: int = 5
+QUANT_N_SUCCESSES_PER_ACTION: int = 50
+QUANT_FAST_N_POINTS: int = FAST_TUNE_KWARGS["n_points"]
+QUANT_SEED: int = 42
+
+
+def QUANT_COST_CALLABLE(x: Union[float, np.ndarray]) -> float:
+    """Cost function for the quantitative ZoomingCC action (average quantity)."""
+    return float(np.asarray(x).mean())
+
+
+@pytest.fixture
+def fitted_smab_cc() -> Callable[..., SmabBernoulliCC]:
+    """Factory building a cold-started ``SmabBernoulliCC`` updated into distinct per-action posteriors."""
+
+    def _build(
+        costs: Dict[str, float] = ACTION_COSTS,
+        rewards: Dict[str, Tuple[int, int]] = ACTION_REWARDS,
+        subsidy_factor: float = DEFAULT_SUBSIDY_FACTOR,
+        seed: int = RANDOM_SEED,
+    ) -> SmabBernoulliCC:
+        mab = SmabBernoulliCC.cold_start(action_ids_cost=dict(costs), subsidy_factor=subsidy_factor, random_seed=seed)
+        actions, reward_list = [], []
+        for action_id, (n_successes, n_failures) in rewards.items():
+            actions += [action_id] * (n_successes + n_failures)
+            reward_list += [1] * n_successes + [0] * n_failures
+        mab.update(actions=actions, rewards=reward_list)
+        return mab
+
+    return _build
+
+
+class TestDetectKnee:
+    """Knee detection on a reward-vs-subsidy_factor curve."""
+
+    @given(
+        knee_x=st.floats(min_value=KNEE_MIN, max_value=KNEE_MAX),
+        n_points=st.integers(min_value=N_POINTS_MIN, max_value=N_POINTS_MAX),
+        plateau=st.floats(min_value=PLATEAU_MIN, max_value=PLATEAU_MAX, allow_nan=False, allow_infinity=False),
+        floor=st.just(FLOOR_REWARD),
+        sf_max=st.just(SF_MAX),
+        eps=st.just(EPS),
+    )
+    def test_finds_analytic_elbow(
+        self, knee_x: float, n_points: int, plateau: float, floor: float, sf_max: float, eps: float
+    ) -> None:
+        """Recovers the corner of a flat-then-declining reward curve (within one grid step)."""
+        subsidy_factors = np.linspace(floor, sf_max, n_points)
+        rewards = np.where(
+            subsidy_factors <= knee_x,
+            plateau,
+            plateau - (subsidy_factors - knee_x) / (sf_max - knee_x) * (plateau - floor),
+        )
+        detected = _detect_knee(subsidy_factors, rewards)
+        grid_step = (sf_max - floor) / (n_points - 1)
+        assert abs(detected - knee_x) <= grid_step + eps
+
+    @given(
+        n_points=st.integers(min_value=N_POINTS_MIN, max_value=N_POINTS_MAX),
+        constant=st.floats(min_value=0.0, max_value=PLATEAU_MAX, allow_nan=False, allow_infinity=False),
+        floor=st.just(FLOOR_REWARD),
+        sf_max=st.just(SF_MAX),
+    )
+    def test_flat_curve_returns_first(self, n_points: int, constant: float, floor: float, sf_max: float) -> None:
+        """A flat reward curve at any constant value has no knee, so the smallest factor is returned."""
+        subsidy_factors = np.linspace(floor, sf_max, n_points)
+        assert _detect_knee(subsidy_factors, np.full(n_points, constant)) == subsidy_factors[0]
+
+
+class TestTuneSubsidyFactor:
+    """End-to-end discovery of the cost-control subsidy factor."""
+
+    def test_end_to_end_smab_cc(
+        self,
+        fitted_smab_cc: Callable[..., SmabBernoulliCC],
+        n_samples: int = N_SAMPLES,
+        n_points: int = N_POINTS,
+        n_bootstrap: int = N_BOOTSTRAP,
+        seed: int = RANDOM_SEED,
+        sf_min: float = SF_MIN,
+        sf_max: float = SF_MAX,
+        unit_sum: float = UNIT_SUM,
+        reward_gap_min: float = REWARD_GAP_MIN,
+        full_pct: float = FULL_PCT,
+        edge_window: int = EDGE_WINDOW,
+    ) -> None:
+        """The full sweep yields a knee in range, a decreasing reward frontier, and an applied copy."""
+        mab = fitted_smab_cc()
+        original_subsidy_factor = mab.strategy.subsidy_factor
+
+        result = tune_subsidy_factor(
+            mab, n_samples=n_samples, n_points=n_points, n_bootstrap=n_bootstrap, random_seed=seed
+        )
+
+        assert isinstance(result, SubsidyFactorTuningResult)
+        assert sf_min <= result.subsidy_factor <= sf_max
+        lower, upper = result.subsidy_factor_ci
+        assert sf_min <= lower <= result.subsidy_factor <= upper <= sf_max
+
+        frontier = result.frontier
+        assert len(frontier) == n_points
+        assert frontier["subsidy_factor"].iloc[0] == sf_min
+        assert frontier["subsidy_factor"].iloc[-1] == sf_max
+        # One selection per draw: per-row selection probabilities sum to 1.
+        select_cols = [c for c in frontier.columns if c.startswith("p_select[")]
+        assert np.allclose(frontier[select_cols].sum(axis=1), unit_sum)
+
+        rewards = frontier["mean_reward"].to_numpy()
+        # Classic (sf=0) maximises reward; cost minimisation (sf=1) is materially worse here.
+        assert rewards[0] == pytest.approx(rewards.max())
+        assert rewards[0] - rewards[-1] > reward_gap_min
+        assert rewards[:edge_window].mean() >= rewards[-edge_window:].mean()
+        assert frontier["mean_reward_pct"].iloc[0] == pytest.approx(full_pct)
+
+        # The discovered factor is applied to the returned copy; the input bandit is untouched.
+        assert result.mab.strategy.subsidy_factor == result.subsidy_factor
+        assert mab.strategy.subsidy_factor == original_subsidy_factor
+
+    def test_deterministic_with_seed(
+        self,
+        fitted_smab_cc: Callable[..., SmabBernoulliCC],
+        n_samples: int = N_SAMPLES,
+        n_points: int = N_POINTS,
+        n_bootstrap: int = N_BOOTSTRAP,
+        seed: int = DETERMINISM_SEED,
+    ) -> None:
+        """A fixed ``random_seed`` makes the discovered factor and frontier reproducible."""
+        mab = fitted_smab_cc()
+        kwargs = dict(n_samples=n_samples, n_points=n_points, n_bootstrap=n_bootstrap, random_seed=seed)
+
+        first = tune_subsidy_factor(mab, **kwargs)
+        second = tune_subsidy_factor(mab, **kwargs)
+
+        assert first.subsidy_factor == second.subsidy_factor
+        assert first.subsidy_factor_ci == second.subsidy_factor_ci
+        pd.testing.assert_frame_equal(first.frontier, second.frontier)
+
+    def test_smoke_cmab_cc(
+        self,
+        costs: Dict[str, float] = CC_COSTS_AB,
+        n_features: int = CMAB_N_FEATURES,
+        n_rows: int = CMAB_CONTEXT_ROWS,
+        n_samples: int = CMAB_SAMPLES,
+        n_points: int = CMAB_POINTS,
+        n_bootstrap: int = CMAB_BOOTSTRAP,
+        seed: int = CMAB_SEED,
+        sf_min: float = SF_MIN,
+        sf_max: float = SF_MAX,
+    ) -> None:
+        """A contextual cost-control bandit produces a valid frontier when given a context."""
+        cmab = CmabBernoulliCC.cold_start(action_ids_cost=dict(costs), n_features=n_features, random_seed=seed)
+        context = np.random.default_rng(seed).normal(size=(n_rows, n_features))
+
+        result = tune_subsidy_factor(
+            cmab, context=context, n_samples=n_samples, n_points=n_points, n_bootstrap=n_bootstrap, random_seed=seed
+        )
+
+        assert sf_min <= result.subsidy_factor <= sf_max
+        assert len(result.frontier) == n_points
+
+    def test_smoke_quantitative_action(
+        self,
+        quant_action_id: str = QUANT_ACTION_ID,
+        discrete_costs: Dict[str, float] = CC_COSTS_AB,
+        quant_cost: Callable[[Union[float, np.ndarray]], float] = QUANT_COST_CALLABLE,
+        segment_quantities: List[float] = QUANT_SEGMENT_QUANTITIES,
+        n_failures: int = QUANT_N_FAILURES,
+        n_successes_per_action: int = QUANT_N_SUCCESSES_PER_ACTION,
+        n_fast_points: int = QUANT_FAST_N_POINTS,
+        seed: int = QUANT_SEED,
+        sf_min: float = SF_MIN,
+        sf_max: float = SF_MAX,
+    ) -> None:
+        """A cost-control bandit with a quantitative action produces a valid result."""
+        mab = SmabBernoulliCC.cold_start(
+            action_ids_cost=dict(discrete_costs),
+            quantitative_action_ids_cost={quant_action_id: quant_cost},
+            subsidy_factor=DEFAULT_SUBSIDY_FACTOR,
+            random_seed=seed,
+        )
+        # Ground posteriors: cover all initial ZoomingCC segments with failures so the
+        # discrete actions dominate. Cold-start ZoomingCC over-optimism otherwise makes the
+        # cost-control threshold unreachable for discrete actions at subsidy_factor=0.
+        discrete_action_ids = list(discrete_costs.keys())
+        mab.update(actions=[quant_action_id] * n_failures, rewards=[0] * n_failures, quantities=segment_quantities)
+        mab.update(
+            actions=discrete_action_ids * n_successes_per_action,
+            rewards=[1] * (len(discrete_action_ids) * n_successes_per_action),
+            quantities=[None] * (len(discrete_action_ids) * n_successes_per_action),
+        )
+        with patch.object(
+            pybandits.strategy.single_objective,
+            "maximize_by_quantity",
+            lambda score_func, dimension, constraint=None, **kwargs: np.zeros(dimension),
+        ):
+            result = tune_subsidy_factor(mab, **FAST_TUNE_KWARGS, random_seed=seed)
+        assert sf_min <= result.subsidy_factor <= sf_max
+        assert len(result.frontier) == n_fast_points
+
+    @pytest.mark.parametrize(
+        "build_mab, call_kwargs, expected_exception",
+        [
+            pytest.param(
+                lambda: SmabBernoulli.cold_start(action_ids=NON_CC_ACTION_IDS),
+                FAST_TUNE_KWARGS,
+                TypeError,
+                id="non_cost_control",
+            ),
+            pytest.param(
+                lambda: SmabBernoulliMOCC.cold_start(action_ids_cost=CC_COSTS_AB, n_objectives=N_OBJECTIVES),
+                FAST_TUNE_KWARGS,
+                NotImplementedError,
+                id="multi_objective_cost_control",
+            ),
+            pytest.param(
+                lambda: CmabBernoulliCC.cold_start(action_ids_cost=CC_COSTS_AB, n_features=CMAB_N_FEATURES),
+                {},
+                ValueError,
+                id="contextual_without_context",
+            ),
+            pytest.param(
+                lambda: SmabBernoulliCC.cold_start(action_ids_cost=CC_COSTS_AB),
+                {**FAST_TUNE_KWARGS, "context": MISUSE_CONTEXT},
+                ValueError,
+                id="context_for_non_contextual",
+            ),
+            pytest.param(
+                lambda: SmabBernoulliCC.cold_start(action_ids_cost=CC_COSTS_AB),
+                {**FAST_TUNE_KWARGS, "n_points": MIN_POINTS_INVALID},
+                ValueError,
+                id="too_few_grid_points",
+            ),
+            pytest.param(
+                lambda: CmabBernoulliCC.cold_start(action_ids_cost=CC_COSTS_AB, n_features=CMAB_N_FEATURES),
+                {**FAST_TUNE_KWARGS, "context": np.zeros((0, CMAB_N_FEATURES))},
+                ValueError,
+                id="contextual_empty_context",
+            ),
+        ],
+    )
+    def test_rejects_invalid_inputs(
+        self, build_mab: Callable[[], BaseMab], call_kwargs: Dict[str, object], expected_exception: Type[Exception]
+    ) -> None:
+        """Misconfigured bandits and arguments raise before any sampling work is done."""
+        mab = build_mab()
+        with pytest.raises(expected_exception):
+            tune_subsidy_factor(mab, **call_kwargs)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -34,7 +34,11 @@ class _EvalArray:
         return self.array
 
 
-def sample_with_replacement(source: list, length: PositiveInt):
+def sample_with_replacement(source: list, length: PositiveInt, rng: Optional[np.random.Generator] = None) -> list:
+    if rng is not None:
+        # Use index-based sampling to avoid numpy converting special chars (e.g. '\x00' → '') during array storage.
+        indices = rng.integers(0, len(source), size=length)
+        return [source[int(i)] for i in indices]
     return [random.choice(source) for _ in range(length)]
 
 


### PR DESCRIPTION
### Changes:

* Add pybandits/subsidy_factor.py — automatic discovery of the cost-control subsidy_factor by replaying the fitted posterior through the strategy
* Add tune_subsidy_factor() — sweeps subsidy_factor over [0, 1], estimates mean reward per value, returns the bootstrap-median knee
  - uses two independent posterior sample sets (one drives selection, one credits it) to remove Thompson-sampling optimism bias
  - works for discrete, quantitative and mixed action sets since cost only enters via select_action
  - copies the bandit with epsilon-greedy disabled and a dedicated rng so the input mab and its rng state are untouched
  - raises NotImplementedError for MultiObjectiveCostControlBandit, TypeError for non-cost-control strategies, ValueError on n_points < 3 or context/contextual mismatch
* Add SubsidyFactorTuningResult NamedTuple — returns subsidy_factor, bootstrap CI, a tuned mab copy, and the full sweep as a frontier DataFrame
* Add _detect_knee() — Kneedle distance-from-chord knee locator, falls back to first factor on a flat curve
* Add _sample_prob_draws() and _credit() helpers — flatten posterior draws to per-action reward dicts and evaluate credited reward (scalar or quantitative callable)
* Add tests/test_subsidy_factor.py — TestDetectKnee and TestTuneSubsidyFactor covering analytic elbow detection, flat-curve fallback, end-to-end sMAB CC, seed determinism, cMAB CC smoke, and invalid-input rejection


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic tuning for cost-control bandits’ `subsidy_factor`, including knee-point detection, confidence intervals, and a frontier-style reward summary with action selection frequencies.

* **Tests**
  * Added coverage for tuning behavior, knee detection (including flat/degenerate curves), input validation, contextual vs non-contextual rules, and reproducibility.
  * Improved test determinism by enabling seeded sampling in shared test utilities.

* **Documentation**
  * Documented cost-control tuning utilities in the API architecture overview.

* **Chores**
  * Bumped the package version to 7.5.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->