### PR TITLE
Add limited actions exploration throttle

### DIFF
--- a/pybandits/mab.py
+++ b/pybandits/mab.py
@@ -105,6 +105,14 @@ class BaseMab(PyBanditsBaseModel, ABC):
             - `default_action_fraction = 1.0`: explore always returns `default_action` (same as omitting this field).
             - `None` (default): legacy behavior; explore returns `default_action` deterministically when set,
               otherwise a uniformly-random action.
+    limited_actions : Optional[Set[ActionId]], None if not specified.
+        A set of actions whose selection is throttled, e.g. newly-introduced arms that Thompson Sampling
+        would otherwise over-explore. On each selection they are allowed to compete only with probability
+        `limited_action_fraction`; otherwise they are masked out. Must be used together with
+        `limited_action_fraction`, must be a subset of the action set, and must not contain `default_action`.
+    limited_action_fraction : Optional[Float01], None if not specified.
+        Probability that the `limited_actions` are allowed to compete on a given selection (mirrors
+        `epsilon`: higher = more exploration). Only meaningful together with `limited_actions`.
     current_supported_version_th : ClassVar[str]
         The threshold of the supported version of PyBandits which don't require any changes to the state.
     strategy_kwargs : Dict[str, Any]
@@ -117,6 +125,8 @@ class BaseMab(PyBanditsBaseModel, ABC):
     epsilon: Optional[Float01] = None
     default_action: Optional[UnifiedActionId] = None
     default_action_fraction: Optional[PositiveFloat01] = None
+    limited_actions: Optional[Set[ActionId]] = None
+    limited_action_fraction: Optional[Float01] = None
     version: Optional[str] = None
     random_seed: Optional[NonNegativeInt] = None
     _current_supported_version_th: ClassVar[str] = _get_pybandits_version()
@@ -125,8 +135,10 @@ class BaseMab(PyBanditsBaseModel, ABC):
     def __init__(
         self,
         epsilon: Optional[Float01] = None,
-        default_action: Optional[ActionId] = None,
+        default_action: Optional[UnifiedActionId] = None,
         default_action_fraction: Optional[PositiveFloat01] = None,
+        limited_actions: Optional[Set[ActionId]] = None,
+        limited_action_fraction: Optional[Float01] = None,
         version: Optional[str] = None,
         random_seed: Optional[NonNegativeInt] = None,
         **kwargs,
@@ -149,6 +161,8 @@ class BaseMab(PyBanditsBaseModel, ABC):
             epsilon=epsilon,
             default_action=default_action,
             default_action_fraction=default_action_fraction,
+            limited_actions=limited_actions,
+            limited_action_fraction=limited_action_fraction,
             version=version,
             random_seed=random_seed,
         )
@@ -206,6 +220,13 @@ class BaseMab(PyBanditsBaseModel, ABC):
             and not isinstance(self.actions[self.default_action], (Model, ModelMO))
         ):
             raise AttributeError("Standard default action requires a standard action model.")
+        if bool(self.limited_actions) != (self.limited_action_fraction is not None):
+            raise AttributeError("limited_actions and limited_action_fraction must be defined together.")
+        if self.limited_actions:
+            if not self.limited_actions.issubset(self.actions):
+                raise AttributeError("limited_actions must be a subset of the action set.")
+            if self.default_action in self.limited_actions:
+                raise AttributeError("default_action must not be a limited action.")
 
     ############################################# Method Input Validators ##############################################
 
@@ -510,6 +531,11 @@ class BaseMab(PyBanditsBaseModel, ABC):
             If self.default_action is not present as a key in the probabilities dictionary.
         """
 
+        if self.limited_actions and not self._rng.binomial(1, self.limited_action_fraction):
+            masked = {k: v for k, v in p.items() if (k[0] if isinstance(k, tuple) else k) not in self.limited_actions}
+            if masked:  # never mask away the entire action set
+                p = masked
+
         if self.epsilon:
             if self.default_action:
                 if isinstance(self.default_action, tuple):
@@ -653,8 +679,10 @@ class BaseMab(PyBanditsBaseModel, ABC):
     def cold_start(
         cls,
         epsilon: Optional[Float01] = None,
-        default_action: Optional[ActionId] = None,
+        default_action: Optional[UnifiedActionId] = None,
         default_action_fraction: Optional[PositiveFloat01] = None,
+        limited_actions: Optional[Set[ActionId]] = None,
+        limited_action_fraction: Optional[Float01] = None,
         random_seed: Optional[NonNegativeInt] = None,
         **kwargs,
     ) -> Self:
@@ -673,6 +701,14 @@ class BaseMab(PyBanditsBaseModel, ABC):
             Probability of picking `default_action` (vs a uniformly-random action) when the explore
             branch of epsilon-greedy fires. Requires both `epsilon` and `default_action` to be set.
             `1.0` always returns `default_action`; `None` (default) preserves legacy behavior.
+        limited_actions : Optional[Set[ActionId]]
+            Actions whose selection is throttled (e.g. newly-introduced arms). On each selection they
+            are allowed to compete only with probability `limited_action_fraction`. Requires
+            `limited_action_fraction`, must be a subset of the action set, and must not contain
+            `default_action`.
+        limited_action_fraction : Optional[Float01]
+            Probability that `limited_actions` are allowed to compete on a given selection (higher =
+            more exploration). Requires `limited_actions`.
         random_seed : Optional[NonNegativeInt]
             Seed for the MAB's central numpy RNG (used for epsilon-greedy and Thompson sampling).
             Propagated automatically to BNN action models so the full pipeline is reproducible.
@@ -690,6 +726,8 @@ class BaseMab(PyBanditsBaseModel, ABC):
             epsilon=epsilon,
             default_action=default_action,
             default_action_fraction=default_action_fraction,
+            limited_actions=limited_actions,
+            limited_action_fraction=limited_action_fraction,
             random_seed=random_seed,
             **kwargs,
         )

--- a/pybandits/meta_model.py
+++ b/pybandits/meta_model.py
@@ -225,6 +225,9 @@ class BaseMetaModel(PyBanditsBaseModel, ABC):
         inner_quantitative_action_ids = quantitative_action_ids or set(quantitative_action_specific_kwargs)
         if not inner_action_ids and not inner_quantitative_action_ids:
             raise AttributeError("At least one action should be defined.")
+        overlap = set(inner_action_ids) & set(inner_quantitative_action_ids)
+        if overlap:
+            raise AttributeError(f"Actions cannot be both regular and quantitative: {overlap}.")
         (
             model_cold_start,
             quantitative_model_cold_start,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybandits"
-version = "7.5.0"
+version = "7.5.1"
 description = "Python Multi-Armed Bandit Library"
 authors = [
     "Dario d'Andrea <dariod@playtika.com>",

--- a/tests/test_actions_manager.py
+++ b/tests/test_actions_manager.py
@@ -68,12 +68,12 @@ class DummyActionsManager(ActionsManager):
 @given(
     data_len=st.integers(min_value=1, max_value=100),
 )
-def test_update_with_invalid_memory_delta_none(data_len):
+def test_update_with_invalid_memory_delta_none(data_len, rng):
     """Test update validation when delta is None but memory is provided"""
     actions = {"action1": Beta(), "action2": Beta()}
     manager = DummyActionsManager(actions=actions, delta=REFERENCE_DELTA)
-    action_list = np.random.choice(["action1", "action2"], size=data_len).tolist()
-    rewards = np.random.randint(0, 2, size=data_len).tolist()
+    action_list = rng.choice(["action1", "action2"], size=data_len).tolist()
+    rewards = rng.integers(0, 2, size=data_len).tolist()
     with pytest.raises(ValueError):
         manager.update(actions=action_list, rewards=rewards, actions_memory=action_list, rewards_memory=rewards)
 
@@ -105,10 +105,10 @@ _UPDATE_RESERVED_PARAMS = {"actions", "rewards", "self", "quantities", "context"
         min_size=1,
     ),
 )
-def test_update_kwargs_separation(data_len, regular_kwargs, memory_kwargs, monkeymodule):
+def test_update_kwargs_separation(data_len, regular_kwargs, memory_kwargs, monkeymodule, rng):
     """Test proper separation of regular and memory kwargs"""
-    action_list = np.random.choice(["action1", "action2"], size=data_len).tolist()
-    rewards = np.random.randint(0, 2, size=data_len).tolist()
+    action_list = rng.choice(["action1", "action2"], size=data_len).tolist()
+    rewards = rng.integers(0, 2, size=data_len).tolist()
     actions = {"action1": Beta(), "action2": Beta()}
     manager = DummyActionsManager(actions=actions, delta=REFERENCE_DELTA)
     all_kwargs = {**regular_kwargs, **memory_kwargs}
@@ -328,9 +328,9 @@ def test_cmab_manager_update(context, context_memory, n_features, other_reward, 
 
 
 @given(st.integers(min_value=1, max_value=1000), st.integers(min_value=1, max_value=100))
-def test_check_context_matrix(n_samples, n_features):
+def test_check_context_matrix(rng, n_samples, n_features):
     # context is numpy array
-    context = np.random.uniform(low=-100.0, high=100.0, size=(n_samples, n_features))
+    context = rng.uniform(low=-100.0, high=100.0, size=(n_samples, n_features))
     CmabActionsManager._check_context_matrix(context=context)
 
     # raise an error for numpy arrays that cannot be cast to float
@@ -484,11 +484,11 @@ def test_slice_memory_empty_data():
 
 
 @given(data_len=st.integers(min_value=101, max_value=200), memory_len=st.integers(min_value=1, max_value=100))
-def test_slice_memory_maintains_last_elements(data_len, memory_len):
+def test_slice_memory_maintains_last_elements(data_len, memory_len, rng):
     actions = {"action1": Beta(), "action2": Beta()}
     manager = DummyActionsManager(actions=actions, delta=REFERENCE_DELTA)
-    actions_backup = np.random.choice(list(actions.keys()), size=data_len).tolist()
-    rewards_backup = np.random.randint(0, 2, size=data_len).tolist()  # Use range to verify order preservation
+    actions_backup = rng.choice(list(actions.keys()), size=data_len).tolist()
+    rewards_backup = rng.integers(0, 2, size=data_len).tolist()  # Use range to verify order preservation
     context_backup = list(range(data_len))
     memory_kwargs = {"context_memory": context_backup.copy()}
 
@@ -509,7 +509,9 @@ def test_slice_memory_maintains_last_elements(data_len, memory_len):
 
 
 # ActionsManager._maybe_trim_memory functionality tests
-def test_memory_trim_when_too_long(mocker: MockerFixture, trials=(3, 3), successes=(2, 1), extra_len=5):
+def test_memory_trim_when_too_long(
+    mocker: MockerFixture, rng: np.random.Generator, trials=(3, 3), successes=(2, 1), extra_len=5
+):
     actions = {"action1": Beta(), "action2": Beta()}
     manager = DummyActionsManager(actions=actions, delta=REFERENCE_DELTA)
     # Mock _extract_current_stats_for_action to return known values
@@ -523,19 +525,17 @@ def test_memory_trim_when_too_long(mocker: MockerFixture, trials=(3, 3), success
     )
 
     actions_memory = (
-        np.random.choice(["action1", "action2"], size=extra_len).tolist()
-        + ["action1"] * trials[0]
-        + ["action2"] * trials[1]
+        rng.choice(["action1", "action2"], size=extra_len).tolist() + ["action1"] * trials[0] + ["action2"] * trials[1]
     )
     rewards_memory = (
-        np.random.randint(0, 2, size=extra_len).tolist()
+        rng.integers(0, 2, size=extra_len).tolist()
         + [1] * successes[0]
         + [0] * (trials[0] - successes[0])
         + [1] * successes[1]
         + [0] * (trials[1] - successes[1])
     )
     shuffled_indexes = list(range(-sum(trials), 0))
-    np.random.shuffle(shuffled_indexes)
+    rng.shuffle(shuffled_indexes)
     temp_actions = [actions_memory[i] for i in shuffled_indexes]
     temp_rewards = [rewards_memory[i] for i in shuffled_indexes]
     actions_memory[-sum(trials) :] = temp_actions
@@ -899,13 +899,13 @@ def actions(names=("action1", "action2")):
     ],
 )
 def test_update_adaptive_window_size_validation(
-    actions, delta, actions_memory, rewards_memory, expected_exception, expected_message
+    actions, delta, actions_memory, rewards_memory, expected_exception, expected_message, rng
 ):
     """Test update validation for adaptive window size scenarios."""
     manager = DummyActionsManager(actions=actions, delta=delta)
 
     action_list = list(actions.keys())
-    rewards = np.random.randint(0, 2, size=len(action_list)).tolist()
+    rewards = rng.integers(0, 2, size=len(action_list)).tolist()
 
     if expected_exception is AttributeError:
         with pytest.raises(expected_exception, match=expected_message):

--- a/tests/test_cmab.py
+++ b/tests/test_cmab.py
@@ -171,12 +171,13 @@ class ModelTestConfig:
         n_features: PositiveInt,
         hidden_dim_list: List[int],
         update_method: UpdateMethods,
+        rng: np.random.Generator,
         n_objectives: Optional[PositiveInt] = None,
         decay_factor: Optional[Float01] = None,
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         model_types = list(self.model_types)
         if len(model_types) < len(action_ids):
-            indices = np.random.randint(0, len(model_types), len(action_ids))
+            indices = rng.integers(0, len(model_types), len(action_ids))
             model_types = [model_types[i] for i in indices]
         if all(
             model in [BayesianNeuralNetworkCC, BayesianNeuralNetworkMOCC, QuantitativeBayesianNeuralNetworkCC]
@@ -276,7 +277,10 @@ class ModelTestConfig:
         n_features: PositiveInt,
         hidden_dim_list: List[int],
         update_method: UpdateMethods,
+        rng: np.random.Generator,
         decay_factor: Optional[Float01] = None,
+        default_action_fraction: Optional[Float01] = None,
+        limited_action_fraction: Optional[Float01] = None,
     ) -> Tuple[BaseCmabBernoulli, Dict[ActionId, CmabModelType], Dict[str, Any]]:
         n_objectives = (
             n_objectives.draw(st.integers(min_value=1, max_value=10))
@@ -284,18 +288,25 @@ class ModelTestConfig:
             else None
         )
         actions, base_model_cold_start_kwargs = self._create_actions(
-            action_ids, values, n_features, hidden_dim_list, update_method, n_objectives, decay_factor
+            action_ids, values, n_features, hidden_dim_list, update_method, rng, n_objectives, decay_factor
         )
         default_action = action_ids[0] if epsilon and not delta else None
         if default_action and isinstance(actions[default_action], QuantitativeModel):
-            default_action = (default_action, tuple(np.random.random(actions[default_action].dimension)))
+            default_action = (default_action, tuple(rng.random(actions[default_action].dimension)))
         epsilon = epsilon if not delta else 0.1
+        # default_action_fraction requires a default_action; limited_actions is derived from the
+        # action set (excluding default_action) exactly as default_action is derived from epsilon.
+        default_action_fraction = default_action_fraction if default_action else None
+        limited_actions = {action_ids[-1]} if limited_action_fraction is not None else None
         kwargs = {
             k: v
             for k, v in {
                 "epsilon": epsilon,
                 "default_action": default_action,
                 "delta": delta,
+                "default_action_fraction": default_action_fraction,
+                "limited_actions": limited_actions,
+                "limited_action_fraction": limited_action_fraction,
             }.items()
             if v is not None
         }
@@ -362,6 +373,8 @@ TEST_CONFIGS = {
         unique=True,
     ),
     epsilon=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
+    default_action_fraction=st.one_of(st.none(), st.floats(min_value=1e-3, max_value=1)),
+    limited_action_fraction=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
     delta=st.one_of(st.none(), st.just(0.1)),
     values=st.data(),
     n_objectives=st.data(),
@@ -376,6 +389,8 @@ def test_cold_start(
     config: ModelTestConfig,
     action_ids: List[str],
     epsilon: Optional[float],
+    default_action_fraction: Optional[float],
+    limited_action_fraction: Optional[float],
     delta,
     values,
     n_objectives,
@@ -385,6 +400,7 @@ def test_cold_start(
     subsidy_factor,
     update_method,
     decay_factor: Optional[float],
+    rng,
 ):
     # Create CMAB instance
     cmab, actions, kwargs = config.create_cmab_and_actions(
@@ -398,7 +414,10 @@ def test_cold_start(
         n_features,
         hidden_dim_list,
         update_method,
+        rng,
         decay_factor,
+        default_action_fraction=default_action_fraction,
+        limited_action_fraction=limited_action_fraction,
     )
 
     # Cold start comparison logic (modified for different model types)
@@ -464,6 +483,7 @@ def test_bad_initialization(
     exploit_p,
     subsidy_factor,
     update_method,
+    rng,
 ):
     """Test various invalid initialization scenarios for CMAB models"""
     real_n_objectives = n_objectives.draw(st.integers(min_value=1, max_value=10))
@@ -552,6 +572,7 @@ def test_bad_initialization(
                 n_features,
                 hidden_dim_list,
                 update_method,
+                rng,
             )
     elif config.cmab_class == CmabBernoulliCC:
         with pytest.raises(ValidationError):
@@ -566,6 +587,7 @@ def test_bad_initialization(
                 n_features,
                 hidden_dim_list,
                 update_method,
+                rng,
             )
     # Test multi-objective specific cases
     if hasattr(config.model_types[0], "models"):
@@ -592,6 +614,8 @@ def test_bad_initialization(
     ),
     n_samples=st.integers(min_value=1, max_value=5),
     epsilon=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
+    default_action_fraction=st.one_of(st.none(), st.floats(min_value=1e-3, max_value=1)),
+    limited_action_fraction=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
     delta=st.one_of(st.none(), st.just(0.1)),
     values=st.data(),
     n_objectives=st.data(),
@@ -607,6 +631,8 @@ def test_update(
     action_ids: List[str],
     n_samples: int,
     epsilon: Optional[float],
+    default_action_fraction: Optional[float],
+    limited_action_fraction: Optional[float],
     delta,
     values,
     n_objectives,
@@ -616,6 +642,7 @@ def test_update(
     subsidy_factor,
     update_method,
     memory_len,
+    rng,
 ):
     # Create CMAB instance
     cmab, _, kwargs = config.create_cmab_and_actions(
@@ -629,16 +656,19 @@ def test_update(
         n_features,
         hidden_dim_list,
         update_method,
+        rng,
+        default_action_fraction=default_action_fraction,
+        limited_action_fraction=limited_action_fraction,
     )
     # create patches
 
     n_objectives = kwargs.get("n_objectives")
-    context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
+    context = rng.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
     # Generate random rewards
     reward_data = (
-        np.random.choice([0, 1], size=(n_samples, n_objectives), replace=True)
+        rng.choice([0, 1], size=(n_samples, n_objectives), replace=True)
         if n_objectives
-        else np.random.choice([0, 1], size=n_samples, replace=True)
+        else rng.choice([0, 1], size=n_samples, replace=True)
     )
     reward_data = reward_data.tolist()
     # Test updates with generated data
@@ -648,7 +678,7 @@ def test_update(
 
     for_update_kwargs = {"actions": actions_to_update, "rewards": reward_data}
     if any(isinstance(model, BaseQuantitativeBayesianNeuralNetwork) for model in cmab.actions.values()):
-        quantity_data = np.random.random(size=n_samples).tolist()
+        quantity_data = rng.random(size=n_samples).tolist()
         quantity_data = [
             q if isinstance(cmab.actions[action], QuantitativeModel) else None
             for q, action in zip(quantity_data, actions_to_update)
@@ -686,6 +716,8 @@ def test_update(
     ),
     n_samples=st.integers(min_value=1, max_value=100),
     epsilon=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
+    default_action_fraction=st.one_of(st.none(), st.floats(min_value=1e-3, max_value=1)),
+    limited_action_fraction=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
     delta=st.one_of(st.none(), st.just(0.1)),
     values=st.data(),
     n_objectives=st.data(),
@@ -701,6 +733,8 @@ def test_predict(
     action_ids: List[str],
     n_samples: int,
     epsilon: Optional[float],
+    default_action_fraction: Optional[float],
+    limited_action_fraction: Optional[float],
     delta,
     values,
     n_objectives,
@@ -711,16 +745,17 @@ def test_predict(
     update_method,
     diff,
     monkeymodule,
+    rng,
 ):
     def mock_maximize_by_quantity(quantity_score_func, dimension, constraint=None, n_trials=10000, **kwargs):
         """Mock maximize_by_quantity to return a quick result."""
-        return np.random.random(dimension)
+        return rng.random(dimension)
 
     if config.cmab_class in (CmabBernoulliMO, CmabBernoulliMOCC):
 
         def mock_find_pareto_front_normal_constraint(self, func, input_dim, n_objectives, n_divisions, model):
             """Mock _find_pareto_front_normal_constraint to return a quick result."""
-            return [np.random.random(input_dim) for _ in range(min(3, n_divisions))]
+            return [rng.random(input_dim) for _ in range(min(3, n_divisions))]
 
         monkeymodule.setattr(
             pybandits.strategy.MultiObjectiveStrategy,
@@ -741,8 +776,11 @@ def test_predict(
             n_features,
             hidden_dim_list,
             update_method,
+            rng,
+            default_action_fraction=default_action_fraction,
+            limited_action_fraction=limited_action_fraction,
         )[0]
-        context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
+        context = rng.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
 
         # Test predictions with random forbidden actions
         forbidden = set(sample_with_replacement(action_ids, len(action_ids) // 2)) if len(action_ids) > 2 else None
@@ -795,6 +833,8 @@ def test_predict(
         unique=True,
     ),
     epsilon=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
+    default_action_fraction=st.one_of(st.none(), st.floats(min_value=1e-3, max_value=1)),
+    limited_action_fraction=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
     delta=st.one_of(st.none(), st.just(0.1)),
     values=st.data(),
     n_objectives=st.data(),
@@ -809,6 +849,8 @@ def test_serialization(
     config: ModelTestConfig,
     action_ids: List[str],
     epsilon: Optional[float],
+    default_action_fraction: Optional[float],
+    limited_action_fraction: Optional[float],
     delta,
     values,
     n_objectives,
@@ -819,6 +861,7 @@ def test_serialization(
     update_method,
     diff,
     monkeymodule,
+    rng,
 ):
     # Create CMAB instance
     cmab = config.create_cmab_and_actions(
@@ -832,6 +875,9 @@ def test_serialization(
         n_features,
         hidden_dim_list,
         update_method,
+        rng,
+        default_action_fraction=default_action_fraction,
+        limited_action_fraction=limited_action_fraction,
     )[0]
 
     pre_update_state = deepcopy(cmab.get_state())
@@ -991,6 +1037,8 @@ def test_cmab_update_kwargs_migration(
         unique=True,
     ),
     epsilon=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
+    default_action_fraction=st.one_of(st.none(), st.floats(min_value=1e-3, max_value=1)),
+    limited_action_fraction=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
     delta=st.one_of(st.none(), st.just(0.1)),
     values=st.data(),
     n_objectives=st.data(),
@@ -1005,6 +1053,8 @@ def test_pickling(
     config: ModelTestConfig,
     action_ids: List[str],
     epsilon: Optional[float],
+    default_action_fraction: Optional[float],
+    limited_action_fraction: Optional[float],
     delta,
     values,
     n_objectives,
@@ -1015,6 +1065,7 @@ def test_pickling(
     update_method,
     diff,
     monkeymodule,
+    rng,
 ):
     # Create CMAB instance
     cmab = config.create_cmab_and_actions(
@@ -1028,6 +1079,9 @@ def test_pickling(
         n_features,
         hidden_dim_list,
         update_method,
+        rng,
+        default_action_fraction=default_action_fraction,
+        limited_action_fraction=limited_action_fraction,
     )[0]
     to_temporary_pickle(cmab)
     apply_mock_update(list(cmab.actions.values()))
@@ -1040,11 +1094,12 @@ def test_pickling(
     st.integers(min_value=1, max_value=100),
     st.just([3]),
 )
-def test_cmab_update_shape_mismatch(n_samples, n_features, hidden_dim_list):
-    actions = np.random.choice(["a1", "a2"], size=n_samples).tolist()
-    rewards = np.random.choice([0, 1], size=n_samples).tolist()
-    context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
-    quantities = np.random.uniform(low=0, high=1, size=n_samples).tolist()
+def test_cmab_update_shape_mismatch(rng, n_samples, n_features, hidden_dim_list):
+    actions = rng.choice(["a1", "a2"], size=n_samples).tolist()
+    actions[0] = "a1"  # ensure the quantitative arm is present so None-quantity checks trigger
+    rewards = rng.choice([0, 1], size=n_samples).tolist()
+    context = rng.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
+    quantities = rng.uniform(low=0, high=1, size=n_samples).tolist()
 
     mab = CmabBernoulli.cold_start(
         action_ids={"a1", "a2"},
@@ -1052,7 +1107,7 @@ def test_cmab_update_shape_mismatch(n_samples, n_features, hidden_dim_list):
         hidden_dim_list=hidden_dim_list,
     )
     quant_mab = CmabBernoulli.cold_start(
-        action_ids={"a1", "a2"}, n_features=n_features, hidden_dim_list=hidden_dim_list, quantitative_action_ids={"a1"}
+        action_ids={"a2"}, n_features=n_features, hidden_dim_list=hidden_dim_list, quantitative_action_ids={"a1"}
     )
     quantities = [
         q if isinstance(quant_mab.actions[action], QuantitativeModel) else None
@@ -1096,11 +1151,11 @@ def test_cmab_update_shape_mismatch(n_samples, n_features, hidden_dim_list):
 
 @settings(deadline=500)
 @given(st.lists(st.integers(min_value=1, max_value=5), min_size=1, max_size=2))
-def test_cmab_predict_shape_mismatch(dim_list):
+def test_cmab_predict_shape_mismatch(rng, dim_list):
     n_features = dim_list[0]
     hidden_dim_list = dim_list[1:]
     n_features = dim_list[0]
-    context = np.random.uniform(low=-1.0, high=1.0, size=(100, n_features - 1))
+    context = rng.uniform(low=-1.0, high=1.0, size=(100, n_features - 1))
     mab = CmabBernoulli.cold_start(action_ids={"a1", "a2"}, n_features=n_features, hidden_dim_list=hidden_dim_list)
     with pytest.raises(AttributeError):
         mab.predict(context=context)
@@ -1116,10 +1171,10 @@ def test_cmab_predict_shape_mismatch(dim_list):
     st.just([2]),
     st.integers(min_value=2, max_value=3),
 )
-def test_cmab_mo_update_shape_mismatch(n_samples, n_features, update_method, hidden_dim_list, n_objectives):
-    actions = np.random.choice(["a1", "a2"], size=n_samples).tolist()
+def test_cmab_mo_update_shape_mismatch(rng, n_samples, n_features, update_method, hidden_dim_list, n_objectives):
+    actions = rng.choice(["a1", "a2"], size=n_samples).tolist()
     # Multi-objective rewards
-    context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
+    context = rng.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
 
     # Create multi-objective models
     models_a1 = [
@@ -1142,12 +1197,12 @@ def test_cmab_mo_update_shape_mismatch(n_samples, n_features, update_method, hid
     )
 
     # Test with wrong number of objectives in rewards
-    wrong_rewards = [[np.random.choice([0, 1]) for _ in range(n_objectives + 1)] for _ in range(n_samples)]
+    wrong_rewards = [[rng.choice([0, 1]) for _ in range(n_objectives + 1)] for _ in range(n_samples)]
     with pytest.raises(AttributeError):
         mab.update(context=context, actions=actions, rewards=wrong_rewards)
 
     # Test with single-objective rewards (should fail for MO model)
-    single_rewards = np.random.choice([0, 1], size=n_samples).tolist()
+    single_rewards = rng.choice([0, 1], size=n_samples).tolist()
     with pytest.raises(ValidationError):
         mab.update(context=context, actions=actions, rewards=single_rewards)
 
@@ -1223,7 +1278,7 @@ def test_extract_element_from_probability_weight_unsupported_type(unsupported_ty
     random_seed=st.integers(min_value=0, max_value=2**31 - 1),
 )
 def test_random_seed_propagates_to_bnn(
-    action_ids: List[str], n_samples: int, n_features: int, random_seed: int
+    action_ids: List[str], n_samples: int, n_features: int, random_seed: int, rng: np.random.Generator
 ) -> None:
     """Verify that random_seed set on the CMAB cold_start flows through to every BNN action model.
 
@@ -1249,7 +1304,7 @@ def test_random_seed_propagates_to_bnn(
     # Deep-copy after mock update so both instances share identical layer params AND rng state.
     cmab2 = CmabBernoulli.from_state(cmab1.get_state()[1])
 
-    context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
+    context = rng.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
     actions1, probs1, ws1 = cmab1.predict(context=context)
     actions2, probs2, ws2 = cmab2.predict(context=context)
 
@@ -1261,214 +1316,255 @@ def test_random_seed_propagates_to_bnn(
 ########################################################################################################################
 # Region-aware forbidden_actions (forbidding part of a quantitative arm's hypercube) — CMAB edition
 
-# A forbidden region on a 1-D quantitative arm: float signed-margin convention, forbidden where region(x) > 0,
-# i.e. the upper half-interval x[0] > REGION_SPLIT is blocked.
-REGION_SPLIT = 0.5
-REGION_TOLERANCE = 1e-2
-EXPLORE_SAMPLES = 50
-HYPOTHESIS_EXPLOIT_SAMPLES = 5  # small enough to stay under hypothesis's default 200ms deadline
-EXPLORE_SEED = 123
-N_FEATURES = 2
-QUANTITATIVE_DIMENSION = 1
-QUANTITATIVE_ARM_ID = "q"
-DISCRETE_ARM_ID = "d"
-EPSILON_FULL_EXPLORE = 1.0  # forces the random explore branch on every step
-CONTEXT_LOW = -1.0
-CONTEXT_HIGH = 1.0
-ALLOWED_SEGMENT_LOW = 0.6
-ALLOWED_SEGMENT_HIGH = 1.0
-MAX_REJECTION_SAMPLES = 1000  # rejection-sampling budget for _constraint_aware_maximize
 
+class TestForbiddenRegions:
+    """Region-aware forbidden_actions: forbidding part of a quantitative arm's hypercube (cMAB edition)."""
 
-def _forbid_upper_half(x: np.ndarray) -> float:
-    """Forbidden-region predicate: x[0] > REGION_SPLIT is forbidden (region(x) > 0 => forbidden)."""
-    return float(x[0]) - REGION_SPLIT
+    # A forbidden region on a 1-D quantitative arm follows the float signed-margin convention: forbidden where
+    # region(x) > 0, i.e. the upper half-interval x[0] > region_split is blocked.
+    region_split = 0.5
+    region_tolerance = 1e-2
+    explore_samples = 50
+    hypothesis_exploit_samples = 5  # small enough to stay under hypothesis's default 200ms deadline
+    explore_seed = 123
+    n_features = 2
+    quantitative_dimension = 1
+    quantitative_arm_id = "q"
+    discrete_arm_id = "d"
+    epsilon_full_explore = 1.0  # forces the random explore branch on every step
+    context_low = -1.0
+    context_high = 1.0
+    max_rejection_samples = 1000  # rejection-sampling budget for _constraint_aware_maximize
 
+    @staticmethod
+    def _forbid_upper_half(x: np.ndarray, split: float = region_split) -> float:
+        """Forbidden-region predicate: x[0] > split is forbidden (region(x) > 0 => forbidden)."""
+        return float(x[0]) - split
 
-def _always_forbidden(x: np.ndarray) -> float:
-    """Forbidden-region predicate that forbids the entire quantity space (margin always positive)."""
-    return 1.0
+    @staticmethod
+    def _always_forbidden(x: np.ndarray) -> float:
+        """Forbidden-region predicate that forbids the entire quantity space (margin always positive)."""
+        return 1.0
 
-
-def _constraint_aware_maximize(
-    quantity_score_func, dimension: int, constraint=None, n_trials: int = 10000, **kwargs
-) -> np.ndarray:
-    """Mock maximize_by_quantity: rejection-samples a feasible quantity; np.zeros fallback is unreachable."""
-    constraints = constraint or []
-    for _ in range(MAX_REJECTION_SAMPLES):
-        candidate = np.random.random(dimension)
-        if all(c(candidate) >= 0 for c in constraints):
-            return candidate
-    return np.zeros(dimension)
-
-
-def _quantitative_cmab(**kwargs) -> CmabBernoulli:
-    """Build a cMAB with one continuous (QuantitativeBayesianNeuralNetwork) arm and one BNN arm."""
-    return CmabBernoulli(
-        actions={
-            QUANTITATIVE_ARM_ID: QuantitativeBayesianNeuralNetwork.cold_start(
-                dimension=QUANTITATIVE_DIMENSION, n_features=N_FEATURES
-            ),
-            DISCRETE_ARM_ID: BayesianNeuralNetwork.cold_start(n_features=N_FEATURES),
-        },
+    @staticmethod
+    def _constraint_aware_maximize(
+        quantity_score_func,
+        dimension: int,
+        constraint=None,
+        n_trials: int = 10000,
+        max_rejection_samples: int = max_rejection_samples,
+        rng: np.random.Generator = None,
         **kwargs,
-    )
+    ) -> np.ndarray:
+        """Mock maximize_by_quantity: rejection-samples a feasible quantity; np.zeros fallback is unreachable."""
+        constraints = constraint or []
+        for _ in range(max_rejection_samples):
+            candidate = rng.random(dimension)
+            if all(c(candidate) >= 0 for c in constraints):
+                return candidate
+        return np.zeros(dimension)
 
+    @pytest.fixture(scope="class")
+    def make_cmab(self):
+        """Factory: builds a cMAB with one continuous (QuantitativeBayesianNeuralNetwork) arm and one BNN arm."""
 
-def test_cmab_normalize_forbidden_actions_forms() -> None:
-    """_normalize_forbidden_actions handles the Set, dict-None (whole arm) and dict-region (partial) forms."""
-    cmab = _quantitative_cmab()
-
-    # Legacy Set form: whole-arm blocking, no region constraints.
-    valid, regions = cmab._normalize_forbidden_actions({DISCRETE_ARM_ID})
-    assert valid == {QUANTITATIVE_ARM_ID} and regions == {}
-
-    # dict with None value is equivalent to whole-arm blocking.
-    valid, regions = cmab._normalize_forbidden_actions({DISCRETE_ARM_ID: None})
-    assert valid == {QUANTITATIVE_ARM_ID} and regions == {}
-
-    # dict with a region keeps the arm valid (only its quantity space shrinks) and records its constraint.
-    valid, regions = cmab._normalize_forbidden_actions({QUANTITATIVE_ARM_ID: _forbid_upper_half})
-    assert valid == {QUANTITATIVE_ARM_ID, DISCRETE_ARM_ID}
-    assert set(regions) == {QUANTITATIVE_ARM_ID} and len(regions[QUANTITATIVE_ARM_ID]) == 1
-
-
-def test_cmab_forbidden_region_rejected_on_discrete_arm() -> None:
-    """A forbidden region cannot be attached to a non-quantitative arm."""
-    cmab = _quantitative_cmab()
-    with pytest.raises(ValueError, match="quantitative"):
-        cmab._normalize_forbidden_actions({DISCRETE_ARM_ID: _forbid_upper_half})
-
-
-@settings(deadline=None)
-@given(
-    quantity=st.floats(min_value=REGION_SPLIT, max_value=1.0, exclude_min=True),
-    epsilon=st.floats(min_value=0.0, max_value=1.0, exclude_min=True),
-)
-def test_cmab_forbidden_region_default_action_in_region_raises(quantity: float, epsilon: float) -> None:
-    """Any quantitative default action strictly above REGION_SPLIT is rejected when the upper half is forbidden."""
-    cmab = _quantitative_cmab(
-        epsilon=epsilon,
-        default_action=(QUANTITATIVE_ARM_ID, (quantity,)),
-    )
-    with pytest.raises(ValueError, match="forbidden region"):
-        cmab._normalize_forbidden_actions({QUANTITATIVE_ARM_ID: _forbid_upper_half})
-
-
-def test_cmab_sample_allowed_quantity_respects_and_exhausts_region() -> None:
-    """_sample_allowed_quantity returns a point outside the region, or None when the whole space is forbidden."""
-    cmab = _quantitative_cmab(random_seed=EXPLORE_SEED)
-    _, regions = cmab._normalize_forbidden_actions({QUANTITATIVE_ARM_ID: _forbid_upper_half})
-
-    allowed = cmab._sample_allowed_quantity(QUANTITATIVE_ARM_ID, regions)
-    assert allowed is not None and allowed[0] <= REGION_SPLIT
-
-    # A region that forbids the entire cube yields no allowed point.
-    _, full_regions = cmab._normalize_forbidden_actions({QUANTITATIVE_ARM_ID: _always_forbidden})
-    assert cmab._sample_allowed_quantity(QUANTITATIVE_ARM_ID, full_regions) is None
-
-
-def test_cmab_predict_explore_never_selects_forbidden_region(monkeypatch) -> None:
-    """With epsilon=1 (always explore), the random quantitative quantity always avoids the forbidden region."""
-    cmab = CmabBernoulli(
-        actions={
-            QUANTITATIVE_ARM_ID: QuantitativeBayesianNeuralNetwork.cold_start(
-                dimension=QUANTITATIVE_DIMENSION, n_features=N_FEATURES
+        def _factory(**kwargs) -> CmabBernoulli:
+            return CmabBernoulli(
+                actions={
+                    self.quantitative_arm_id: QuantitativeBayesianNeuralNetwork.cold_start(
+                        dimension=self.quantitative_dimension, n_features=self.n_features
+                    ),
+                    self.discrete_arm_id: BayesianNeuralNetwork.cold_start(n_features=self.n_features),
+                },
+                **kwargs,
             )
-        },
-        epsilon=EPSILON_FULL_EXPLORE,
-        random_seed=EXPLORE_SEED,
+
+        return _factory
+
+    def test_normalize_forbidden_actions_forms(
+        self,
+        make_cmab,
+        quantitative_arm_id: str = quantitative_arm_id,
+        discrete_arm_id: str = discrete_arm_id,
+    ) -> None:
+        """_normalize_forbidden_actions handles the Set, dict-None (whole arm) and dict-region (partial) forms."""
+        cmab = make_cmab()
+
+        # Legacy Set form: whole-arm blocking, no region constraints.
+        valid, regions = cmab._normalize_forbidden_actions({discrete_arm_id})
+        assert valid == {quantitative_arm_id} and regions == {}
+
+        # dict with None value is equivalent to whole-arm blocking.
+        valid, regions = cmab._normalize_forbidden_actions({discrete_arm_id: None})
+        assert valid == {quantitative_arm_id} and regions == {}
+
+        # dict with a region keeps the arm valid (only its quantity space shrinks) and records its constraint.
+        valid, regions = cmab._normalize_forbidden_actions({quantitative_arm_id: self._forbid_upper_half})
+        assert valid == {quantitative_arm_id, discrete_arm_id}
+        assert set(regions) == {quantitative_arm_id} and len(regions[quantitative_arm_id]) == 1
+
+    def test_region_rejected_on_discrete_arm(self, make_cmab, discrete_arm_id: str = discrete_arm_id) -> None:
+        """A forbidden region cannot be attached to a non-quantitative arm."""
+        cmab = make_cmab()
+        with pytest.raises(ValueError, match="quantitative"):
+            cmab._normalize_forbidden_actions({discrete_arm_id: self._forbid_upper_half})
+
+    @settings(deadline=None)
+    @given(
+        quantity=st.floats(min_value=region_split, max_value=1.0, exclude_min=True),
+        epsilon=st.floats(min_value=0.0, max_value=1.0, exclude_min=True),
+        arm_id=st.just(quantitative_arm_id),
     )
-    apply_mock_update(list(cmab.actions.values()))
-    context = np.random.default_rng(EXPLORE_SEED).uniform(CONTEXT_LOW, CONTEXT_HIGH, size=(EXPLORE_SAMPLES, N_FEATURES))
-    monkeypatch.setattr(
-        pybandits.strategy.single_objective,
-        "maximize_by_quantity",
-        lambda quantity_score_func, dimension, constraint=None, n_trials=10000: np.random.random(dimension),
+    def test_default_action_in_region_raises(self, make_cmab, quantity: float, epsilon: float, arm_id: str) -> None:
+        """Any quantitative default action strictly above region_split is rejected when the upper half is forbidden."""
+        cmab = make_cmab(epsilon=epsilon, default_action=(arm_id, (quantity,)))
+        with pytest.raises(ValueError, match="forbidden region"):
+            cmab._normalize_forbidden_actions({arm_id: self._forbid_upper_half})
+
+    @given(
+        region_split=st.floats(min_value=0.1, max_value=0.9),
+        arm_id=st.just(quantitative_arm_id),
+        random_seed=st.just(explore_seed),
     )
+    def test_sample_allowed_quantity_respects_and_exhausts_region(
+        self,
+        make_cmab,
+        region_split: float,
+        arm_id: str,
+        random_seed: int,
+    ) -> None:
+        """_sample_allowed_quantity returns a point outside the region, or None when the whole space is forbidden."""
+        cmab = make_cmab(random_seed=random_seed)
+        _, regions = cmab._normalize_forbidden_actions({arm_id: partial(self._forbid_upper_half, split=region_split)})
 
-    selected_actions, _, _ = cmab.predict(context=context, forbidden_actions={QUANTITATIVE_ARM_ID: _forbid_upper_half})
+        allowed = cmab._sample_allowed_quantity(arm_id, regions)
+        assert allowed is not None and allowed[0] <= region_split
 
-    assert all(isinstance(action, tuple) and action[0] == QUANTITATIVE_ARM_ID for action in selected_actions)
-    assert all(action[1][0] <= REGION_SPLIT + REGION_TOLERANCE for action in selected_actions)
+        # A region that forbids the entire cube yields no allowed point.
+        _, full_regions = cmab._normalize_forbidden_actions({arm_id: self._always_forbidden})
+        assert cmab._sample_allowed_quantity(arm_id, full_regions) is None
 
+    def test_predict_explore_never_selects_forbidden_region(
+        self,
+        monkeypatch: MonkeyPatch,
+        arm_id: str = quantitative_arm_id,
+        dimension: int = quantitative_dimension,
+        n_features: int = n_features,
+        epsilon: float = epsilon_full_explore,
+        random_seed: int = explore_seed,
+        n_samples: int = explore_samples,
+        context_low: float = context_low,
+        context_high: float = context_high,
+        region_split: float = region_split,
+        tolerance: float = region_tolerance,
+        rng: np.random.Generator = None,
+    ) -> None:
+        """With epsilon=1 (always explore), the random quantitative quantity always avoids the forbidden region."""
+        cmab = CmabBernoulli(
+            actions={arm_id: QuantitativeBayesianNeuralNetwork.cold_start(dimension=dimension, n_features=n_features)},
+            epsilon=epsilon,
+            random_seed=random_seed,
+        )
+        apply_mock_update(list(cmab.actions.values()))
+        context = np.random.default_rng(random_seed).uniform(context_low, context_high, size=(n_samples, n_features))
+        monkeypatch.setattr(
+            pybandits.strategy.single_objective,
+            "maximize_by_quantity",
+            lambda quantity_score_func, dimension, constraint=None, n_trials=10000: rng.random(dimension),
+        )
 
-@given(
-    region_split=st.floats(min_value=0.1, max_value=0.9),
-    arm_id=st.just(QUANTITATIVE_ARM_ID),
-    dimension=st.just(QUANTITATIVE_DIMENSION),
-    n_features=st.just(N_FEATURES),
-    random_seed=st.just(EXPLORE_SEED),
-    n_samples=st.just(HYPOTHESIS_EXPLOIT_SAMPLES),
-    context_low=st.just(CONTEXT_LOW),
-    context_high=st.just(CONTEXT_HIGH),
-    tolerance=st.just(REGION_TOLERANCE),
-)
-def test_cmab_predict_exploit_respects_forbidden_region(
-    region_split: float,
-    arm_id: str,
-    dimension: int,
-    n_features: int,
-    random_seed: int,
-    n_samples: int,
-    context_low: float,
-    context_high: float,
-    tolerance: float,
-) -> None:
-    """Constrained optimizer stays below any forbidden boundary, not just the default split of 0.5."""
+        selected_actions, _, _ = cmab.predict(context=context, forbidden_actions={arm_id: self._forbid_upper_half})
 
-    def forbid_above(x: np.ndarray) -> float:
-        return float(x[0]) - region_split
+        assert all(isinstance(action, tuple) and action[0] == arm_id for action in selected_actions)
+        assert all(action[1][0] <= region_split + tolerance for action in selected_actions)
 
-    cmab = CmabBernoulli(
-        actions={arm_id: QuantitativeBayesianNeuralNetwork.cold_start(dimension=dimension, n_features=n_features)},
-        random_seed=random_seed,
+    @given(
+        region_split=st.floats(min_value=0.1, max_value=0.9),
+        arm_id=st.just(quantitative_arm_id),
+        dimension=st.just(quantitative_dimension),
+        n_features=st.just(n_features),
+        random_seed=st.just(explore_seed),
+        n_samples=st.just(hypothesis_exploit_samples),
+        context_low=st.just(context_low),
+        context_high=st.just(context_high),
+        tolerance=st.just(region_tolerance),
     )
-    apply_mock_update(list(cmab.actions.values()))
-    context = np.random.default_rng(random_seed).uniform(context_low, context_high, size=(n_samples, n_features))
+    def test_predict_exploit_respects_forbidden_region(
+        self,
+        region_split: float,
+        arm_id: str,
+        dimension: int,
+        n_features: int,
+        random_seed: int,
+        n_samples: int,
+        context_low: float,
+        context_high: float,
+        tolerance: float,
+        rng: np.random.Generator,
+    ) -> None:
+        """Constrained optimizer stays below any forbidden boundary, not just the default split of 0.5."""
 
-    with patch.object(pybandits.strategy.single_objective, "maximize_by_quantity", _constraint_aware_maximize):
-        selected_actions, _, _ = cmab.predict(context=context, forbidden_actions={arm_id: forbid_above})
+        def forbid_above(x: np.ndarray) -> float:
+            return float(x[0]) - region_split
 
-    assert all(isinstance(action, tuple) and action[0] == arm_id for action in selected_actions)
-    assert all(action[1][0] <= region_split + tolerance for action in selected_actions)
+        cmab = CmabBernoulli(
+            actions={arm_id: QuantitativeBayesianNeuralNetwork.cold_start(dimension=dimension, n_features=n_features)},
+            random_seed=random_seed,
+        )
+        apply_mock_update(list(cmab.actions.values()))
+        context = np.random.default_rng(random_seed).uniform(context_low, context_high, size=(n_samples, n_features))
 
+        with patch.object(
+            pybandits.strategy.single_objective,
+            "maximize_by_quantity",
+            partial(self._constraint_aware_maximize, rng=rng),
+        ):
+            selected_actions, _, _ = cmab.predict(context=context, forbidden_actions={arm_id: forbid_above})
 
-@given(
-    seg_lo=st.floats(min_value=0.05, max_value=0.45),
-    seg_hi=st.floats(min_value=0.55, max_value=0.95),
-    arm_id=st.just(QUANTITATIVE_ARM_ID),
-    dimension=st.just(QUANTITATIVE_DIMENSION),
-    n_features=st.just(N_FEATURES),
-    random_seed=st.just(EXPLORE_SEED),
-    n_samples=st.just(HYPOTHESIS_EXPLOIT_SAMPLES),
-    context_low=st.just(CONTEXT_LOW),
-    context_high=st.just(CONTEXT_HIGH),
-    tolerance=st.just(REGION_TOLERANCE),
-)
-def test_cmab_segment_forbidden_region_outside_end_to_end(
-    seg_lo: float,
-    seg_hi: float,
-    arm_id: str,
-    dimension: int,
-    n_features: int,
-    random_seed: int,
-    n_samples: int,
-    context_low: float,
-    context_high: float,
-    tolerance: float,
-) -> None:
-    """forbidden_region_outside keeps the exploited quantity inside any valid allowed segment."""
-    allowed = Segment(intervals=((seg_lo, seg_hi),))
-    cmab = CmabBernoulli(
-        actions={arm_id: QuantitativeBayesianNeuralNetwork.cold_start(dimension=dimension, n_features=n_features)},
-        random_seed=random_seed,
+        assert all(isinstance(action, tuple) and action[0] == arm_id for action in selected_actions)
+        assert all(action[1][0] <= region_split + tolerance for action in selected_actions)
+
+    @given(
+        seg_lo=st.floats(min_value=0.05, max_value=0.45),
+        seg_hi=st.floats(min_value=0.55, max_value=0.95),
+        arm_id=st.just(quantitative_arm_id),
+        dimension=st.just(quantitative_dimension),
+        n_features=st.just(n_features),
+        random_seed=st.just(explore_seed),
+        n_samples=st.just(hypothesis_exploit_samples),
+        context_low=st.just(context_low),
+        context_high=st.just(context_high),
+        tolerance=st.just(region_tolerance),
     )
-    apply_mock_update(list(cmab.actions.values()))
-    context = np.random.default_rng(random_seed).uniform(context_low, context_high, size=(n_samples, n_features))
-    region = allowed.forbidden_region_outside()
+    def test_segment_region_outside_end_to_end(
+        self,
+        seg_lo: float,
+        seg_hi: float,
+        arm_id: str,
+        dimension: int,
+        n_features: int,
+        random_seed: int,
+        n_samples: int,
+        context_low: float,
+        context_high: float,
+        tolerance: float,
+        rng: np.random.Generator,
+    ) -> None:
+        """forbidden_region_outside keeps the exploited quantity inside any valid allowed segment."""
+        allowed = Segment(intervals=((seg_lo, seg_hi),))
+        cmab = CmabBernoulli(
+            actions={arm_id: QuantitativeBayesianNeuralNetwork.cold_start(dimension=dimension, n_features=n_features)},
+            random_seed=random_seed,
+        )
+        apply_mock_update(list(cmab.actions.values()))
+        context = np.random.default_rng(random_seed).uniform(context_low, context_high, size=(n_samples, n_features))
+        region = allowed.forbidden_region_outside()
 
-    with patch.object(pybandits.strategy.single_objective, "maximize_by_quantity", _constraint_aware_maximize):
-        selected_actions, _, _ = cmab.predict(context=context, forbidden_actions={arm_id: region})
+        with patch.object(
+            pybandits.strategy.single_objective,
+            "maximize_by_quantity",
+            partial(self._constraint_aware_maximize, rng=rng),
+        ):
+            selected_actions, _, _ = cmab.predict(context=context, forbidden_actions={arm_id: region})
 
-    assert all(seg_lo - tolerance <= action[1][0] <= seg_hi for action in selected_actions)
+        assert all(seg_lo - tolerance <= action[1][0] <= seg_hi for action in selected_actions)

--- a/tests/test_cmab_simulator.py
+++ b/tests/test_cmab_simulator.py
@@ -130,6 +130,7 @@ def test_cmab_simulator_with_explicit_probs_reward(
     expected_values: Dict[str, Dict[str, float]],
     groups: List[str],
     context_shape: tuple,
+    rng: np.random.Generator,
     dimension: int = 2,
     test_context=np.array([0.5, 0.3, 0.7]),
 ):
@@ -172,7 +173,7 @@ def test_cmab_simulator_with_explicit_probs_reward(
 
     # Create context and group arrays
     n_samples, n_features = context_shape
-    context = np.random.random(context_shape)
+    context = rng.random(context_shape)
     group_list = groups * (n_samples // len(groups)) + groups[: n_samples % len(groups)]
 
     # Create simulator with explicit probs_reward
@@ -219,8 +220,9 @@ def test_non_matching_context_and_group_shape(
     n_features,
     n_samples: int,
     group_extra: int,
+    rng: np.random.Generator,
 ):
-    context = np.random.random((n_samples, n_features))
+    context = rng.random((n_samples, n_features))
     # Create a group list with a different length than n_samples
     group: List[str] = [str(i) for i in range(n_samples + group_extra)]
     cmab = CmabBernoulli(actions=dict(zip(action_ids, models)))
@@ -276,13 +278,13 @@ def mock_mab_update(self, actions, rewards, quantities=None, **kwargs):
     st.just(2),
     st.sampled_from([None, 2]),
 )
-def test_cmab_e2e_simulation_with_default_arguments(monkeymodule, action_ids, models, n_features, num_groups):
-    monkeymodule.setattr(pybandits.utils, "maximize_by_quantity", lambda *args, **kwargs: np.random.random(size=(1,)))
+def test_cmab_e2e_simulation_with_default_arguments(monkeymodule, rng, action_ids, models, n_features, num_groups):
+    monkeymodule.setattr(pybandits.utils, "maximize_by_quantity", lambda *args, **kwargs: rng.random(size=(1,)))
     monkeymodule.setattr(
-        pybandits.cmab_simulator, "maximize_by_quantity", lambda *args, **kwargs: np.random.random(size=(1,))
+        pybandits.cmab_simulator, "maximize_by_quantity", lambda *args, **kwargs: rng.random(size=(1,))
     )
     monkeymodule.setattr(
-        pybandits.strategy.single_objective, "maximize_by_quantity", lambda *args, **kwargs: np.random.random(size=(1,))
+        pybandits.strategy.single_objective, "maximize_by_quantity", lambda *args, **kwargs: rng.random(size=(1,))
     )
     monkeymodule.setattr(pybandits.cmab.CmabBernoulli, "predict", mock_predict)
     monkeymodule.setattr(pybandits.cmab.CmabBernoulli, "update", mock_mab_update)
@@ -351,13 +353,14 @@ def test_cmab_e2e_simulation_with_non_default_args(
     file_prefix,
     num_groups,
     monkeymodule,
+    rng,
 ):
-    monkeymodule.setattr(pybandits.utils, "maximize_by_quantity", lambda *args, **kwargs: np.random.random(size=(1,)))
+    monkeymodule.setattr(pybandits.utils, "maximize_by_quantity", lambda *args, **kwargs: rng.random(size=(1,)))
     monkeymodule.setattr(
-        pybandits.cmab_simulator, "maximize_by_quantity", lambda *args, **kwargs: np.random.random(size=(1,))
+        pybandits.cmab_simulator, "maximize_by_quantity", lambda *args, **kwargs: rng.random(size=(1,))
     )
     monkeymodule.setattr(
-        pybandits.strategy.single_objective, "maximize_by_quantity", lambda *args, **kwargs: np.random.random(size=(1,))
+        pybandits.strategy.single_objective, "maximize_by_quantity", lambda *args, **kwargs: rng.random(size=(1,))
     )
     monkeymodule.setattr(pybandits.cmab.CmabBernoulli, "predict", mock_predict)
     monkeymodule.setattr(pybandits.cmab.CmabBernoulli, "update", mock_mab_update)

--- a/tests/test_mab.py
+++ b/tests/test_mab.py
@@ -37,6 +37,8 @@ from pybandits.quantitative_model import Zooming
 from pybandits.strategy import ClassicBandit
 from tests.test_actions_manager import REFERENCE_DELTA, DummyActionsManager
 
+_rng = np.random.default_rng(seed=42)
+
 
 class DummyMab(BaseMab):
     epsilon: Optional[Float01] = None
@@ -57,7 +59,7 @@ class DummyMab(BaseMab):
         forbidden_actions: Optional[Set[ActionId]] = None,
     ):
         valid_actions = self._get_valid_actions(forbidden_actions)
-        return np.random.choice(valid_actions)
+        return _rng.choice(valid_actions)
 
     def get_state(self) -> Tuple[str, dict]:
         model_name = self.__class__.__name__
@@ -379,3 +381,168 @@ def test_mab_model_post_init_valid_configurations(epsilon=_EPSILON):
     assert mab.epsilon == epsilon
     assert mab.default_action is None
     assert mab.actions_manager.delta == REFERENCE_DELTA
+
+
+class TestLimitedActions:
+    """Tests for BaseMab.limited_actions throttling via limited_action_fraction."""
+
+    other_arm = "a1"
+    limited_arm = "a2"
+    unknown_arm = "a3"
+    other_p = 0.4
+    limited_p = 0.6  # the limited arm strictly wins whenever it is allowed to compete
+    limited_epsilon = 0.1
+    mix_fraction = 0.3
+    mix_tolerance = 0.03
+    mix_seed = 42
+    n_draws = 4_000
+    fraction_min = 0.05
+    fraction_max = 0.95
+
+    @pytest.fixture(scope="class")
+    def make_mab(self):
+        """Factory: builds a DummyMab over the two-arm action set with the given limited-action config."""
+
+        def _factory(**kwargs) -> DummyMab:
+            return DummyMab(
+                actions={self.other_arm: Beta(), self.limited_arm: Beta()},
+                strategy=ClassicBandit(),
+                **kwargs,
+            )
+
+        return _factory
+
+    @pytest.fixture(scope="class")
+    def p(self) -> Dict[ActionId, Probability]:
+        """Sampled probabilities where the limited arm strictly wins whenever it is allowed to compete."""
+        return {self.other_arm: self.other_p, self.limited_arm: self.limited_p}
+
+    @given(fraction=st.floats(min_value=fraction_min, max_value=fraction_max))
+    def test_requires_limited_actions(self, make_mab, fraction: float) -> None:
+        """limited_action_fraction is rejected when limited_actions is not set, for any valid fraction."""
+        with pytest.raises(AttributeError, match="must be defined together"):
+            make_mab(limited_action_fraction=fraction)
+
+    def test_requires_fraction(self, make_mab, limited_arm: ActionId = limited_arm) -> None:
+        """limited_actions is rejected when limited_action_fraction is not set."""
+        with pytest.raises(AttributeError, match="must be defined together"):
+            make_mab(limited_actions={limited_arm})
+
+    @given(
+        fraction=st.floats(min_value=fraction_min, max_value=fraction_max),
+        unknown_arm=st.just(unknown_arm),
+    )
+    def test_rejects_unknown_action(self, make_mab, fraction: float, unknown_arm: ActionId) -> None:
+        """A limited action outside the action set is rejected, for any valid fraction."""
+        with pytest.raises(AttributeError, match="must be a subset of the action set"):
+            make_mab(limited_actions={unknown_arm}, limited_action_fraction=fraction)
+
+    @given(
+        fraction=st.floats(min_value=fraction_min, max_value=fraction_max),
+        epsilon=st.just(limited_epsilon),
+        limited_arm=st.just(limited_arm),
+    )
+    def test_rejects_default_action_in_limited(
+        self, make_mab, fraction: float, epsilon: float, limited_arm: ActionId
+    ) -> None:
+        """A default_action that is also a limited action is rejected, for any valid fraction."""
+        with pytest.raises(AttributeError, match="default_action must not be a limited action"):
+            make_mab(
+                epsilon=epsilon,
+                default_action=limited_arm,
+                limited_actions={limited_arm},
+                limited_action_fraction=fraction,
+            )
+
+    @given(
+        fraction=st.floats(min_value=fraction_min, max_value=fraction_max),
+        limited_arm=st.just(limited_arm),
+        other_arm=st.just(other_arm),
+    )
+    def test_masks_when_gate_closed(
+        self, make_mab, p: Dict[ActionId, Probability], fraction: float, limited_arm: ActionId, other_arm: ActionId
+    ) -> None:
+        """When the gate draw is 0 the limited arm is masked out, so the strategy picks the other arm."""
+        mab = make_mab(limited_actions={limited_arm}, limited_action_fraction=fraction)
+        mab._rng = MagicMock()
+        mab._rng.binomial.return_value = 0
+        assert mab._select_epsilon_greedy_action(p, actions=mab.actions) == other_arm
+
+    @given(
+        fraction=st.floats(min_value=fraction_min, max_value=fraction_max),
+        limited_arm=st.just(limited_arm),
+    )
+    def test_competes_when_gate_open(
+        self, make_mab, p: Dict[ActionId, Probability], fraction: float, limited_arm: ActionId
+    ) -> None:
+        """When the gate draw is 1 the limited arm competes normally and wins on probability."""
+        mab = make_mab(limited_actions={limited_arm}, limited_action_fraction=fraction)
+        mab._rng = MagicMock()
+        mab._rng.binomial.return_value = 1
+        assert mab._select_epsilon_greedy_action(p, actions=mab.actions) == limited_arm
+
+    def test_never_masks_entire_set(
+        self,
+        make_mab,
+        p: Dict[ActionId, Probability],
+        fraction: float = mix_fraction,
+        limited_arm: ActionId = limited_arm,
+        other_arm: ActionId = other_arm,
+    ) -> None:
+        """If every action is limited, a closed gate leaves the full set intact rather than emptying it."""
+        mab = make_mab(limited_actions={other_arm, limited_arm}, limited_action_fraction=fraction)
+        mab._rng = MagicMock()
+        mab._rng.binomial.return_value = 0
+        assert mab._select_epsilon_greedy_action(p, actions=mab.actions) == limited_arm
+
+    def test_mix_distribution(
+        self,
+        make_mab,
+        p: Dict[ActionId, Probability],
+        fraction: float = mix_fraction,
+        seed: int = mix_seed,
+        n_draws: int = n_draws,
+        tolerance: float = mix_tolerance,
+        limited_arm: ActionId = limited_arm,
+        other_arm: ActionId = other_arm,
+    ) -> None:
+        """Empirical share of the limited arm approximates limited_action_fraction.
+
+        No epsilon is set, so selection routes straight through the gate to the strategy; a seeded
+        real rng drives the gate Bernoulli, making the fraction draw the sole source of variance.
+        """
+        mab = make_mab(limited_actions={limited_arm}, limited_action_fraction=fraction, random_seed=seed)
+
+        selections = [mab._select_epsilon_greedy_action(p, actions=mab.actions) for _ in range(n_draws)]
+        limited_share = sum(1 for s in selections if s == limited_arm) / n_draws
+        assert other_arm in selections and limited_arm in selections
+        assert abs(limited_share - fraction) < tolerance
+
+
+class TestActionKindDisjoint:
+    """An action id may be regular xor quantitative, never both (meta_model._instantiate_actions guard)."""
+
+    regular_arm = "a1"
+    quantitative_arm = "a2"
+    shared_arm = "a3"
+    overlap_match = "both regular and quantitative"
+
+    @pytest.mark.parametrize(
+        "action_ids, quantitative_action_ids",
+        [
+            ({shared_arm}, {shared_arm}),  # full overlap
+            ({regular_arm, shared_arm}, {shared_arm}),  # overlap alongside a distinct regular arm
+            ({shared_arm}, {shared_arm, quantitative_arm}),  # overlap alongside a distinct quantitative arm
+            ({regular_arm, shared_arm}, {shared_arm, quantitative_arm}),  # overlap with distinct arms on both sides
+        ],
+    )
+    def test_rejects_shared_action_id(
+        self, action_ids: Set[ActionId], quantitative_action_ids: Set[ActionId], match: str = overlap_match
+    ) -> None:
+        """An id present in both the regular and quantitative sets is rejected, whatever else is declared."""
+        with pytest.raises(AttributeError, match=match):
+            DummyMab(
+                action_ids=action_ids,
+                quantitative_action_ids=quantitative_action_ids,
+                strategy=ClassicBandit(),
+            )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -844,14 +844,14 @@ class TestCalibrateOutputBias:
     n_features=st.integers(min_value=1, max_value=3),
     hidden_dim_list=st.lists(st.integers(min_value=1, max_value=3), min_size=0, max_size=2),
 )
-def test_check_context_matrix(n_samples, n_features, hidden_dim_list):
+def test_check_context_matrix(rng, n_samples, n_features, hidden_dim_list):
     bnn = BayesianNeuralNetwork.cold_start(
         n_features=n_features,
         hidden_dim_list=hidden_dim_list,
     )
 
     # context is numpy array
-    context = np.random.uniform(low=-100.0, high=100.0, size=(n_samples, n_features))
+    context = rng.uniform(low=-100.0, high=100.0, size=(n_samples, n_features))
     assert type(context) is np.ndarray
     bnn.check_context_matrix(context=context)
 
@@ -893,7 +893,9 @@ def test_check_context_matrix_bad_input_type(invalid_context) -> None:
     n_rows=st.integers(min_value=1, max_value=3),
     invalid_col_delta=st.integers(min_value=1, max_value=3),
 )
-def test_check_context_matrix_error_handling(n_features: int, n_rows: int, invalid_col_delta: int) -> None:
+def test_check_context_matrix_error_handling(
+    rng: np.random.Generator, n_features: int, n_rows: int, invalid_col_delta: int
+) -> None:
     """
     Test error handling in check_context_matrix method for ArrayLike inputs with invalid number of columns.
 
@@ -904,7 +906,7 @@ def test_check_context_matrix_error_handling(n_features: int, n_rows: int, inval
     for invalid_n_features in [n_features + invalid_col_delta, max(1, n_features - invalid_col_delta)]:
         if invalid_n_features == n_features:
             continue  # skip if by chance delta is 0
-        invalid_context = np.random.rand(n_rows, invalid_n_features)
+        invalid_context = rng.random((n_rows, invalid_n_features))
         bnn = BayesianNeuralNetwork.cold_start(
             n_features=n_features,
             hidden_dim_list=[],
@@ -948,12 +950,12 @@ def test_bnn_sample_proba(
         assert isinstance(layer_params.bias, expected_array)
 
     # context is numpy array
-    context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
+    context = rng.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
     assert type(context) is np.ndarray
     sample_proba(context=context)
 
     # check that the model is working with multi-sample prediction
-    context = np.repeat(np.random.uniform(low=-1.0, high=1.0, size=(1, n_features)), n_samples, axis=0)
+    context = np.repeat(rng.uniform(low=-1.0, high=1.0, size=(1, n_features)), n_samples, axis=0)
     assert type(context) is np.ndarray
     prob_and_weighted_sum = bnn.sample_proba(context=np.array(context), rng=rng)
     prob, weighted_sum = zip(*prob_and_weighted_sum)
@@ -974,6 +976,7 @@ def test_bnn_sample_proba(
     epochs=st.just(1),
 )
 def test_bnn_vi_update(
+    rng,
     activation,
     use_residual_connections,
     use_layerwise_scaling,
@@ -1036,7 +1039,7 @@ def test_bnn_vi_update(
     rewards = _make_random_rewards(n_samples)
 
     # context is numpy array
-    context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
+    context = rng.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
     update(context=context, rewards=rewards)
 
     # raise an error if len(context) != len(rewards)
@@ -1452,7 +1455,7 @@ def test_vi_training_options(
         update_method=update_method,
         update_kwargs=update_kwargs,
     )
-    context = np.random.rand(n_samples, n_features).astype(np.float32)
+    context = rng.random((n_samples, n_features)).astype(np.float32)
     rewards = _make_random_rewards(n_samples)
     bnn.update(context=context, rewards=rewards)
     result = bnn.sample_proba(context=context, rng=rng)
@@ -1547,7 +1550,7 @@ class TestKLAnnealing:
     @pytest.mark.parametrize("kl_annealing_factor", [1.0, 0.3])
     @pytest.mark.parametrize("n_features, n_samples", [(1, 3), (3, 7)])
     def test_model_trace_scale_annotation_on_priors_and_not_on_likelihood(
-        self, n_features: int, n_samples: int, kl_annealing_factor: float
+        self, rng: np.random.Generator, n_features: int, n_samples: int, kl_annealing_factor: float
     ) -> None:
         """Tracing the inner model surfaces handlers.scale on every prior sample site (weights, biases)
         with the supplied factor, while the likelihood ``out`` site is left unscaled.
@@ -1559,7 +1562,7 @@ class TestKLAnnealing:
         bnn = self._build_bnn(kl_annealing_fraction=None, n_features=n_features)
         model_fn = bnn._create_update_model()
 
-        x = jnp.asarray(np.random.rand(n_samples, n_features).astype(np.float32))
+        x = jnp.asarray(rng.random((n_samples, n_features)).astype(np.float32))
         y = jnp.asarray(_make_random_rewards(n_samples), dtype=jnp.int32)
 
         tr = numpyro.handlers.trace(numpyro.handlers.seed(model_fn, rng_seed=0)).get_trace(x, y, kl_annealing_factor)
@@ -1590,7 +1593,7 @@ class TestKLAnnealing:
         ),
     )
     def test_symmetric_guide_wrap_scales_guide_sample_sites(
-        self, n_features: int, n_samples: int, kl_annealing_factor: float
+        self, rng: np.random.Generator, n_features: int, n_samples: int, kl_annealing_factor: float
     ) -> None:
         """The guide wrap installed in `_run_svi_training_loop` must scale the guide's sample
         sites symmetrically with the model's prior sites. Without it the per-site KL contribution
@@ -1612,7 +1615,7 @@ class TestKLAnnealing:
         guide = AutoNormal(model_fn)
         scaled_guide = _wrap_guide_with_kl_scale(guide)
 
-        x = jnp.asarray(np.random.rand(n_samples, n_features).astype(np.float32))
+        x = jnp.asarray(rng.random((n_samples, n_features)).astype(np.float32))
         y = jnp.asarray(_make_random_rewards(n_samples), dtype=jnp.int32)
 
         tr = numpyro.handlers.trace(numpyro.handlers.seed(scaled_guide, rng_seed=0)).get_trace(
@@ -1686,7 +1689,14 @@ def test_epochs_and_num_steps_warns(n_features: int, update_method: UpdateMethod
 
 @pytest.mark.parametrize("n_features", [1, 2])
 def test_bnn_mcmc_update(
-    n_features, hidden_dim_list=(1,), n_samples=3, update_method="MCMC", num_warmup=1, mcmc_num_samples=2, num_chains=1
+    rng,
+    n_features,
+    hidden_dim_list=(1,),
+    n_samples=3,
+    update_method="MCMC",
+    num_warmup=1,
+    mcmc_num_samples=2,
+    num_chains=1,
 ):
     hidden_dim_list = list(hidden_dim_list)
     update_kwargs = {"num_warmup": num_warmup, "num_samples": mcmc_num_samples, "num_chains": num_chains}
@@ -1724,7 +1734,7 @@ def test_bnn_mcmc_update(
                 assert layer_b.params[param].tolist() == getattr(layer_b, param)
 
     rewards = _make_random_rewards(n_samples)
-    context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
+    context = rng.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
     update(context=context, rewards=rewards)
 
     # raise an error if len(context) != len(rewards)
@@ -1739,7 +1749,9 @@ def test_bnn_mcmc_update(
 
 
 @pytest.mark.parametrize("n_features", [1, 2])
-def test_bnn_fullrank_advi_update(n_features, hidden_dim_list=(1,), n_samples=5, method="fullrank_advi", num_steps=1):
+def test_bnn_fullrank_advi_update(
+    rng, n_features, hidden_dim_list=(1,), n_samples=5, method="fullrank_advi", num_steps=1
+):
     hidden_dim_list = list(hidden_dim_list)
 
     def update(context: np.ndarray, rewards: list):
@@ -1775,7 +1787,7 @@ def test_bnn_fullrank_advi_update(n_features, hidden_dim_list=(1,), n_samples=5,
                 assert layer_b.params[param].tolist() == getattr(layer_b, param)
 
     rewards = _make_random_rewards(n_samples)
-    context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
+    context = rng.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
     update(context=context, rewards=rewards)
 
 
@@ -1792,7 +1804,7 @@ def test_bnn_fullrank_advi_update(n_features, hidden_dim_list=(1,), n_samples=5,
     update_method=st.just("VI"),
 )
 def test_bnn_svi_nan_loss_raises_error(
-    n_features: int, hidden_dim_list: list[int], n_samples: int, update_method: UpdateMethods
+    rng: np.random.Generator, n_features: int, hidden_dim_list: list[int], n_samples: int, update_method: UpdateMethods
 ) -> None:
     """Test that a NaN loss during SVI training raises a ValueError immediately."""
 
@@ -1812,7 +1824,7 @@ def test_bnn_svi_nan_loss_raises_error(
             return float("nan")
         return original_mean(a, *args, **kwargs)
 
-    context = np.random.uniform(size=(n_samples, n_features))
+    context = rng.uniform(size=(n_samples, n_features))
     rewards = _make_random_rewards(n_samples)
 
     with patch("pybandits.model.bnn.network.np.mean", nan_mean):
@@ -1986,7 +1998,7 @@ def test_create_default_instance_bayesian_neural_network_cc(
         assert bnn_cold_start.use_residual_connections == use_residual_connections
 
         # Test sample_proba works
-        context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
+        context = rng.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
         prob_and_weighted_sum = bnn_cold_start.sample_proba(context=context, rng=rng)
         prob, weighted_sum = zip(*prob_and_weighted_sum)
         assert len(prob) == n_samples
@@ -2089,7 +2101,7 @@ def test_create_default_instance_bayesian_neural_network_dp(
         assert bnn_cold_start.use_residual_connections == use_residual_connections
 
         # Test sample_proba works
-        context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
+        context = rng.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
         prob_and_weighted_sum = bnn_cold_start.sample_proba(context=context, rng=rng)
         prob, weighted_sum = zip(*prob_and_weighted_sum)
         assert len(prob) == n_samples
@@ -2194,7 +2206,7 @@ def test_bayesian_neural_network_mo_sample_proba(
         assert model.activation == activation
         assert model.use_residual_connections == use_residual_connections
 
-    context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
+    context = rng.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
     prob_weights = bnn_mo.sample_proba(context=context, rng=rng)
 
     assert len(prob_weights) == n_samples
@@ -2217,7 +2229,7 @@ def test_bayesian_neural_network_mo_sample_proba(
     epochs=st.just(1),
 )
 def test_bayesian_neural_network_mo_update(
-    activation, n_features, hidden_dim_list, n_samples, update_method, n_objectives, epochs
+    rng, activation, n_features, hidden_dim_list, n_samples, update_method, n_objectives, epochs
 ):
     models = [
         BayesianNeuralNetwork.cold_start(
@@ -2234,8 +2246,8 @@ def test_bayesian_neural_network_mo_update(
     for model in bnn_mo.models:
         assert model.activation == activation
 
-    context = np.random.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
-    rewards = [[np.random.randint(0, 2) for _ in range(n_objectives)] for _ in range(n_samples)]
+    context = rng.uniform(low=-1.0, high=1.0, size=(n_samples, n_features))
+    rewards = [[rng.integers(0, 2) for _ in range(n_objectives)] for _ in range(n_samples)]
 
     # Should not raise any exceptions
     bnn_mo.update(context=context, rewards=rewards)
@@ -2502,7 +2514,7 @@ def test_cold_start_with_feature_config(n_features, cardinality, hidden_dim_list
     cardinality=st.integers(min_value=2, max_value=8),
     n_samples=st.integers(min_value=2, max_value=10),
 )
-def test_check_context_matrix_with_categorical(n_features, cardinality, n_samples):
+def test_check_context_matrix_with_categorical(rng, n_features, cardinality, n_samples):
     """check_context_matrix validates column count and categorical range for feature_config models."""
     cat_col = n_features - 1
     bnn = _make_bnn_with_categoricals(n_features=n_features, categorical_features={cat_col: cardinality})
@@ -2511,7 +2523,7 @@ def test_check_context_matrix_with_categorical(n_features, cardinality, n_sample
     bnn.check_context_matrix(context)
     # too few columns
     with pytest.raises(AttributeError, match="Shape mismatch"):
-        bnn.check_context_matrix(np.random.uniform(size=(n_samples, 1)))
+        bnn.check_context_matrix(rng.uniform(size=(n_samples, 1)))
     # out-of-range category
     bad_context = _make_categorical_context(1, n_features, {cat_col: cardinality})
     bad_context[0, cat_col] = cardinality + 2
@@ -2700,7 +2712,7 @@ def test_bnn_sample_proba_and_update_both_use_forward_layers(
         update_method=update_method,
         update_kwargs=update_kwargs,
     )
-    context = np.random.rand(n_samples, n_features).astype(np.float32)
+    context = rng.random((n_samples, n_features)).astype(np.float32)
     rewards = _make_random_rewards(n_samples)
 
     original_forward_layers = BaseBayesianNeuralNetwork._forward_layers
@@ -2743,7 +2755,16 @@ def test_bnn_sample_proba_and_update_both_use_forward_layers(
     n_sigma_tolerance=st.just(5),
 )
 def test_advi_extracted_params_match_predictive_moments(
-    n_features, hidden_dim_list, dist_type, n_samples, sigma_init, nu, epochs, n_predictive_samples, n_sigma_tolerance
+    rng,
+    n_features,
+    hidden_dim_list,
+    dist_type,
+    n_samples,
+    sigma_init,
+    nu,
+    epochs,
+    n_predictive_samples,
+    n_sigma_tolerance,
 ):
     """Stored (mu, sigma) from _extract_advi_params must match guide posterior sample moments.
 
@@ -2753,7 +2774,7 @@ def test_advi_extracted_params_match_predictive_moments(
     """
     dist_params_init = {"sigma": sigma_init} if dist_type == "normal" else {"sigma": sigma_init, "nu": nu}
     context = np.random.default_rng(0).standard_normal((n_samples, n_features)).astype(np.float32)
-    rewards = np.random.choice([0, 1], size=n_samples).tolist()
+    rewards = rng.choice([0, 1], size=n_samples).tolist()
 
     bnn = BayesianNeuralNetwork.cold_start(
         n_features=n_features,
@@ -2795,7 +2816,7 @@ def test_advi_extracted_params_match_predictive_moments(
     lr=st.just(0.0),
 )
 def test_advi_zero_lr_posterior_equals_prior(
-    n_features, hidden_dim_list, dist_type, n_samples, mu_init, sigma_init, nu, num_steps, lr
+    rng, n_features, hidden_dim_list, dist_type, n_samples, mu_init, sigma_init, nu, num_steps, lr
 ):
     """With SGD step_size=0, ADVI must leave mu and sigma identical to the prior.
 
@@ -2822,8 +2843,8 @@ def test_advi_zero_lr_posterior_equals_prior(
         dist_params_init=dist_params_init,
     )
 
-    context = np.random.standard_normal((n_samples, n_features)).astype(np.float32)
-    rewards = np.random.choice([0, 1], size=n_samples).tolist()
+    context = rng.standard_normal((n_samples, n_features)).astype(np.float32)
+    rewards = rng.choice([0, 1], size=n_samples).tolist()
     bnn.update(context=context, rewards=rewards)
 
     # float32 rounding on mu; softplus(softplus_inverse(sigma)) rounding on sigma

--- a/tests/test_offline_policy_evaluator.py
+++ b/tests/test_offline_policy_evaluator.py
@@ -51,21 +51,21 @@ from tests.utils import mock_update
 
 
 @pytest.fixture(scope="module")
-def logged_data(n_samples=10, n_actions=2, n_batches=3, n_rewards=2, n_groups=2, n_features=3):
+def logged_data(rng, n_samples=10, n_actions=2, n_batches=3, n_rewards=2, n_groups=2, n_features=3):
     unique_actions = [f"a{i}" for i in range(n_actions)]
-    action_ids = np.random.choice(unique_actions, n_samples * n_batches)
+    action_ids = rng.choice(unique_actions, n_samples * n_batches)
     batches = [i for i in range(n_batches) for _ in range(n_samples)]
-    rewards = [np.random.randint(2, size=(n_samples * n_batches)) for _ in range(n_rewards)]
-    action_true_rewards = {(a, r): np.random.rand() for a in unique_actions for r in range(n_rewards)}
+    rewards = [rng.integers(2, size=(n_samples * n_batches)) for _ in range(n_rewards)]
+    action_true_rewards = {(a, r): rng.random() for a in unique_actions for r in range(n_rewards)}
     true_rewards = [
         np.array([action_true_rewards[(a, r)] for a in action_ids]).reshape(n_samples * n_batches)
         for r in range(n_rewards)
     ]
-    groups = np.random.randint(n_groups, size=n_samples * n_batches)
-    action_costs = {action: np.random.rand() for action in unique_actions}
+    groups = rng.integers(n_groups, size=n_samples * n_batches)
+    action_costs = {action: rng.random() for action in unique_actions}
     costs = np.array([action_costs[a] for a in action_ids])
-    context = np.random.rand(n_samples * n_batches, n_features)
-    action_propensity_score = {action: np.random.rand() for action in unique_actions}
+    context = rng.random((n_samples * n_batches, n_features))
+    action_propensity_score = {action: rng.random() for action in unique_actions}
     propensity_score = np.array([action_propensity_score[a] for a in action_ids])
     return pd.DataFrame(
         {
@@ -524,7 +524,7 @@ class TestFunctionEstimatorEdgeCases:
     )
     @settings(max_examples=5, deadline=None)
     def test_predict_multiclass_path(
-        self, n_samples: int, n_features: int, n_actions: int, base_estimator_kwargs: dict
+        self, n_samples: int, n_features: int, n_actions: int, base_estimator_kwargs: dict, rng: np.random.Generator
     ) -> None:
         """include_action_in_features=False exercises the multiclass probability extraction path."""
         n_test = min(n_actions, n_samples)
@@ -532,7 +532,7 @@ class TestFunctionEstimatorEdgeCases:
         label_to_int = {label: i for i, label in enumerate(unique_labels)}
         actions = np.array([f"a{i % n_actions}" for i in range(n_samples)])
         encoded = np.array([label_to_int[a] for a in actions])
-        context = np.random.rand(n_samples, n_features)
+        context = rng.random((n_samples, n_features))
 
         estimator = _FunctionEstimator(
             **{**base_estimator_kwargs, "include_action_in_features": False, "calibrate": False},

--- a/tests/test_quantitative_model.py
+++ b/tests/test_quantitative_model.py
@@ -177,9 +177,9 @@ def test_sample_proba_returns_valid_probabilities(rng, n_samples=100, test_locat
     seeds=st.lists(st.integers(min_value=0, max_value=2**31 - 1), min_size=2, max_size=2, unique=True),
     n_locations=st.just(10),
 )
-def test_sample_proba_reproducible_with_same_rng(dimension, n_samples, seeds, n_locations):
+def test_sample_proba_reproducible_with_same_rng(rng, dimension, n_samples, seeds, n_locations):
     model = Zooming.cold_start(dimension=dimension, n_max_segments=None)
-    locations = [tuple([q] * dimension) for q in np.random.uniform(size=n_locations)]
+    locations = [tuple([q] * dimension) for q in rng.uniform(size=n_locations)]
 
     def draw(seed):
         functions = model.sample_proba(n_samples=n_samples, rng=np.random.default_rng(seed=seed))
@@ -305,10 +305,10 @@ def test_initializes_smab_zooming_model_correctly(dimension, n_max_segments):
     rewards=st.lists(st.integers(min_value=0, max_value=1), min_size=1, max_size=5),
     dimension=st.just(1),
 )
-def test_updates_smab_zooming_model_correctly(rewards, dimension):
+def test_updates_smab_zooming_model_correctly(rng, rewards, dimension):
     model = Zooming.cold_start(dimension=dimension)
     initial_segments = deepcopy(model.segmented_actions)
-    quantities = np.random.uniform(0, 1, size=len(rewards)).tolist()
+    quantities = rng.uniform(0, 1, size=len(rewards)).tolist()
     model.update(quantities=quantities, rewards=rewards)
     assert model.segmented_actions != initial_segments
 
@@ -419,7 +419,7 @@ def test_sample_proba_returns_valid_probabilities_cmab(
         context = np.array([[0], [1], [2], [0], [1]], dtype=np.float64)
     else:
         model = QuantitativeBayesianNeuralNetwork.cold_start(dimension=dimension, n_features=n_features)
-        context = np.random.uniform(low=0, high=1, size=(5, 1))
+        context = rng.uniform(low=0, high=1, size=(5, 1))
 
     prob_functions = model.sample_proba(context=context, rng=rng)
     assert len(prob_functions) == len(context)

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -78,9 +78,9 @@ def test_mismatched_probs_reward_columns(mocker: MockerFixture):
 
 # Returns spline function for single dimension input when second_dimension=0
 @given(first_dimension=st.integers(min_value=1, max_value=10))
-def test_single_dimension_spline(first_dimension):
+def test_single_dimension_spline(first_dimension, rng):
     spline_fn = Simulator._generate_prob_reward(first_dimension=first_dimension)
-    test_input = np.random.random(first_dimension)
+    test_input = rng.random(first_dimension)
     result = spline_fn(test_input)
     assert isinstance(result, float)
     assert 0 <= result <= 1
@@ -88,10 +88,10 @@ def test_single_dimension_spline(first_dimension):
 
 # Returns spline function for two dimension inputs when second_dimension>0
 @given(first_dim=st.integers(min_value=1, max_value=5), second_dim=st.integers(min_value=1, max_value=5))
-def test_two_dimension_spline(first_dim, second_dim):
+def test_two_dimension_spline(first_dim, second_dim, rng):
     spline_fn = Simulator._generate_prob_reward(first_dimension=first_dim, second_dimension=second_dim)
-    input1 = np.random.random(first_dim)
-    input2 = np.random.random(second_dim)
+    input1 = rng.random(first_dim)
+    input2 = rng.random(second_dim)
     result = spline_fn(input1, input2)
     assert isinstance(result, float)
     assert 0 <= result <= 1

--- a/tests/test_smab.py
+++ b/tests/test_smab.py
@@ -93,11 +93,12 @@ class ModelTestConfig:
         action_ids: List[str],
         values: Optional[st.SearchStrategy],
         n_objectives: Optional[PositiveInt],
+        rng: np.random.Generator,
         decay_factor: Optional[Float01] = None,
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         model_types = list(self.model_types)
         if len(model_types) < len(action_ids):
-            indices = np.random.randint(0, len(model_types), len(action_ids))
+            indices = rng.integers(0, len(model_types), len(action_ids))
             model_types = [model_types[i] for i in indices]
         base_model_cold_start_kwargs: Dict[str, Any] = {}
         if decay_factor is not None:
@@ -164,24 +165,36 @@ class ModelTestConfig:
         n_objectives: st.SearchStrategy[PositiveInt],
         exploit_p: Union[st.SearchStrategy[Optional[Float01]], Optional[float]],
         subsidy_factor: Union[st.SearchStrategy[Optional[Float01]], Optional[float]],
+        rng: np.random.Generator,
         decay_factor: Optional[Float01] = None,
+        default_action_fraction: Optional[Float01] = None,
+        limited_action_fraction: Optional[Float01] = None,
     ) -> Tuple[BaseSmabBernoulli, Dict[ActionId, SmabModelType], Dict[str, Any]]:
         n_objectives = (
             n_objectives.draw(st.integers(min_value=1, max_value=10))
             if self.smab_class in [SmabBernoulliMO, SmabBernoulliMOCC]
             else None
         )
-        actions, base_model_cold_start_kwargs = self._create_actions(action_ids, values, n_objectives, decay_factor)
+        actions, base_model_cold_start_kwargs = self._create_actions(
+            action_ids, values, n_objectives, rng, decay_factor
+        )
         default_action = action_ids[0] if epsilon and not delta else None
         if default_action and isinstance(actions[default_action], QuantitativeModel):
-            default_action = (default_action, tuple(np.random.random(actions[default_action].dimension)))
+            default_action = (default_action, tuple(rng.random(actions[default_action].dimension)))
         epsilon = epsilon if not delta else 0.1
+        # default_action_fraction requires a default_action; limited_actions is derived from the
+        # action set (excluding default_action) exactly as default_action is derived from epsilon.
+        default_action_fraction = default_action_fraction if default_action else None
+        limited_actions = {action_ids[-1]} if limited_action_fraction is not None else None
         kwargs = {
             k: v
             for k, v in {
                 "epsilon": epsilon,
                 "default_action": default_action,
                 "delta": delta,
+                "default_action_fraction": default_action_fraction,
+                "limited_actions": limited_actions,
+                "limited_action_fraction": limited_action_fraction,
             }.items()
             if v is not None
         }
@@ -235,6 +248,8 @@ TEST_CONFIGS = {
         unique=True,
     ),
     epsilon=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
+    default_action_fraction=st.one_of(st.none(), st.floats(min_value=1e-3, max_value=1)),
+    limited_action_fraction=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
     delta=st.one_of(st.none(), st.just(0.1)),
     values=st.data(),
     n_objectives=st.data(),
@@ -246,16 +261,29 @@ def test_cold_start(
     config: ModelTestConfig,
     action_ids: List[str],
     epsilon: Optional[float],
+    default_action_fraction: Optional[float],
+    limited_action_fraction: Optional[float],
     delta,
     values,
     n_objectives,
     exploit_p,
     subsidy_factor,
     decay_factor: Optional[float],
+    rng: np.random.Generator,
 ):
     # Create SMAB instance
     smab, actions, kwargs = config.create_smab_and_actions(
-        action_ids, epsilon, delta, values, n_objectives, exploit_p, subsidy_factor, decay_factor
+        action_ids,
+        epsilon,
+        delta,
+        values,
+        n_objectives,
+        exploit_p,
+        subsidy_factor,
+        rng,
+        decay_factor,
+        default_action_fraction=default_action_fraction,
+        limited_action_fraction=limited_action_fraction,
     )
 
     # Cold start comparison logic (modified for different model types)
@@ -281,6 +309,10 @@ def test_cold_start(
         }
     cold_start_kwargs.update(kwargs)  # Add exploit_p or subsidy_factor if needed
     cold_start_kwargs = {k: v for k, v in cold_start_kwargs.items() if v is not None}
+    # cold_start's default_action argument only accepts a discrete action id; a quantitative
+    # (tuple) default_action cannot be expressed through it, so skip the equivalence check there.
+    if isinstance(cold_start_kwargs.get("default_action"), tuple):
+        return
     assert config.smab_class.cold_start(**cold_start_kwargs) == smab
 
 
@@ -300,6 +332,7 @@ def test_bad_initialization(
     values,
     exploit_p,
     subsidy_factor,
+    rng: np.random.Generator,
 ):
     real_n_objectives = n_objectives.draw(st.integers(min_value=1, max_value=10))
     if config.smab_class in (SmabBernoulliCC, SmabBernoulliMOCC):
@@ -343,6 +376,7 @@ def test_bad_initialization(
                 n_objectives,
                 exploit_p.draw(st.sampled_from([-0.1, 1.1])),
                 subsidy_factor,
+                rng,
             )
     elif config.smab_class == SmabBernoulliCC:
         with pytest.raises(ValidationError):
@@ -354,6 +388,7 @@ def test_bad_initialization(
                 n_objectives,
                 exploit_p,
                 subsidy_factor.draw(st.sampled_from([-0.1, 1.1])),
+                rng,
             )
 
     # Test multi-objective specific cases
@@ -380,6 +415,8 @@ def test_bad_initialization(
     ),
     n_samples=st.integers(min_value=1, max_value=100),
     epsilon=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
+    default_action_fraction=st.one_of(st.none(), st.floats(min_value=1e-3, max_value=1)),
+    limited_action_fraction=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
     delta=st.one_of(st.none(), st.just(0.1)),
     values=st.data(),
     n_objectives=st.data(),
@@ -392,24 +429,27 @@ def test_update(
     action_ids: List[str],
     n_samples: int,
     epsilon: Optional[float],
+    default_action_fraction: Optional[float],
+    limited_action_fraction: Optional[float],
     delta,
     values,
     n_objectives,
     exploit_p,
     subsidy_factor,
     memory_len,
+    rng: np.random.Generator,
 ):
     # Create SMAB instance
     smab, _, kwargs = config.create_smab_and_actions(
-        action_ids, epsilon, delta, values, n_objectives, exploit_p, subsidy_factor
+        action_ids, epsilon, delta, values, n_objectives, exploit_p, subsidy_factor, rng
     )
     batched_smab = deepcopy(smab)
     n_objectives = kwargs.get("n_objectives")
     # Generate random rewards
     reward_data = (
-        np.random.choice([0, 1], size=(n_samples, n_objectives), replace=True)
+        rng.choice([0, 1], size=(n_samples, n_objectives), replace=True)
         if n_objectives
-        else np.random.choice([0, 1], size=n_samples, replace=True)
+        else rng.choice([0, 1], size=n_samples, replace=True)
     )
     reward_data = reward_data.tolist()
     # Test updates with generated data
@@ -417,7 +457,7 @@ def test_update(
         action_ids, n_samples
     )  # Generate quantities only if there are any QuantitativeModel actions
     if any(isinstance(model, QuantitativeModel) for model in smab.actions.values()):
-        quantity_data = np.random.random(size=n_samples).tolist()
+        quantity_data = rng.random(size=n_samples).tolist()
         quantity_data = [
             q if isinstance(smab.actions[action], QuantitativeModel) else None
             for q, action in zip(quantity_data, actions_to_update)
@@ -484,6 +524,8 @@ def test_update(
     ),
     n_samples=st.integers(min_value=1, max_value=100),
     epsilon=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
+    default_action_fraction=st.one_of(st.none(), st.floats(min_value=1e-3, max_value=1)),
+    limited_action_fraction=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
     delta=st.one_of(st.none(), st.just(0.1)),
     values=st.data(),
     n_objectives=st.data(),
@@ -496,6 +538,8 @@ def test_predict(
     action_ids: List[str],
     n_samples: int,
     epsilon: Optional[float],
+    default_action_fraction: Optional[float],
+    limited_action_fraction: Optional[float],
     delta,
     values,
     n_objectives,
@@ -503,16 +547,17 @@ def test_predict(
     subsidy_factor,
     diff,
     monkeymodule,
+    rng: np.random.Generator,
 ):
     def mock_maximize_by_quantity(quantity_score_func, dimension, constraint=None, n_trials=10000, **kwargs):
         """Mock maximize_by_quantity to return a quick result."""
-        return np.random.random(dimension)
+        return rng.random(dimension)
 
     if config.smab_class in (SmabBernoulliMO, SmabBernoulliMOCC):
 
         def mock_find_pareto_front_normal_constraint(self, func, input_dim, n_objectives, n_divisions, model):
             """Mock _find_pareto_front_normal_constraint to return a quick result."""
-            return [np.random.random(input_dim) for _ in range(min(3, n_divisions))]
+            return [rng.random(input_dim) for _ in range(min(3, n_divisions))]
 
         monkeymodule.setattr(
             pybandits.strategy.MultiObjectiveStrategy,
@@ -523,7 +568,16 @@ def test_predict(
     with patch.object(pybandits.strategy.single_objective, "maximize_by_quantity", mock_maximize_by_quantity):
         # Create SMAB instance
         smab = config.create_smab_and_actions(
-            action_ids, epsilon, delta, values, n_objectives, exploit_p, subsidy_factor
+            action_ids,
+            epsilon,
+            delta,
+            values,
+            n_objectives,
+            exploit_p,
+            subsidy_factor,
+            rng,
+            default_action_fraction=default_action_fraction,
+            limited_action_fraction=limited_action_fraction,
         )[0]
 
         # Test predictions with random forbidden actions
@@ -567,6 +621,8 @@ def test_predict(
         unique=True,
     ),
     epsilon=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
+    default_action_fraction=st.one_of(st.none(), st.floats(min_value=1e-3, max_value=1)),
+    limited_action_fraction=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
     delta=st.one_of(st.none(), st.just(0.1)),
     values=st.data(),
     n_objectives=st.data(),
@@ -578,6 +634,8 @@ def test_serialization(
     config: ModelTestConfig,
     action_ids: List[str],
     epsilon: Optional[float],
+    default_action_fraction: Optional[float],
+    limited_action_fraction: Optional[float],
     delta,
     values,
     n_objectives,
@@ -585,11 +643,21 @@ def test_serialization(
     subsidy_factor,
     diff,
     monkeymodule,
+    rng: np.random.Generator,
 ):
     # Create SMAB instance
-    smab = config.create_smab_and_actions(action_ids, epsilon, delta, values, n_objectives, exploit_p, subsidy_factor)[
-        0
-    ]
+    smab = config.create_smab_and_actions(
+        action_ids,
+        epsilon,
+        delta,
+        values,
+        n_objectives,
+        exploit_p,
+        subsidy_factor,
+        rng,
+        default_action_fraction=default_action_fraction,
+        limited_action_fraction=limited_action_fraction,
+    )[0]
 
     pre_update_state = smab.get_state()
     mock_update(list(smab.actions.values()), diff, monkeymodule)
@@ -614,6 +682,8 @@ def test_serialization(
         unique=True,
     ),
     epsilon=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
+    default_action_fraction=st.one_of(st.none(), st.floats(min_value=1e-3, max_value=1)),
+    limited_action_fraction=st.one_of(st.none(), st.floats(min_value=0, max_value=1)),
     delta=st.one_of(st.none(), st.just(0.1)),
     values=st.data(),
     n_objectives=st.data(),
@@ -625,6 +695,8 @@ def test_pickling(
     config: ModelTestConfig,
     action_ids: List[str],
     epsilon: Optional[float],
+    default_action_fraction: Optional[float],
+    limited_action_fraction: Optional[float],
     delta,
     values,
     n_objectives,
@@ -632,11 +704,21 @@ def test_pickling(
     subsidy_factor,
     diff,
     monkeymodule,
+    rng: np.random.Generator,
 ):
     # Create SMAB instance
-    smab = config.create_smab_and_actions(action_ids, epsilon, delta, values, n_objectives, exploit_p, subsidy_factor)[
-        0
-    ]
+    smab = config.create_smab_and_actions(
+        action_ids,
+        epsilon,
+        delta,
+        values,
+        n_objectives,
+        exploit_p,
+        subsidy_factor,
+        rng,
+        default_action_fraction=default_action_fraction,
+        limited_action_fraction=limited_action_fraction,
+    )[0]
     to_temporary_pickle(smab)
     mock_update(list(smab.actions.values()), diff, monkeymodule)
     to_temporary_pickle(smab)
@@ -673,230 +755,266 @@ def test_smab_predict_raise_when_all_actions_forbidden():
 ########################################################################################################################
 # Region-aware forbidden_actions (forbidding part of a quantitative arm's hypercube)
 
-# A forbidden region on a 1-D quantitative arm: float signed-margin convention, forbidden where region(x) > 0,
-# i.e. the upper half-interval x[0] > REGION_SPLIT is blocked.
-REGION_SPLIT = 0.5
-REGION_TOLERANCE = 1e-2
-EXPLORE_SAMPLES = 50
-HYPOTHESIS_EXPLOIT_SAMPLES = 5  # small enough to stay under hypothesis's default 200ms deadline
-EXPLORE_SEED = 123
-QUANTITATIVE_DIMENSION = 1
-QUANTITATIVE_ARM_ID = "q"
-DISCRETE_ARM_ID = "d"
-EPSILON_FULL_EXPLORE = 1.0  # forces the random explore branch on every step
-ALLOWED_SEGMENT_LOW = 0.6
-ALLOWED_SEGMENT_HIGH = 1.0
-_MAX_REJECTION_SAMPLES = 1000
 
+class TestForbiddenRegions:
+    """Region-aware forbidden_actions: forbidding part of a quantitative arm's hypercube (sMAB edition)."""
 
-def _constraint_aware_maximize(
-    quantity_score_func, dimension: int, constraint=None, n_trials: int = 10000, **kwargs
-) -> np.ndarray:
-    """Mock maximize_by_quantity: rejection-samples a feasible quantity for hypothesis speed."""
-    constraints = constraint or []
-    for _ in range(_MAX_REJECTION_SAMPLES):
-        candidate = np.random.random(dimension)
-        if all(c(candidate) >= 0 for c in constraints):
-            return candidate
-    return np.random.random(dimension)
+    # A forbidden region on a 1-D quantitative arm follows the float signed-margin convention: forbidden where
+    # region(x) > 0, i.e. the upper half-interval x[0] > region_split is blocked.
+    region_split = 0.5
+    region_tolerance = 1e-2
+    explore_samples = 50
+    hypothesis_exploit_samples = 5  # small enough to stay under hypothesis's default 200ms deadline
+    explore_seed = 123
+    quantitative_dimension = 1
+    quantitative_arm_id = "q"
+    discrete_arm_id = "d"
+    epsilon_full_explore = 1.0  # forces the random explore branch on every step
+    allowed_segment_high = 1.0
+    max_rejection_samples = 1000
 
-
-def _forbid_upper_half(x: np.ndarray) -> float:
-    """Forbidden-region predicate: x[0] > REGION_SPLIT is forbidden (region(x) > 0 => forbidden)."""
-    return float(x[0]) - REGION_SPLIT
-
-
-def _always_forbidden(x: np.ndarray) -> float:
-    """Forbidden-region predicate that forbids the entire quantity space (margin always positive)."""
-    return 1.0
-
-
-def _quantitative_smab(**kwargs) -> SmabBernoulli:
-    """Build a sMAB with one continuous (Zooming) arm and one discrete (Beta) arm."""
-    return SmabBernoulli(
-        actions={
-            QUANTITATIVE_ARM_ID: Zooming.cold_start(dimension=QUANTITATIVE_DIMENSION),
-            DISCRETE_ARM_ID: Beta(),
-        },
+    def _constraint_aware_maximize(
+        self,
+        quantity_score_func,
+        dimension: int,
+        constraint=None,
+        n_trials: int = 10000,
+        max_rejection_samples: int = max_rejection_samples,
         **kwargs,
+    ) -> np.ndarray:
+        """Mock maximize_by_quantity: rejection-samples a feasible quantity for hypothesis speed."""
+        constraints = constraint or []
+        for _ in range(max_rejection_samples):
+            candidate = self._rng.random(dimension)
+            if all(c(candidate) >= 0 for c in constraints):
+                return candidate
+        return self._rng.random(dimension)
+
+    @staticmethod
+    def _forbid_upper_half(x: np.ndarray, split: float = region_split) -> float:
+        """Forbidden-region predicate: x[0] > split is forbidden (region(x) > 0 => forbidden)."""
+        return float(x[0]) - split
+
+    @staticmethod
+    def _always_forbidden(x: np.ndarray) -> float:
+        """Forbidden-region predicate that forbids the entire quantity space (margin always positive)."""
+        return 1.0
+
+    @pytest.fixture(scope="class")
+    def make_smab(self):
+        """Factory: builds a sMAB with one continuous (Zooming) arm and one discrete (Beta) arm."""
+
+        def _factory(**kwargs) -> SmabBernoulli:
+            return SmabBernoulli(
+                actions={
+                    self.quantitative_arm_id: Zooming.cold_start(dimension=self.quantitative_dimension),
+                    self.discrete_arm_id: Beta(),
+                },
+                **kwargs,
+            )
+
+        return _factory
+
+    def test_normalize_forbidden_actions_forms(
+        self,
+        make_smab,
+        quantitative_arm_id: str = quantitative_arm_id,
+        discrete_arm_id: str = discrete_arm_id,
+    ) -> None:
+        """_normalize_forbidden_actions handles the Set, dict-None (whole arm) and dict-region (partial) forms."""
+        smab = make_smab()
+
+        # Legacy Set form: whole-arm blocking, no region constraints.
+        valid, regions = smab._normalize_forbidden_actions({discrete_arm_id})
+        assert valid == {quantitative_arm_id} and regions == {}
+
+        # dict with None value is equivalent to whole-arm blocking.
+        valid, regions = smab._normalize_forbidden_actions({discrete_arm_id: None})
+        assert valid == {quantitative_arm_id} and regions == {}
+
+        # dict with a region keeps the arm valid (only its quantity space shrinks) and records its constraint.
+        valid, regions = smab._normalize_forbidden_actions({quantitative_arm_id: self._forbid_upper_half})
+        assert valid == {quantitative_arm_id, discrete_arm_id}
+        assert set(regions) == {quantitative_arm_id} and len(regions[quantitative_arm_id]) == 1
+
+    def test_region_rejected_on_discrete_arm(self, make_smab, discrete_arm_id: str = discrete_arm_id) -> None:
+        """A forbidden region cannot be attached to a non-quantitative arm."""
+        smab = make_smab()
+        with pytest.raises(ValueError, match="quantitative"):
+            smab._normalize_forbidden_actions({discrete_arm_id: self._forbid_upper_half})
+
+    @settings(deadline=None)
+    @given(
+        quantity=st.floats(min_value=region_split, max_value=1.0, exclude_min=True),
+        epsilon=st.floats(min_value=0.0, max_value=1.0, exclude_min=True),
+        arm_id=st.just(quantitative_arm_id),
     )
+    def test_default_action_in_region_raises(self, make_smab, quantity: float, epsilon: float, arm_id: str) -> None:
+        """Any quantitative default action strictly above region_split is rejected when the upper half is forbidden."""
+        smab = make_smab(epsilon=epsilon, default_action=(arm_id, (quantity,)))
+        with pytest.raises(ValueError, match="forbidden region"):
+            smab._normalize_forbidden_actions({arm_id: self._forbid_upper_half})
 
+    @settings(deadline=None)
+    @given(x0=st.floats(min_value=0.0, max_value=1.0), region_split=st.floats(min_value=0.1, max_value=0.9))
+    def test_to_feasibility_constraint_negates_margin(self, x0: float, region_split: float) -> None:
+        """Points above region_split are marked forbidden by the converted constraint; at/below are feasible."""
+        constraint = SmabBernoulli._to_feasibility_constraint(partial(self._forbid_upper_half, split=region_split))
+        point = np.array([x0])
+        # By contract: constraint(x) < 0 means forbidden; >= 0 means feasible.
+        if x0 > region_split:
+            assert constraint(point) < 0
+        else:
+            assert constraint(point) >= 0
 
-def test_smab_normalize_forbidden_actions_forms() -> None:
-    """_normalize_forbidden_actions handles the Set, dict-None (whole arm) and dict-region (partial) forms."""
-    smab = _quantitative_smab()
-
-    # Legacy Set form: whole-arm blocking, no region constraints.
-    valid, regions = smab._normalize_forbidden_actions({DISCRETE_ARM_ID})
-    assert valid == {QUANTITATIVE_ARM_ID} and regions == {}
-
-    # dict with None value is equivalent to whole-arm blocking.
-    valid, regions = smab._normalize_forbidden_actions({DISCRETE_ARM_ID: None})
-    assert valid == {QUANTITATIVE_ARM_ID} and regions == {}
-
-    # dict with a region keeps the arm valid (only its quantity space shrinks) and records its constraint.
-    valid, regions = smab._normalize_forbidden_actions({QUANTITATIVE_ARM_ID: _forbid_upper_half})
-    assert valid == {QUANTITATIVE_ARM_ID, DISCRETE_ARM_ID}
-    assert set(regions) == {QUANTITATIVE_ARM_ID} and len(regions[QUANTITATIVE_ARM_ID]) == 1
-
-
-def test_smab_forbidden_region_rejected_on_discrete_arm() -> None:
-    """A forbidden region cannot be attached to a non-quantitative arm."""
-    smab = _quantitative_smab()
-    with pytest.raises(ValueError, match="quantitative"):
-        smab._normalize_forbidden_actions({DISCRETE_ARM_ID: _forbid_upper_half})
-
-
-@settings(deadline=None)
-@given(
-    quantity=st.floats(min_value=REGION_SPLIT, max_value=1.0, exclude_min=True),
-    epsilon=st.floats(min_value=0.0, max_value=1.0, exclude_min=True),
-)
-def test_smab_forbidden_region_default_action_in_region_raises(quantity: float, epsilon: float) -> None:
-    """Any quantitative default action strictly above REGION_SPLIT is rejected when the upper half is forbidden."""
-    smab = _quantitative_smab(
-        epsilon=epsilon,
-        default_action=(QUANTITATIVE_ARM_ID, (quantity,)),
+    @given(
+        region_split=st.floats(min_value=0.1, max_value=0.9),
+        arm_id=st.just(quantitative_arm_id),
+        random_seed=st.just(explore_seed),
     )
-    with pytest.raises(ValueError, match="forbidden region"):
-        smab._normalize_forbidden_actions({QUANTITATIVE_ARM_ID: _forbid_upper_half})
+    def test_sample_allowed_quantity_respects_and_exhausts_region(
+        self,
+        make_smab,
+        region_split: float,
+        arm_id: str,
+        random_seed: int,
+    ) -> None:
+        """_sample_allowed_quantity returns a point outside the region, or None when the whole space is forbidden."""
+        smab = make_smab(random_seed=random_seed)
+        _, regions = smab._normalize_forbidden_actions({arm_id: partial(self._forbid_upper_half, split=region_split)})
 
+        allowed = smab._sample_allowed_quantity(arm_id, regions)
+        assert allowed is not None and allowed[0] <= region_split
 
-@settings(deadline=None)
-@given(x0=st.floats(min_value=0.0, max_value=1.0))
-def test_to_feasibility_constraint_negates_margin(x0: float) -> None:
-    """Points above REGION_SPLIT are marked forbidden by the converted constraint; at/below are feasible."""
-    constraint = SmabBernoulli._to_feasibility_constraint(_forbid_upper_half)
-    point = np.array([x0])
-    # By contract: constraint(x) < 0 means forbidden; >= 0 means feasible.
-    if x0 > REGION_SPLIT:
-        assert constraint(point) < 0
-    else:
-        assert constraint(point) >= 0
+        # A region that forbids the entire cube yields no allowed point.
+        _, full_regions = smab._normalize_forbidden_actions({arm_id: self._always_forbidden})
+        assert smab._sample_allowed_quantity(arm_id, full_regions) is None
 
+    def test_predict_explore_never_selects_forbidden_region(
+        self,
+        arm_id: str = quantitative_arm_id,
+        dimension: int = quantitative_dimension,
+        epsilon: float = epsilon_full_explore,
+        random_seed: int = explore_seed,
+        n_samples: int = explore_samples,
+        region_split: float = region_split,
+        tolerance: float = region_tolerance,
+    ) -> None:
+        """With epsilon=1 (always explore), the random quantitative quantity always avoids the forbidden region."""
+        smab = SmabBernoulli(
+            actions={arm_id: Zooming.cold_start(dimension=dimension)},
+            epsilon=epsilon,
+            random_seed=random_seed,
+        )
 
-def test_smab_sample_allowed_quantity_respects_and_exhausts_region() -> None:
-    """_sample_allowed_quantity returns a point outside the region, or None when the whole space is forbidden."""
-    smab = _quantitative_smab(random_seed=EXPLORE_SEED)
-    _, regions = smab._normalize_forbidden_actions({QUANTITATIVE_ARM_ID: _forbid_upper_half})
+        selected_actions, _ = smab.predict(n_samples=n_samples, forbidden_actions={arm_id: self._forbid_upper_half})
 
-    allowed = smab._sample_allowed_quantity(QUANTITATIVE_ARM_ID, regions)
-    assert allowed is not None and allowed[0] <= REGION_SPLIT
+        assert all(isinstance(action, tuple) and action[0] == arm_id for action in selected_actions)
+        assert all(action[1][0] <= region_split + tolerance for action in selected_actions)
 
-    # A region that forbids the entire cube yields no allowed point.
-    _, full_regions = smab._normalize_forbidden_actions({QUANTITATIVE_ARM_ID: _always_forbidden})
-    assert smab._sample_allowed_quantity(QUANTITATIVE_ARM_ID, full_regions) is None
-
-
-def test_smab_predict_explore_never_selects_forbidden_region() -> None:
-    """With epsilon=1 (always explore), the random quantitative quantity always avoids the forbidden region."""
-    smab = SmabBernoulli(
-        actions={QUANTITATIVE_ARM_ID: Zooming.cold_start(dimension=QUANTITATIVE_DIMENSION)},
-        epsilon=EPSILON_FULL_EXPLORE,
-        random_seed=EXPLORE_SEED,
+    @given(
+        region_split=st.floats(min_value=0.1, max_value=0.9),
+        arm_id=st.just(quantitative_arm_id),
+        dimension=st.just(quantitative_dimension),
+        random_seed=st.just(explore_seed),
+        n_samples=st.just(hypothesis_exploit_samples),
+        tolerance=st.just(region_tolerance),
     )
+    def test_predict_exploit_respects_forbidden_region(
+        self,
+        region_split: float,
+        arm_id: str,
+        dimension: int,
+        random_seed: int,
+        n_samples: int,
+        tolerance: float,
+        rng: np.random.Generator,
+    ) -> None:
+        """Constrained optimizer stays below any forbidden boundary, not just the default split of 0.5."""
+        self._rng = rng
 
-    selected_actions, _ = smab.predict(
-        n_samples=EXPLORE_SAMPLES, forbidden_actions={QUANTITATIVE_ARM_ID: _forbid_upper_half}
+        def forbid_above(x: np.ndarray) -> float:
+            return float(x[0]) - region_split
+
+        smab = SmabBernoulli(
+            actions={arm_id: Zooming.cold_start(dimension=dimension)},
+            random_seed=random_seed,
+        )
+
+        with patch.object(pybandits.strategy.single_objective, "maximize_by_quantity", self._constraint_aware_maximize):
+            selected_actions, _ = smab.predict(n_samples=n_samples, forbidden_actions={arm_id: forbid_above})
+
+        assert all(isinstance(action, tuple) and action[0] == arm_id for action in selected_actions)
+        assert all(action[1][0] <= region_split + tolerance for action in selected_actions)
+
+    @settings(deadline=None)
+    @given(
+        lo=st.floats(min_value=0.0, max_value=0.4),
+        hi=st.floats(min_value=0.6, max_value=1.0),
+        x=st.floats(min_value=0.0, max_value=1.0),
     )
+    def test_segment_region_outside_1d(self, lo: float, hi: float, x: float) -> None:
+        """forbidden_region_outside is non-positive inside [lo, hi] and positive outside (1-D)."""
+        region = Segment(intervals=((lo, hi),)).forbidden_region_outside()
+        point = np.array([x])
+        if lo <= x <= hi:
+            assert region(point) <= 0
+        else:
+            assert region(point) > 0
 
-    assert all(isinstance(action, tuple) and action[0] == QUANTITATIVE_ARM_ID for action in selected_actions)
-    assert all(action[1][0] <= REGION_SPLIT + REGION_TOLERANCE for action in selected_actions)
-
-
-@given(
-    region_split=st.floats(min_value=0.1, max_value=0.9),
-    arm_id=st.just(QUANTITATIVE_ARM_ID),
-    dimension=st.just(QUANTITATIVE_DIMENSION),
-    random_seed=st.just(EXPLORE_SEED),
-    n_samples=st.just(HYPOTHESIS_EXPLOIT_SAMPLES),
-    tolerance=st.just(REGION_TOLERANCE),
-)
-def test_smab_predict_exploit_respects_forbidden_region(
-    region_split: float,
-    arm_id: str,
-    dimension: int,
-    random_seed: int,
-    n_samples: int,
-    tolerance: float,
-) -> None:
-    """Constrained optimizer stays below any forbidden boundary, not just the default split of 0.5."""
-
-    def forbid_above(x: np.ndarray) -> float:
-        return float(x[0]) - region_split
-
-    smab = SmabBernoulli(
-        actions={arm_id: Zooming.cold_start(dimension=dimension)},
-        random_seed=random_seed,
+    @pytest.mark.parametrize(
+        "x0, x1, expected_forbidden",
+        [
+            (0.2, 0.7, False),  # inside [0, 0.5) x [0.5, 1.0] => allowed
+            (0.8, 0.7, True),  # x0=0.8 outside [0, 0.5) => forbidden
+        ],
     )
+    def test_segment_region_outside_2d(
+        self,
+        x0: float,
+        x1: float,
+        expected_forbidden: bool,
+        region_split: float = region_split,
+        segment_high: float = allowed_segment_high,
+    ) -> None:
+        """forbidden_region_outside extends to 2-D: a point outside any dimension's interval is forbidden."""
+        intervals = ((0.0, region_split), (region_split, segment_high))
+        region = Segment(intervals=intervals).forbidden_region_outside()
+        assert (region(np.array([x0, x1])) > 0) == expected_forbidden
 
-    with patch.object(pybandits.strategy.single_objective, "maximize_by_quantity", _constraint_aware_maximize):
-        selected_actions, _ = smab.predict(n_samples=n_samples, forbidden_actions={arm_id: forbid_above})
-
-    assert all(isinstance(action, tuple) and action[0] == arm_id for action in selected_actions)
-    assert all(action[1][0] <= region_split + tolerance for action in selected_actions)
-
-
-@settings(deadline=None)
-@given(
-    lo=st.floats(min_value=0.0, max_value=0.4),
-    hi=st.floats(min_value=0.6, max_value=1.0),
-    x=st.floats(min_value=0.0, max_value=1.0),
-)
-def test_segment_forbidden_region_outside_1d(lo: float, hi: float, x: float) -> None:
-    """forbidden_region_outside is non-positive inside [lo, hi] and positive outside (1-D)."""
-    region = Segment(intervals=((lo, hi),)).forbidden_region_outside()
-    point = np.array([x])
-    if lo <= x <= hi:
-        assert region(point) <= 0
-    else:
-        assert region(point) > 0
-
-
-@pytest.mark.parametrize(
-    "x0, x1, expected_forbidden",
-    [
-        (0.2, 0.7, False),  # inside [0, 0.5) x [0.5, 1.0] => allowed
-        (0.8, 0.7, True),  # x0=0.8 outside [0, 0.5) => forbidden
-    ],
-)
-def test_segment_forbidden_region_outside_2d(x0: float, x1: float, expected_forbidden: bool) -> None:
-    """forbidden_region_outside extends to 2-D: a point outside any dimension's interval is forbidden."""
-    intervals = ((0.0, REGION_SPLIT), (REGION_SPLIT, ALLOWED_SEGMENT_HIGH))
-    region = Segment(intervals=intervals).forbidden_region_outside()
-    assert (region(np.array([x0, x1])) > 0) == expected_forbidden
-
-
-@given(
-    seg_lo=st.floats(min_value=0.05, max_value=0.45),
-    seg_hi=st.floats(min_value=0.55, max_value=0.95),
-    arm_id=st.just(QUANTITATIVE_ARM_ID),
-    dimension=st.just(QUANTITATIVE_DIMENSION),
-    random_seed=st.just(EXPLORE_SEED),
-    n_samples=st.just(HYPOTHESIS_EXPLOIT_SAMPLES),
-    tolerance=st.just(REGION_TOLERANCE),
-)
-def test_segment_forbidden_region_outside_end_to_end(
-    seg_lo: float,
-    seg_hi: float,
-    arm_id: str,
-    dimension: int,
-    random_seed: int,
-    n_samples: int,
-    tolerance: float,
-) -> None:
-    """forbidden_region_outside keeps the exploited quantity inside any valid allowed segment."""
-    allowed = Segment(intervals=((seg_lo, seg_hi),))
-    smab = SmabBernoulli(
-        actions={arm_id: Zooming.cold_start(dimension=dimension)},
-        random_seed=random_seed,
+    @given(
+        seg_lo=st.floats(min_value=0.05, max_value=0.45),
+        seg_hi=st.floats(min_value=0.55, max_value=0.95),
+        arm_id=st.just(quantitative_arm_id),
+        dimension=st.just(quantitative_dimension),
+        random_seed=st.just(explore_seed),
+        n_samples=st.just(hypothesis_exploit_samples),
+        tolerance=st.just(region_tolerance),
     )
-    region = allowed.forbidden_region_outside()
+    def test_segment_region_outside_end_to_end(
+        self,
+        seg_lo: float,
+        seg_hi: float,
+        arm_id: str,
+        dimension: int,
+        random_seed: int,
+        n_samples: int,
+        tolerance: float,
+        rng: np.random.Generator,
+    ) -> None:
+        """forbidden_region_outside keeps the exploited quantity inside any valid allowed segment."""
+        self._rng = rng
+        allowed = Segment(intervals=((seg_lo, seg_hi),))
+        smab = SmabBernoulli(
+            actions={arm_id: Zooming.cold_start(dimension=dimension)},
+            random_seed=random_seed,
+        )
+        region = allowed.forbidden_region_outside()
 
-    with patch.object(pybandits.strategy.single_objective, "maximize_by_quantity", _constraint_aware_maximize):
-        selected_actions, _ = smab.predict(n_samples=n_samples, forbidden_actions={arm_id: region})
+        with patch.object(pybandits.strategy.single_objective, "maximize_by_quantity", self._constraint_aware_maximize):
+            selected_actions, _ = smab.predict(n_samples=n_samples, forbidden_actions={arm_id: region})
 
-    assert all(seg_lo - tolerance <= action[1][0] <= seg_hi + tolerance for action in selected_actions)
+        assert all(seg_lo - tolerance <= action[1][0] <= seg_hi + tolerance for action in selected_actions)
 
 
 @given(st.text())

--- a/tests/test_smab_simulator.py
+++ b/tests/test_smab_simulator.py
@@ -199,7 +199,7 @@ def mock_predict(self, n_samples, *args, **kwargs):
     models=st.lists(st.sampled_from([Beta(), Zooming.cold_start()]), min_size=2, max_size=2),
 )
 def test_smab_e2e_simulation_with_default_args(
-    action_ids: List[str], models: List[BaseModel], monkeymodule: pytest.MonkeyPatch
+    action_ids: List[str], models: List[BaseModel], monkeymodule: pytest.MonkeyPatch, rng: np.random.Generator
 ):
     """
     Test end-to-end simulation with default arguments.
@@ -213,12 +213,12 @@ def test_smab_e2e_simulation_with_default_args(
     monkeymodule : MonkeyPatch
         Pytest monkeypatch fixture for modifying module attributes.
     """
-    monkeymodule.setattr(pybandits.utils, "maximize_by_quantity", lambda *args, **kwargs: np.random.random(size=(1,)))
+    monkeymodule.setattr(pybandits.utils, "maximize_by_quantity", lambda *args, **kwargs: rng.random(size=(1,)))
     monkeymodule.setattr(
-        pybandits.smab_simulator, "maximize_by_quantity", lambda *args, **kwargs: np.random.random(size=(1,))
+        pybandits.smab_simulator, "maximize_by_quantity", lambda *args, **kwargs: rng.random(size=(1,))
     )
     monkeymodule.setattr(
-        pybandits.strategy.single_objective, "maximize_by_quantity", lambda *args, **kwargs: np.random.random(size=(1,))
+        pybandits.strategy.single_objective, "maximize_by_quantity", lambda *args, **kwargs: rng.random(size=(1,))
     )
     monkeymodule.setattr(pybandits.smab.SmabBernoulli, "predict", mock_predict)
 
@@ -257,6 +257,7 @@ def test_smab_e2e_simulation_with_non_default_args(
     visualize: bool,
     file_prefix: str,
     monkeymodule: MonkeyPatch,
+    rng: np.random.Generator,
 ):
     """
     Test end-to-end simulation with non-default arguments.
@@ -283,13 +284,15 @@ def test_smab_e2e_simulation_with_non_default_args(
         Prefix for saved files.
     monkeymodule : MonkeyPatch
         Pytest monkeypatch fixture for modifying module attributes.
+    rng : np.random.Generator
+        Central numpy random generator for tests.
     """
-    monkeymodule.setattr(pybandits.utils, "maximize_by_quantity", lambda *args, **kwargs: np.random.random(size=(1,)))
+    monkeymodule.setattr(pybandits.utils, "maximize_by_quantity", lambda *args, **kwargs: rng.random(size=(1,)))
     monkeymodule.setattr(
-        pybandits.smab_simulator, "maximize_by_quantity", lambda *args, **kwargs: np.random.random(size=(1,))
+        pybandits.smab_simulator, "maximize_by_quantity", lambda *args, **kwargs: rng.random(size=(1,))
     )
     monkeymodule.setattr(
-        pybandits.strategy.single_objective, "maximize_by_quantity", lambda *args, **kwargs: np.random.random(size=(1,))
+        pybandits.strategy.single_objective, "maximize_by_quantity", lambda *args, **kwargs: rng.random(size=(1,))
     )
     monkeymodule.setattr(pybandits.smab.SmabBernoulli, "predict", mock_predict)
 

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -274,14 +274,16 @@ class TestMergeMABs:
         action_ids2=action_ids_strategy,
         subsidy_factor=subsidy_factor_strategy,
     )
-    def test_merge_cc_mabs(self, action_ids1: set, action_ids2: set, subsidy_factor: float) -> None:
+    def test_merge_cc_mabs(
+        self, action_ids1: set, action_ids2: set, subsidy_factor: float, rng: np.random.Generator
+    ) -> None:
         """Test merging cost-control MABs uses mab2 as template."""
         # Ensure no overlap
         action_ids2 = {f"b_{aid}" for aid in action_ids2}
 
         # Generate random costs for each action
-        action_ids_cost1 = {aid: np.random.uniform(0.5, 5.0) for aid in action_ids1}
-        action_ids_cost2 = {aid: np.random.uniform(0.5, 5.0) for aid in action_ids2}
+        action_ids_cost1 = {aid: rng.uniform(0.5, 5.0) for aid in action_ids1}
+        action_ids_cost2 = {aid: rng.uniform(0.5, 5.0) for aid in action_ids2}
 
         mab1 = SmabBernoulliCC.cold_start(
             action_ids_cost=action_ids_cost1, strategy=CostControlBandit(subsidy_factor=subsidy_factor)


### PR DESCRIPTION
### Changes:

* Add limited_actions and limited_action_fraction fields to BaseMab — throttle over-exploration of newly-introduced arms
  - limited_actions competes only with probability limited_action_fraction on each selection, otherwise masked out
* Update BaseMab.__init__ and cold_start() to accept and propagate the two new params
* Add validation in the model validator — both must be set together, limited_actions must be a subset of the action set and must not contain default_action
* Update _predict_actions selection path to mask limited_actions via self._rng.binomial(1, limited_action_fraction)
  - skips masking when it would empty the action set


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added epsilon-greedy action limiting via `limited_actions` and `limited_action_fraction`, including probabilistic masking during exploration.
  * Extended CMAB/sMAB configurations with `default_action_fraction` and `limited_action_fraction`.
* **Bug Fixes**
  * Added validation to require both limiting parameters together, ensure `limited_actions` is a subset of available actions, and prevent limiting the default action.
  * Improved action-id handling to reject ids that are declared as both regular and quantitative.
* **Tests**
  * Added coverage for validation, masking vs competition, and empirical selection-share behavior.
  * Improved test determinism by switching many random inputs to use injected RNGs.
* **Chores**
  * Bumped package version to **7.5.1**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->