### PR TITLE
Add categorical feature expansion to transfer learning

### DIFF
--- a/pybandits/model/bnn/network.py
+++ b/pybandits/model/bnn/network.py
@@ -1823,6 +1823,7 @@ class BaseBayesianNeuralNetworkMO(ModelMO, ABC):
         use_residual_connections: bool = False,
         use_layerwise_scaling: bool = False,
         bias_std: Optional[PositiveFloat] = None,
+        categorical_features: Optional[Dict[NonNegativeInt, NonNegativeInt]] = None,
         decay_factor: Optional[PositiveFloat01] = None,
         **kwargs,
     ) -> Self:
@@ -1854,6 +1855,8 @@ class BaseBayesianNeuralNetworkMO(ModelMO, ABC):
         bias_std : Optional[PositiveFloat]
             If provided, overrides ``sigma`` from ``dist_params`` for all layers' bias priors,
             leaving weight priors untouched. Default is None.
+        categorical_features : Optional[Dict[int, int]], optional
+            Categorical columns as ``{column_index: cardinality}``, forwarded to each per-objective BNN.
         decay_factor : Optional[PositiveFloat01]
             Per-update forgetting factor forwarded to each per-objective BNN.
         **kwargs
@@ -1877,6 +1880,7 @@ class BaseBayesianNeuralNetworkMO(ModelMO, ABC):
                 use_residual_connections=use_residual_connections,
                 use_layerwise_scaling=use_layerwise_scaling,
                 bias_std=bias_std,
+                categorical_features=categorical_features,
                 decay_factor=decay_factor,
             )
             for _ in range(n_objectives)

--- a/pybandits/transfer.py
+++ b/pybandits/transfer.py
@@ -477,6 +477,107 @@ def _expand_bnn_weights(
             _sync_and_expand_dist_params(current_b, template_b)
 
 
+def _expand_embedding_params(
+    current_model_params: Dict[str, Any],
+    template_model_params: Dict[str, Any],
+    current_feature_config: Dict[str, Any],
+    template_feature_config: Dict[str, Any],
+    action_id: str,
+    obj_idx: Optional[int] = None,
+) -> None:
+    """Expand embedding parameters in-place to match template's categorical features.
+
+    Handles two scenarios:
+    1. New categorical feature (present in template, absent in current): embedding copied from template.
+    2. Grown cardinality with same embedding_dim: new category rows appended from template.
+
+    Raises ValueError if an existing categorical feature's ``embedding_dim`` changes, since that
+    alters the first dense-layer input width and requires retraining from scratch.
+
+    Parameters
+    ----------
+    current_model_params : Dict[str, Any]
+        Current action model_params dict, modified in-place.
+    template_model_params : Dict[str, Any]
+        Template action model_params dict.
+    current_feature_config : Dict[str, Any]
+        Current action feature_config dict.
+    template_feature_config : Dict[str, Any]
+        Template action feature_config dict.
+    action_id : str
+        Action ID for error messages.
+    obj_idx : Optional[int]
+        Objective index for MO models, or None for SO models.
+
+    Raises
+    ------
+    ValueError
+        If an existing categorical feature's embedding_dim changes.
+    """
+    template_cats = template_feature_config.get("categorical_features_configs", [])
+    if not template_cats:
+        # ponytail: clear stale embedding payloads so model_params stays consistent with the new feature_config
+        for outer_key in ("embedding_params", "embedding_params_init"):
+            current_model_params.pop(outer_key, None)
+        return
+
+    current_cats = current_feature_config.get("categorical_features_configs", [])
+    prefix = f" (objective {obj_idx})" if obj_idx is not None else ""
+
+    # column_index → (list_position, config) for current categorical features
+    current_cat_by_col = {cfg["column_index"]: (i, cfg) for i, cfg in enumerate(current_cats)}
+
+    # Validate: embedding_dim must not change for existing categorical features
+    for tpl_cfg in template_cats:
+        col_idx = tpl_cfg["column_index"]
+        if col_idx in current_cat_by_col:
+            _, cur_cfg = current_cat_by_col[col_idx]
+            if tpl_cfg["embedding_dim"] != cur_cfg["embedding_dim"]:
+                raise ValueError(
+                    f"Cannot change embedding_dim for categorical feature at column {col_idx} "
+                    f"in action '{action_id}'{prefix}: "
+                    f"{cur_cfg['embedding_dim']} -> {tpl_cfg['embedding_dim']}. "
+                    "Changing embedding_dim requires retraining from scratch."
+                )
+
+    # Expand both embedding_params and embedding_params_init (outer frozen copy)
+    for outer_key in ("embedding_params", "embedding_params_init"):
+        tpl_ep = template_model_params.get(outer_key)
+        if tpl_ep is None:
+            continue
+
+        # Capture original current embedding data before any writes
+        cur_ep = current_model_params.get(outer_key) or {}
+
+        for inner_key in ("embeddings", "embeddings_init"):
+            tpl_list = tpl_ep.get(inner_key, [])
+            cur_list = cur_ep.get(inner_key, [])
+
+            new_list = []
+            for tpl_idx, tpl_cfg in enumerate(template_cats):
+                col_idx = tpl_cfg["column_index"]
+                if tpl_idx >= len(tpl_list):
+                    continue
+                tpl_emb = tpl_list[tpl_idx]
+
+                if col_idx in current_cat_by_col:
+                    cur_pos, _ = current_cat_by_col[col_idx]
+                    if cur_pos < len(cur_list):
+                        # Existing categorical: expand cardinality rows if needed
+                        cur_emb = {k: v for k, v in cur_list[cur_pos].items()}
+                        _sync_and_expand_dist_params(cur_emb, tpl_emb)
+                        new_list.append(cur_emb)
+                    else:
+                        new_list.append({k: v for k, v in tpl_emb.items()})
+                else:
+                    # New categorical feature: copy embedding from template
+                    new_list.append({k: v for k, v in tpl_emb.items()})
+
+            if current_model_params.get(outer_key) is None:
+                current_model_params[outer_key] = {}
+            current_model_params[outer_key][inner_key] = new_list
+
+
 def _validate_hidden_dims(
     src_dims: List[int],
     tgt_dims: List[int],
@@ -583,11 +684,26 @@ def _expand_with_template_weights(
                     current_action["models"][model_idx]["model_params"],
                     template_action["models"][model_idx]["model_params"],
                 )
+                _expand_embedding_params(
+                    current_action["models"][model_idx]["model_params"],
+                    template_action["models"][model_idx]["model_params"],
+                    current_action["models"][model_idx]["feature_config"],
+                    template_action["models"][model_idx]["feature_config"],
+                    action_id,
+                    model_idx,
+                )
         elif isinstance(action_model, BaseBayesianNeuralNetwork):
             # Single-objective BNN
             _expand_bnn_weights(
                 current_action["model_params"],
                 template_action["model_params"],
+            )
+            _expand_embedding_params(
+                current_action["model_params"],
+                template_action["model_params"],
+                current_action["feature_config"],
+                template_action["feature_config"],
+                action_id,
             )
         else:
             raise TypeError(
@@ -637,8 +753,11 @@ def edit_model_on_the_fly(
     - More input features, same hidden dims: expands first-layer input rows from template
     - Same input features, larger hidden dims: expands all layers' output columns from template
     - Both more features and larger hidden dims: expands rows and columns simultaneously
+    - New categorical feature appended to feature vector: embedding copied from template
+    - Grown cardinality (same embedding_dim): new category rows appended to embedding from template
     - Fewer input features: raises ValueError (cannot reduce dimensions)
     - Smaller hidden dims: raises ValueError (cannot reduce hidden dimensions)
+    - Changed embedding_dim on existing categorical: raises ValueError (requires retraining)
 
     The resulting MAB will have:
     - Actions: All actions from new_mab

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybandits"
-version = "7.4.0"
+version = "7.4.1"
 description = "Python Multi-Armed Bandit Library"
 authors = [
     "Dario d'Andrea <dariod@playtika.com>",

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -24,6 +24,7 @@
 
 import json
 import logging
+import math
 from typing import Any, Dict, List, Tuple
 
 import numpy as np
@@ -1029,6 +1030,353 @@ class TestHiddenDimExpansion:
         )
         template = CmabBernoulli.cold_start(
             action_ids={"a2"}, n_features=_N_FEATURES, hidden_dim_list=new_hidden, strategy=ClassicBandit()
+        )
+        result = edit_model_on_the_fly(current, template)
+        assert set(result.actions.keys()) == {"a2"}
+
+
+class TestCategoricalFeatureExpansion:
+    """Tests for categorical feature embedding expansion via edit_model_on_the_fly."""
+
+    _CAT_COLUMN = 2  # a valid column index given _N_FEATURES = 5
+    _CAT_OLD_CARDINALITY = 5  # embedding_dim = ceil(5/4) = 2
+    _CAT_INCOMPATIBLE_CARDINALITY = 4  # embedding_dim = ceil(4/4) = 1 — different from old=5
+
+    @st.composite
+    def _compatible_grow_scenario(draw: st.DrawFn) -> Tuple[str, int, int, int, int]:
+        """Draw (action_id, n_features, cat_col, old_cardinality, new_cardinality) with same embedding_dim."""
+        action_id = draw(single_action_id_strategy)
+        n_features = draw(st.integers(min_value=2, max_value=6))
+        cat_col = draw(st.integers(min_value=0, max_value=n_features - 1))
+        # Pick a dimension bin (divisor=4); draw old < new within that bin so embedding_dim is preserved
+        dim = draw(st.integers(min_value=1, max_value=3))
+        low, high = 4 * (dim - 1) + 1, 4 * dim
+        old_cardinality = draw(st.integers(min_value=low, max_value=high - 1))
+        new_cardinality = draw(st.integers(min_value=old_cardinality + 1, max_value=high))
+        return action_id, n_features, cat_col, old_cardinality, new_cardinality
+
+    @st.composite
+    def _add_cat_scenario(draw: st.DrawFn) -> Tuple[str, int, int, int]:
+        """Draw (action_id, n_features, new_cat_col, new_cat_cardinality) for adding a new categorical."""
+        action_id = draw(single_action_id_strategy)
+        n_features = draw(st.integers(min_value=2, max_value=6))
+        new_cat_col = draw(st.integers(min_value=0, max_value=n_features - 1))
+        new_cat_cardinality = draw(st.integers(min_value=1, max_value=12))
+        return action_id, n_features, new_cat_col, new_cat_cardinality
+
+    @st.composite
+    def _incompatible_cardinality_scenario(draw: st.DrawFn) -> Tuple[str, int, int, int, int]:
+        """Draw (action_id, n_features, cat_col, old_cardinality, new_cardinality) with DIFFERENT embedding_dims."""
+        action_id = draw(single_action_id_strategy)
+        n_features = draw(st.integers(min_value=2, max_value=6))
+        cat_col = draw(st.integers(min_value=0, max_value=n_features - 1))
+        dim_old = draw(st.integers(min_value=1, max_value=3))
+        dim_new = draw(st.integers(min_value=1, max_value=3).filter(lambda d: d != dim_old))
+        old_cardinality = draw(st.integers(min_value=4 * (dim_old - 1) + 1, max_value=4 * dim_old))
+        new_cardinality = draw(st.integers(min_value=4 * (dim_new - 1) + 1, max_value=4 * dim_new))
+        return action_id, n_features, cat_col, old_cardinality, new_cardinality
+
+    # ------------------------------------------------------------------
+    # Grow cardinality — same embedding_dim
+    # ------------------------------------------------------------------
+
+    @given(scenario=_compatible_grow_scenario())
+    def test_grow_cardinality_embedding_shape_correct_so(self, scenario: Tuple[str, int, int, int, int]) -> None:
+        """Grown cardinality produces an embedding of the correct shape for SO CMAB."""
+        action_id, n_features, cat_col, old_cardinality, new_cardinality = scenario
+        current = CmabBernoulli.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            categorical_features={cat_col: old_cardinality},
+            strategy=ClassicBandit(),
+        )
+        template = CmabBernoulli.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            categorical_features={cat_col: new_cardinality},
+            strategy=ClassicBandit(),
+        )
+        result = edit_model_on_the_fly(current, template)
+        result_emb = result.actions[action_id].model_params.embedding_params.embeddings[0]
+        expected_dim = math.ceil(new_cardinality / BaseBayesianNeuralNetwork._embedding_dim_divisor)
+        assert result_emb.shape == (new_cardinality, expected_dim)
+
+    @given(scenario=_compatible_grow_scenario(), n_objectives=n_objectives_strategy)
+    def test_grow_cardinality_embedding_shape_correct_mo(
+        self, scenario: Tuple[str, int, int, int, int], n_objectives: int
+    ) -> None:
+        """Grown cardinality produces an embedding of the correct shape for MO CMAB."""
+        action_id, n_features, cat_col, old_cardinality, new_cardinality = scenario
+        current = CmabBernoulliMO.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            n_objectives=n_objectives,
+            categorical_features={cat_col: old_cardinality},
+            strategy=MultiObjectiveBandit(),
+        )
+        template = CmabBernoulliMO.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            n_objectives=n_objectives,
+            categorical_features={cat_col: new_cardinality},
+            strategy=MultiObjectiveBandit(),
+        )
+        result = edit_model_on_the_fly(current, template)
+        expected_dim = math.ceil(new_cardinality / BaseBayesianNeuralNetwork._embedding_dim_divisor)
+        for obj_model in result.actions[action_id].models:
+            result_emb = obj_model.model_params.embedding_params.embeddings[0]
+            assert result_emb.shape == (new_cardinality, expected_dim)
+
+    @given(scenario=_compatible_grow_scenario())
+    def test_grow_cardinality_preserves_existing_rows(self, scenario: Tuple[str, int, int, int, int]) -> None:
+        """Embedding rows for existing categories are preserved unchanged after cardinality grows."""
+        action_id, n_features, cat_col, old_cardinality, new_cardinality = scenario
+        current = CmabBernoulli.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            categorical_features={cat_col: old_cardinality},
+            strategy=ClassicBandit(),
+        )
+        template = CmabBernoulli.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            categorical_features={cat_col: new_cardinality},
+            strategy=ClassicBandit(),
+        )
+        current_emb = current.actions[action_id].model_params.embedding_params.embeddings[0]
+        result = edit_model_on_the_fly(current, template)
+        result_emb = result.actions[action_id].model_params.embedding_params.embeddings[0]
+        assert result_emb.mu[:old_cardinality] == current_emb.mu
+        assert result_emb.sigma[:old_cardinality] == current_emb.sigma
+
+    @given(scenario=_compatible_grow_scenario())
+    def test_grow_cardinality_new_rows_from_template(self, scenario: Tuple[str, int, int, int, int]) -> None:
+        """Rows for new categories come from the template embedding."""
+        action_id, n_features, cat_col, old_cardinality, new_cardinality = scenario
+        current = CmabBernoulli.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            categorical_features={cat_col: old_cardinality},
+            strategy=ClassicBandit(),
+        )
+        template = CmabBernoulli.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            categorical_features={cat_col: new_cardinality},
+            strategy=ClassicBandit(),
+        )
+        template_emb = template.actions[action_id].model_params.embedding_params.embeddings[0]
+        result = edit_model_on_the_fly(current, template)
+        result_emb = result.actions[action_id].model_params.embedding_params.embeddings[0]
+        assert result_emb.mu[old_cardinality:] == template_emb.mu[old_cardinality:]
+        assert result_emb.sigma[old_cardinality:] == template_emb.sigma[old_cardinality:]
+
+    @given(scenario=_compatible_grow_scenario())
+    def test_grow_cardinality_feature_config_updated(self, scenario: Tuple[str, int, int, int, int]) -> None:
+        """feature_config cardinality reflects the template's new cardinality."""
+        action_id, n_features, cat_col, old_cardinality, new_cardinality = scenario
+        current = CmabBernoulli.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            categorical_features={cat_col: old_cardinality},
+            strategy=ClassicBandit(),
+        )
+        template = CmabBernoulli.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            categorical_features={cat_col: new_cardinality},
+            strategy=ClassicBandit(),
+        )
+        result = edit_model_on_the_fly(current, template)
+        cat_cfg = result.actions[action_id].feature_config.categorical_features_configs[0]
+        assert cat_cfg.cardinality == new_cardinality
+        assert cat_cfg.column_index == cat_col
+
+    # ------------------------------------------------------------------
+    # Add new categorical feature
+    # ------------------------------------------------------------------
+
+    @given(scenario=_add_cat_scenario())
+    def test_add_new_categorical_embedding_created_so(self, scenario: Tuple[str, int, int, int]) -> None:
+        """Adding a new categorical feature creates embedding_params where there were none for SO."""
+        action_id, n_features, new_cat_col, new_cat_cardinality = scenario
+        current = CmabBernoulli.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            strategy=ClassicBandit(),
+        )
+        template = CmabBernoulli.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            categorical_features={new_cat_col: new_cat_cardinality},
+            strategy=ClassicBandit(),
+        )
+        assert current.actions[action_id].model_params.embedding_params is None
+        result = edit_model_on_the_fly(current, template)
+        assert result.actions[action_id].model_params.embedding_params is not None
+        assert len(result.actions[action_id].model_params.embedding_params.embeddings) == 1
+
+    @given(scenario=_add_cat_scenario(), n_objectives=n_objectives_strategy)
+    def test_add_new_categorical_embedding_created_mo(
+        self, scenario: Tuple[str, int, int, int], n_objectives: int
+    ) -> None:
+        """Adding a new categorical feature creates embedding_params for each objective in MO."""
+        action_id, n_features, new_cat_col, new_cat_cardinality = scenario
+        current = CmabBernoulliMO.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            n_objectives=n_objectives,
+            strategy=MultiObjectiveBandit(),
+        )
+        template = CmabBernoulliMO.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            n_objectives=n_objectives,
+            categorical_features={new_cat_col: new_cat_cardinality},
+            strategy=MultiObjectiveBandit(),
+        )
+        for obj_model in current.actions[action_id].models:
+            assert obj_model.model_params.embedding_params is None
+        result = edit_model_on_the_fly(current, template)
+        for obj_model in result.actions[action_id].models:
+            assert obj_model.model_params.embedding_params is not None
+            assert len(obj_model.model_params.embedding_params.embeddings) == 1
+
+    @given(scenario=_add_cat_scenario())
+    def test_add_new_categorical_embedding_values_from_template(self, scenario: Tuple[str, int, int, int]) -> None:
+        """New categorical feature embedding values are copied exactly from the template."""
+        action_id, n_features, new_cat_col, new_cat_cardinality = scenario
+        current = CmabBernoulli.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            strategy=ClassicBandit(),
+        )
+        template = CmabBernoulli.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            categorical_features={new_cat_col: new_cat_cardinality},
+            strategy=ClassicBandit(),
+        )
+        template_emb = template.actions[action_id].model_params.embedding_params.embeddings[0]
+        result = edit_model_on_the_fly(current, template)
+        result_emb = result.actions[action_id].model_params.embedding_params.embeddings[0]
+        assert result_emb.mu == template_emb.mu
+        assert result_emb.sigma == template_emb.sigma
+
+    @given(scenario=_add_cat_scenario())
+    def test_add_new_categorical_embedding_shape_correct(self, scenario: Tuple[str, int, int, int]) -> None:
+        """New categorical embedding has shape (cardinality, embedding_dim)."""
+        action_id, n_features, new_cat_col, new_cat_cardinality = scenario
+        current = CmabBernoulli.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            strategy=ClassicBandit(),
+        )
+        template = CmabBernoulli.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            categorical_features={new_cat_col: new_cat_cardinality},
+            strategy=ClassicBandit(),
+        )
+        result = edit_model_on_the_fly(current, template)
+        result_emb = result.actions[action_id].model_params.embedding_params.embeddings[0]
+        expected_dim = math.ceil(new_cat_cardinality / BaseBayesianNeuralNetwork._embedding_dim_divisor)
+        assert result_emb.shape == (new_cat_cardinality, expected_dim)
+
+    @given(
+        action_id=single_action_id_strategy,
+        n_features=n_features_strategy,
+        new_cat_cardinality=st.integers(min_value=1, max_value=12),
+        extra_features=st.integers(min_value=1, max_value=4),
+    )
+    def test_add_new_categorical_with_extra_n_features(
+        self, action_id: str, n_features: int, new_cat_cardinality: int, extra_features: int
+    ) -> None:
+        """Adding a categorical when n_features also grows works: weight and embedding both expand."""
+        new_n_features = n_features + extra_features
+        new_cat_col = n_features  # first new column, valid index in the larger feature set
+        current = CmabBernoulli.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            strategy=ClassicBandit(),
+        )
+        template = CmabBernoulli.cold_start(
+            action_ids={action_id},
+            n_features=new_n_features,
+            categorical_features={new_cat_col: new_cat_cardinality},
+            strategy=ClassicBandit(),
+        )
+        result = edit_model_on_the_fly(current, template)
+        assert result.actions[action_id].input_dim == new_n_features
+        assert result.actions[action_id].model_params.embedding_params is not None
+        result_emb = result.actions[action_id].model_params.embedding_params.embeddings[0]
+        expected_dim = math.ceil(new_cat_cardinality / BaseBayesianNeuralNetwork._embedding_dim_divisor)
+        assert result_emb.shape == (new_cat_cardinality, expected_dim)
+
+    # ------------------------------------------------------------------
+    # Error cases
+    # ------------------------------------------------------------------
+
+    @given(scenario=_incompatible_cardinality_scenario())
+    def test_embedding_dim_change_raises_value_error(self, scenario: Tuple[str, int, int, int, int]) -> None:
+        """Changing embedding_dim (incompatible cardinalities on the same column) raises ValueError."""
+        action_id, n_features, cat_col, old_cardinality, new_cardinality = scenario
+        current = CmabBernoulli.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            categorical_features={cat_col: old_cardinality},
+            strategy=ClassicBandit(),
+        )
+        template = CmabBernoulli.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            categorical_features={cat_col: new_cardinality},
+            strategy=ClassicBandit(),
+        )
+        with pytest.raises(ValueError, match="embedding_dim"):
+            edit_model_on_the_fly(current, template)
+
+    @given(scenario=_incompatible_cardinality_scenario())
+    def test_embedding_dim_change_raises_value_error_mo(self, scenario: Tuple[str, int, int, int, int]) -> None:
+        """MO: changing embedding_dim on the same column raises ValueError through the MO loop."""
+        action_id, n_features, cat_col, old_cardinality, new_cardinality = scenario
+        current = CmabBernoulliMO.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            categorical_features={cat_col: old_cardinality},
+            n_objectives=2,
+            strategy=MultiObjectiveBandit(),
+        )
+        template = CmabBernoulliMO.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            categorical_features={cat_col: new_cardinality},
+            n_objectives=2,
+            strategy=MultiObjectiveBandit(),
+        )
+        with pytest.raises(ValueError, match="embedding_dim"):
+            edit_model_on_the_fly(current, template)
+
+    def test_non_overlapping_action_no_embedding_expansion(
+        self,
+        action_id: str = _ACTION_ID,
+        n_features: int = _N_FEATURES,
+        cat_col: int = _CAT_COLUMN,
+        old_cardinality: int = _CAT_OLD_CARDINALITY,
+        incompatible_cardinality: int = _CAT_INCOMPATIBLE_CARDINALITY,
+    ) -> None:
+        """Incompatible categoricals on non-overlapping actions do not raise errors."""
+        current = CmabBernoulli.cold_start(
+            action_ids={action_id},
+            n_features=n_features,
+            categorical_features={cat_col: old_cardinality},
+            strategy=ClassicBandit(),
+        )
+        template = CmabBernoulli.cold_start(
+            action_ids={"a2"},
+            n_features=n_features,
+            categorical_features={cat_col: incompatible_cardinality},
+            strategy=ClassicBandit(),
         )
         result = edit_model_on_the_fly(current, template)
         assert set(result.actions.keys()) == {"a2"}


### PR DESCRIPTION
### Changes:

* Add `categorical_features` param to `BaseBayesianNeuralNetworkMO.cold_start()` — forwards to each per-objective BNN at construction
* Add `_expand_embedding_params()` to `pybandits/transfer.py` — handles two scenarios: new categorical feature (embedding copied from template) and grown cardinality with same `embedding_dim` (new rows appended); raises `ValueError` if `embedding_dim` changes
* Update `_expand_with_template_weights()` to call `_expand_embedding_params()` for both SO and MO BNN models after weight expansion
* Update `edit_model_on_the_fly()` docstring to list categorical expansion cases and new `ValueError` condition
* Add `TestCategoricalFeatureExpansion` class to `tests/test_transfer.py` — covers grow-cardinality (SO/MO), add-new-categorical (SO/MO), incompatible-embedding-dim error (SO/MO), and no-op when template has no categoricals


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for categorical feature configurations in multi-objective cold starts (`column_index: cardinality`).

* **Bug Fixes**
  * Enhanced “edit model on the fly” updates to correctly copy, expand, and initialize categorical embedding parameters when cardinality grows.
  * Now validates embedding dimension compatibility and raises an error for incompatible categorical embedding changes.

* **Tests**
  * Added comprehensive test coverage for categorical embedding expansion behavior across single- and multi-objective scenarios and failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->