### PR TITLE
Add backbone_anchor_strength to CmabMetaModel

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,9 @@ repos:
     rev: 0.8.1
     hooks:
       - id: nbstripout
+        # fastjsonschema>=2.22.0 uses `dict | bool` PEP 604 syntax without a `__future__` import,
+        # which breaks the CI Python 3.9 job; pin below that until 3.9 support is dropped.
+        additional_dependencies: ['fastjsonschema<2.22.0']
         args: [
           '--extra-keys',
           'metadata.kernelspec metadata.language_info.version metadata.language_info.pygments_lexer'

--- a/pybandits/meta_model/cmab_meta_model.py
+++ b/pybandits/meta_model/cmab_meta_model.py
@@ -41,6 +41,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import numpyro
+import optax
 from loguru import logger
 from numpyro.distributions import Bernoulli as NumpyroBernoulli
 from numpyro.infer import TraceMeanField_ELBO
@@ -92,6 +93,9 @@ class CmabMetaModel(BaseMetaModel, Generic[CmabHeadType]):
     * a single BNN (SO/CC/DP);
     * a multi-objective head — a list of per-objective BNNs (``BaseBayesianNeuralNetworkMO``);
     * a quantitative head — wraps a ``.bnn`` whose input is ``[quantity ‖ context]``.
+
+    How the shared encoder is trained (anchoring penalty, backbone-only learning rate) is configured on
+    the backbone itself — see :class:`~pybandits.model.bnn.backbone.MLPBackbone`.
     """
 
     actions: Dict[ActionId, CmabHeadType]  # type: ignore[assignment]
@@ -106,6 +110,9 @@ class CmabMetaModel(BaseMetaModel, Generic[CmabHeadType]):
     _obj_prefix: ClassVar[str] = "obj"
     # tqdm progress-bar label for the joint SVI run.
     _svi_desc: ClassVar[str] = "cmab joint SVI"
+    # Cold-start kwargs prefix marking a key as backbone-only: it is popped and forwarded, prefix
+    # stripped, to ``MLPBackbone.cold_start`` (so a new backbone knob needs no change here).
+    _backbone_kwargs_prefix: ClassVar[str] = "backbone_"
 
     _rng_key: Any = PrivateAttr(default=None)
 
@@ -121,11 +128,12 @@ class CmabMetaModel(BaseMetaModel, Generic[CmabHeadType]):
         """Build from a pre-made ``actions`` dict or cold-start specs, plus an optional ``backbone``.
 
         The shared ``backbone`` / ``random_seed`` fields reach this constructor two ways: inside the
-        ``kwargs`` bag on **cold start** (the backbone requested via ``backbone_hidden_dims`` plus
-        optional ``embedding_dim`` / ``backbone_activation`` — how ``cold_start`` reaches this class
-        through the generic ``BaseMab.cold_start`` factory, so no bespoke cmab ``cold_start`` is needed),
-        or as top-level keyword arguments on **pydantic (de)serialization**. Both are folded into the
-        single bag here so ``BaseMetaModel.__init__`` handles every field uniformly (no catch-all kwarg).
+        ``kwargs`` bag on **cold start** (the backbone requested via ``backbone_hidden_dims`` plus any
+        other ``backbone_``-prefixed knob — see ``_build_backbone_from_kwargs``; this is how
+        ``cold_start`` reaches this class through the generic ``BaseMab.cold_start`` factory, so no
+        bespoke cmab ``cold_start`` is needed), or as top-level keyword arguments on **pydantic
+        (de)serialization**. Both are folded into the single bag here so ``BaseMetaModel.__init__``
+        handles every field uniformly (no catch-all kwarg).
         """
         kwargs = kwargs or {}
         # Fold the explicitly-passed (de)serialization fields into the bag; ``setdefault`` yields to a
@@ -138,7 +146,7 @@ class CmabMetaModel(BaseMetaModel, Generic[CmabHeadType]):
         # heads that ``BaseMetaModel.__init__`` cold-starts sit on the embedding. The built backbone is
         # stashed back into the bag as the ``backbone`` field for the base ``__init__`` to forward.
         if kwargs.get("backbone") is None:
-            built = self._build_backbone_from_kwargs(kwargs, kwargs.get("random_seed"))
+            built = self._build_backbone_from_kwargs(kwargs)
             if built is not None:
                 kwargs["backbone"] = built
         super().__init__(
@@ -149,41 +157,34 @@ class CmabMetaModel(BaseMetaModel, Generic[CmabHeadType]):
         )
 
     @classmethod
-    def _build_backbone_from_kwargs(
-        cls, kwargs: Dict[str, Any], random_seed: Optional[NonNegativeInt]
-    ) -> Optional[MLPBackbone]:
-        """Pop the backbone specs from ``kwargs`` and build the shared encoder (``None`` if not requested).
+    def _build_backbone_from_kwargs(cls, kwargs: Dict[str, Any]) -> Optional[MLPBackbone]:
+        """Pop every ``backbone_``-prefixed key from ``kwargs`` and build the shared encoder (``None``
+        if not requested).
 
-        Mutates ``kwargs`` in place: removes ``backbone_hidden_dims``/``embedding_dim``/
-        ``backbone_activation`` and, when a backbone is built, rewrites ``n_features`` to the embedding
-        width so the per-arm heads sit on the embedding. Backbone-only knobs without
-        ``backbone_hidden_dims`` raise, rather than being silently ignored.
+        Mutates ``kwargs`` in place: each ``f"{_backbone_kwargs_prefix}{name}"`` key is popped and,
+        prefix stripped, forwarded as ``name=`` to :meth:`MLPBackbone.cold_start` — so a new
+        backbone-only knob needs a ``cold_start`` parameter there and nothing here. Keys not given keep
+        ``MLPBackbone.cold_start``'s own defaults rather than duplicating them here, except
+        ``random_seed``, which falls back to the meta-model's own so one top-level seed makes the whole
+        model reproducible. When a backbone is built, ``n_features`` is rewritten to the embedding width
+        so the per-arm heads sit on the embedding. Backbone-only knobs without ``hidden_dims`` (i.e. no
+        backbone requested) raise, rather than being silently ignored.
         """
-        hidden_dims = kwargs.pop("backbone_hidden_dims", None)
-        embedding_dim = kwargs.pop("embedding_dim", None)
-        activation = kwargs.pop("backbone_activation", None)
-        if hidden_dims is None:
-            backbone_only = {"embedding_dim": embedding_dim, "backbone_activation": activation}
-            set_params = sorted(name for name, value in backbone_only.items() if value is not None)
-            if set_params:
+        prefix = cls._backbone_kwargs_prefix
+        backbone_kwargs = {key[len(prefix) :]: kwargs.pop(key) for key in list(kwargs) if key.startswith(prefix)}
+        if "hidden_dims" not in backbone_kwargs:
+            if backbone_kwargs:
+                set_params = sorted(f"{prefix}{name}" for name in backbone_kwargs)
                 raise TypeError(f"{set_params} only apply with a backbone; pass backbone_hidden_dims=[...].")
             return None
         n_features = kwargs.get("n_features")
         if n_features is None:
             raise ValueError("n_features must be provided to build the shared backbone.")
-        emb = (
-            embedding_dim
-            if embedding_dim is not None
-            else max(1, n_features // BaseBayesianNeuralNetwork.embedding_dim_divisor)
-        )
-        backbone = MLPBackbone.cold_start(
-            n_features=n_features,
-            hidden_dims=hidden_dims,
-            embedding_dim=emb,
-            activation=activation or "relu",
-            random_seed=kwargs.get("random_seed", random_seed),
-        )
-        kwargs["n_features"] = emb  # per-arm heads live on the embedding, not the raw context
+        backbone_kwargs.setdefault("random_seed", kwargs.get("random_seed"))
+        if backbone_kwargs.get("embedding_dim") is None:
+            backbone_kwargs["embedding_dim"] = max(1, n_features // BaseBayesianNeuralNetwork.embedding_dim_divisor)
+        backbone = MLPBackbone.cold_start(n_features=n_features, **backbone_kwargs)
+        kwargs["n_features"] = backbone_kwargs["embedding_dim"]  # heads live on the embedding, not raw context
         return backbone
 
     def model_post_init(self, __context: Any) -> None:
@@ -448,7 +449,7 @@ class CmabMetaModel(BaseMetaModel, Generic[CmabHeadType]):
         svi, params, _history, self._rng_key = run_svi(
             model=model,
             guide=guide,
-            optimizer=representative_bnn._obj_optimizer,
+            optimizer=self._get_joint_optimizer(representative_bnn, n_bb_layers),
             loss=loss,
             rng_key=self._rng_key,
             model_args=model_args,
@@ -462,12 +463,56 @@ class CmabMetaModel(BaseMetaModel, Generic[CmabHeadType]):
             self._store_head(self.actions[arm], site_mu, site_sigma, arm)
         self._store_backbone(params, n_bb_layers)
 
+    def _get_joint_optimizer(self, representative_bnn: BaseBayesianNeuralNetwork, n_bb_layers: int) -> Any:
+        """The optimizer for the joint SVI pass.
+
+        One optimizer for every parameter (backbone and heads alike) unless the shared backbone sets its
+        own ``lr``, in which case an ``optax.multi_transform`` gives the backbone's params their own rate
+        — everything else (optimizer type, remaining ``optimizer_kwargs``, lr schedule) stays shared with
+        the heads. Gradient clipping is applied globally, *before* the per-group split, so the threshold
+        keeps bounding the whole gradient's norm either way.
+
+        ``backbone.lr=0.0`` uses ``optax.set_to_zero()`` rather than the adaptive optimizer at a zero
+        rate, so the per-step update is architecturally zero whatever the optimizer's internals do.
+        """
+        if self.backbone is None or self.backbone.lr is None:
+            return representative_bnn.obj_optimizer
+
+        backbone_optimizer = (
+            optax.set_to_zero()
+            if not self.backbone.lr
+            else representative_bnn.build_optax_optimizer(step_size=self.backbone.lr)
+        )
+        backbone_param_names: Set[str] = {
+            name for i in range(n_bb_layers) for name in self.backbone.get_layer_params_name(i)
+        }
+
+        def label_fn(params: Dict[str, Any]) -> Dict[str, str]:
+            return {name: ("backbone" if name in backbone_param_names else "head") for name in params}
+
+        return representative_bnn.clip_and_wrap_optimizer(
+            optax.multi_transform(
+                {"backbone": backbone_optimizer, "head": representative_bnn.build_optax_optimizer()}, label_fn
+            )
+        )
+
     def _declare_backbone(self, backbone_w: list, backbone_b: list, n_bb_layers: int) -> list:
-        """Register the backbone's deterministic weights as ``numpyro.param`` (inside the trace)."""
+        """Register the backbone's deterministic weights as ``numpyro.param`` (inside the trace).
+
+        When ``backbone.l2_anchoring > 0``, also adds a ``numpyro.factor`` quadratic penalty pulling each
+        layer's optimized weights *and* biases back toward ``backbone_w``/``backbone_b`` — the values at
+        the start of this SVI run, i.e. the previous ``update()`` call's — to bound per-call drift (see
+        :class:`~pybandits.model.bnn.backbone.MLPBackbone`). Declared outside the data plate, so the
+        penalty is not scaled by the minibatch.
+        """
         weights_biases = []
         for i in range(n_bb_layers):
             w_name, b_name = self.backbone.get_layer_params_name(i)
-            weights_biases.append((numpyro.param(w_name, backbone_w[i]), numpyro.param(b_name, backbone_b[i])))
+            w, b = numpyro.param(w_name, backbone_w[i]), numpyro.param(b_name, backbone_b[i])
+            if self.backbone.l2_anchoring > 0:
+                penalty = jnp.sum((w - backbone_w[i]) ** 2) + jnp.sum((b - backbone_b[i]) ** 2)
+                numpyro.factor(f"backbone_anchor_{i}", -0.5 * self.backbone.l2_anchoring * penalty)
+            weights_biases.append((w, b))
         return weights_biases
 
     def _full_batch_model(

--- a/pybandits/model/bnn/backbone.py
+++ b/pybandits/model/bnn/backbone.py
@@ -33,7 +33,7 @@ from typing import ClassVar, List, Optional, Tuple
 
 import jax.numpy as jnp
 import numpy as np
-from pydantic import ConfigDict, NonNegativeInt, PositiveInt
+from pydantic import ConfigDict, NonNegativeFloat, NonNegativeInt, PositiveInt
 from typing_extensions import Self
 
 from pybandits.model.bnn._dnn import DNNMixin
@@ -49,6 +49,22 @@ class MLPBackbone(DNNMixin):
     heads supply the decision non-linearity). Point-estimate weights/biases are stored as plain lists
     (``weights``/``biases``) so the model serialises via ``get_state``/``from_state``; numpy views
     (``weight_arrays``/``bias_arrays``) are rebuilt on init for the forward pass.
+
+    Two optional knobs control how the shared backbone behaves under repeated joint training (both are
+    no-ops at their defaults, and are preserved by :meth:`reset` — they are configuration, not state):
+
+    * ``l2_anchoring`` — weight of a quadratic penalty pulling each ``update()`` call's weights *and*
+      biases back toward their values at the start of that call, the point-estimate analogue of the
+      heads' KL-to-previous-posterior anchor. Bounds per-call drift, which otherwise compounds under
+      continual small-batch updates and degrades online performance. It trades off against the
+      likelihood term (which scales with batch and network size), so tune it per deployment — start
+      around ``1e3``-``1e5`` and increase until drift stabilises without stalling the backbone.
+    * ``lr`` — a backbone-only learning rate for the joint SVI pass (heads keep the one from their
+      ``update_kwargs``); ``0.0`` freezes the backbone entirely. Prefer ``l2_anchoring`` as the primary
+      drift control: empirically it beats any ``lr`` setting, freeze included.
+
+    When cold-starting a :class:`~pybandits.meta_model.cmab_meta_model.CmabMetaModel`, pass these as
+    ``backbone_l2_anchoring`` / ``backbone_lr``.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -65,20 +81,27 @@ class MLPBackbone(DNNMixin):
     random_seed: Optional[NonNegativeInt] = None
     weights: List[List[List[float]]]  # per layer: (input_dim, output_dim)
     biases: List[List[float]]  # per layer: (output_dim,)
+    l2_anchoring: NonNegativeFloat = 0.0
+    lr: Optional[NonNegativeFloat] = None
 
     # Site-name prefixes for the backbone's deterministic params inside the joint NumPyro model.
     weight_var_name: ClassVar[str] = "backbone_weight"
     bias_var_name: ClassVar[str] = "backbone_bias"
 
+    @staticmethod
+    def _as_float32_arrays(nested: List[List[float]]) -> List[np.ndarray]:
+        """Convert per-layer nested lists to ``float32`` numpy arrays (JAX's default working precision)."""
+        return [np.asarray(arr, dtype=np.float32) for arr in nested]
+
     @property
     def weight_arrays(self) -> List[np.ndarray]:
         """Per-layer weight matrices as numpy arrays (consumed by the forward pass / joint SVI engine)."""
-        return [np.asarray(w, dtype=float) for w in self.weights]
+        return self._as_float32_arrays(self.weights)
 
     @property
     def bias_arrays(self) -> List[np.ndarray]:
         """Per-layer bias vectors as numpy arrays (consumed by the forward pass / joint SVI engine)."""
-        return [np.asarray(b, dtype=float) for b in self.biases]
+        return self._as_float32_arrays(self.biases)
 
     @classmethod
     def get_layer_params_name(cls, layer_ind: int) -> Tuple[str, str]:
@@ -175,6 +198,8 @@ class MLPBackbone(DNNMixin):
         embedding_dim: PositiveInt,
         activation: ActivationFunctions = "relu",
         random_seed: Optional[NonNegativeInt] = None,
+        l2_anchoring: NonNegativeFloat = 0.0,
+        lr: Optional[NonNegativeFloat] = None,
     ) -> Self:
         """Initialise an MLP backbone with activation-dependent (He/Xavier) weights and zero biases.
 
@@ -190,6 +215,10 @@ class MLPBackbone(DNNMixin):
             Element-wise activation applied after every layer except the last.
         random_seed : Optional[NonNegativeInt], default=None
             Seed for reproducible initialisation.
+        l2_anchoring : NonNegativeFloat, default=0.0
+            Weight of the per-update anchoring penalty on the backbone's params (``0.0`` disables it).
+        lr : Optional[NonNegativeFloat], default=None
+            Backbone-only learning rate for joint SVI (``None`` shares the heads'; ``0.0`` freezes).
 
         Returns
         -------
@@ -205,10 +234,12 @@ class MLPBackbone(DNNMixin):
             random_seed=random_seed,
             weights=[w.tolist() for w in weights],
             biases=[b.tolist() for b in biases],
+            l2_anchoring=l2_anchoring,
+            lr=lr,
         )
 
     def reset(self) -> Self:
-        """Return a fresh backbone with the same architecture / seed (weights re-initialised).
+        """Return a fresh backbone with the same architecture / seed / knobs (weights re-initialised).
 
         Returns
         -------
@@ -221,6 +252,8 @@ class MLPBackbone(DNNMixin):
             embedding_dim=self.embedding_dim,
             activation=self.activation,
             random_seed=self.random_seed,
+            l2_anchoring=self.l2_anchoring,
+            lr=self.lr,
         )
 
     def embed(self, x: np.ndarray) -> np.ndarray:

--- a/pybandits/model/bnn/network.py
+++ b/pybandits/model/bnn/network.py
@@ -262,6 +262,11 @@ class BaseBayesianNeuralNetwork(Model, DNNMixin, ABC):
     def approx_history(self) -> Optional[np.ndarray]:
         return self._approx_history
 
+    @property
+    def obj_optimizer(self) -> Any:
+        """The optax optimizer built from ``update_kwargs``, wrapped via ``optax_to_numpyro``."""
+        return self._obj_optimizer
+
     def _prepare_context_arrays(self, context: np.ndarray) -> Tuple[np.ndarray, Dict[int, np.ndarray]]:
         """
         Split a numpy context array into numerical and categorical index arrays.
@@ -295,36 +300,47 @@ class BaseBayesianNeuralNetwork(Model, DNNMixin, ABC):
 
         return numerical_arr, cat_indices_dict
 
-    def _get_obj_optimizer(self) -> Any:
-        """Build an optax optimizer from update_kwargs, wrapped via ``optax_to_numpyro``.
+    def build_optax_optimizer(self, step_size: Optional[float] = None) -> optax.GradientTransformation:
+        """Build the raw optax optimizer from ``update_kwargs`` (learning-rate schedule included).
 
-        Optionally chains a learning-rate schedule and/or gradient clipping.
+        Gradient clipping and the ``optax_to_numpyro`` wrapping are *not* applied here, so callers
+        training several parameter groups at once (see ``CmabMetaModel._get_joint_optimizer``) can
+        combine per-group optimizers before clipping globally.
+
+        Parameters
+        ----------
+        step_size : Optional[float], default=None
+            Learning rate override; ``None`` uses ``optimizer_kwargs["step_size"]`` (default ``0.01``).
         """
-        optimizer_type = self.update_kwargs.optimizer_type
         optimizer_kwargs = dict(self.update_kwargs.optimizer_kwargs or {})
-        lr_scheduler_type = self.update_kwargs.lr_scheduler_type
-        lr_scheduler_kwargs = self.update_kwargs.lr_scheduler_kwargs or {}
-        gradient_clip_norm = self.update_kwargs.gradient_clip_norm
-
-        optimizer_fn = self._resolve_optax_fn(optimizer_type, "optimizer")
+        default_step_size = optimizer_kwargs.pop("step_size", 0.01)
+        learning_rate = default_step_size if step_size is None else step_size
 
         # Resolve learning rate (possibly a schedule)
-        learning_rate = optimizer_kwargs.pop("step_size", 0.01)
-        if lr_scheduler_type is not None:
-            scheduler_fn = self._resolve_optax_fn(lr_scheduler_type, "lr_scheduler")
+        if self.update_kwargs.lr_scheduler_type is not None:
+            scheduler_fn = self._resolve_optax_fn(self.update_kwargs.lr_scheduler_type, "lr_scheduler")
+            lr_scheduler_kwargs = self.update_kwargs.lr_scheduler_kwargs or {}
             try:
                 learning_rate = scheduler_fn(init_value=learning_rate, **lr_scheduler_kwargs)
             except (TypeError, ValueError) as e:
                 raise e.__class__(f"Invalid lr_scheduler_kwargs: {lr_scheduler_kwargs}.\n{e}") from e
 
+        optimizer_fn = self._resolve_optax_fn(self.update_kwargs.optimizer_type, "optimizer")
         try:
-            base_optimizer = optimizer_fn(learning_rate=learning_rate, **optimizer_kwargs)
+            return optimizer_fn(learning_rate=learning_rate, **optimizer_kwargs)
         except (TypeError, ValueError, KeyError) as e:
             raise e.__class__(f"Invalid optimizer kwargs: {optimizer_kwargs}.\n{e}") from e
 
+    def clip_and_wrap_optimizer(self, optimizer: optax.GradientTransformation) -> Any:
+        """Chain ``gradient_clip_norm`` (when set) onto ``optimizer`` and wrap it for numpyro."""
+        gradient_clip_norm = self.update_kwargs.gradient_clip_norm
         if gradient_clip_norm is not None:
-            return noptim.optax_to_numpyro(optax.chain(optax.clip_by_global_norm(gradient_clip_norm), base_optimizer))
-        return noptim.optax_to_numpyro(base_optimizer)
+            optimizer = optax.chain(optax.clip_by_global_norm(gradient_clip_norm), optimizer)
+        return noptim.optax_to_numpyro(optimizer)
+
+    def _get_obj_optimizer(self) -> Any:
+        """The single-model optimizer: ``build_optax_optimizer`` plus clipping and numpyro wrapping."""
+        return self.clip_and_wrap_optimizer(self.build_optax_optimizer())
 
     def _get_early_stopping_callback(self) -> Optional[EarlyStopping]:
         early_stopping_kwargs = self.update_kwargs.early_stopping_kwargs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybandits"
-version = "8.0.0"
+version = "8.1.0"
 description = "Python Multi-Armed Bandit Library"
 authors = [
     "Dario d'Andrea <dariod@playtika.com>",

--- a/tests/test_cmab.py
+++ b/tests/test_cmab.py
@@ -23,7 +23,7 @@
 import json
 from copy import deepcopy
 from functools import partial
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union, get_args
 from unittest.mock import patch
 
 import numpy as np
@@ -49,7 +49,6 @@ from pybandits.cmab import (
     CmabBernoulliMO,
     CmabBernoulliMOCC,
 )
-from pybandits.meta_model import CmabMetaModel
 from pybandits.model import (
     BaseBayesianNeuralNetwork,
     BaseBayesianNeuralNetworkMO,
@@ -60,6 +59,7 @@ from pybandits.model import (
     BayesianNeuralNetworkMOCC,
     StudentTArray,
 )
+from pybandits.model.bnn._typing import ActivationFunctions
 from pybandits.quantitative_model import (
     BaseQuantitativeBayesianNeuralNetwork,
     QuantitativeBayesianNeuralNetwork,
@@ -78,7 +78,7 @@ from pybandits.strategy import (
 )
 from tests.utils import (
     apply_mock_update,
-    mock_joint_svi_update,
+    mocked_cmab_training,
     sample_with_replacement,
     to_temporary_pickle,
 )
@@ -677,9 +677,9 @@ def test_update(
 
     old_cmab = deepcopy(cmab)
     for k, transform in enumerate([lambda x: x, np.array, lambda x: x.copy()]):
-        # The unified cmab engine trains jointly (never per-head _update), so skip real SVI by
-        # patching the joint training method; the surrounding update plumbing stays exercised.
-        with patch.object(CmabMetaModel, "_joint_svi_update", mock_joint_svi_update):
+        # Skip real SVI on both update paths (joint engine with a backbone, per-head dispatch without);
+        # the surrounding update plumbing stays exercised.
+        with mocked_cmab_training():
             if k and delta and "actions_memory" not in for_update_kwargs:
                 with pytest.warns(UserWarning):
                     cmab.update(context=transform(context), **for_update_kwargs)
@@ -1599,18 +1599,37 @@ def test_cold_start_with_backbone_reports_raw_input_dim() -> None:
 
 
 @pytest.mark.parametrize(
-    "kwargs, expected_exception, match",
+    "kwarg_name, value_strategy",
     [
-        # Backbone-only knobs are rejected when no backbone is requested.
-        (dict(embedding_dim=8), TypeError, "only apply with a backbone"),
-        (dict(backbone_activation="tanh"), TypeError, "only apply with a backbone"),
-        # The shared-backbone path does not support the adaptive window yet.
-        (dict(backbone_hidden_dims=_BACKBONE_HIDDEN_DIMS, delta=0.1), ValueError, "adaptive window"),
+        ("backbone_embedding_dim", st.integers(min_value=1, max_value=64)),
+        ("backbone_activation", st.sampled_from(get_args(ActivationFunctions))),
+        ("backbone_l2_anchoring", st.floats(min_value=0, max_value=1e6, allow_nan=False, allow_infinity=False)),
+        (
+            "backbone_lr",
+            st.one_of(st.none(), st.floats(min_value=0, max_value=1.0, allow_nan=False, allow_infinity=False)),
+        ),
     ],
 )
-def test_cold_start_rejects_cross_path_arguments(
-    kwargs: Dict[str, Any], expected_exception: Type[Exception], match: str
+@given(data=st.data())
+def test_cold_start_rejects_backbone_only_kwargs_without_backbone(
+    kwarg_name: str, value_strategy: st.SearchStrategy, data: st.DataObject
 ) -> None:
-    """Arguments belonging to the other model path raise instead of being silently ignored."""
-    with pytest.raises(expected_exception, match=match):
-        CmabBernoulli.cold_start(action_ids=_BACKBONE_ACTION_IDS, n_features=_BACKBONE_N_FEATURES, **kwargs)
+    """A backbone-only knob, at any valid value, raises instead of being silently ignored when no
+    backbone is requested (no ``backbone_hidden_dims``)."""
+    value = data.draw(value_strategy)
+    with pytest.raises(TypeError, match="only apply with a backbone"):
+        CmabBernoulli.cold_start(
+            action_ids=_BACKBONE_ACTION_IDS, n_features=_BACKBONE_N_FEATURES, **{kwarg_name: value}
+        )
+
+
+@given(delta=st.floats(min_value=0, max_value=1, exclude_min=True, allow_nan=False, allow_infinity=False))
+def test_cold_start_rejects_delta_with_backbone(delta: float) -> None:
+    """The shared-backbone path does not support the adaptive window (``delta``) yet."""
+    with pytest.raises(ValueError, match="adaptive window"):
+        CmabBernoulli.cold_start(
+            action_ids=_BACKBONE_ACTION_IDS,
+            n_features=_BACKBONE_N_FEATURES,
+            backbone_hidden_dims=_BACKBONE_HIDDEN_DIMS,
+            delta=delta,
+        )

--- a/tests/test_cmab_meta_model.py
+++ b/tests/test_cmab_meta_model.py
@@ -25,12 +25,21 @@ from typing import List, Optional, Set
 
 import numpy as np
 import pytest
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from pybandits.base import ActionId
 from pybandits.meta_model import CmabMetaModelMO, CmabMetaModelSO
 from pybandits.model.bnn.backbone import MLPBackbone
+
+# Shared strategies for the backbone's architecture and its joint-training knobs. Used by the tests
+# that only build/serialise a backbone; the SVI-training tests below keep fixed architectures instead,
+# so their runtime stays bounded.
+_HIDDEN_DIMS = st.lists(st.integers(min_value=1, max_value=8), min_size=0, max_size=2)
+_TRAINING_KNOBS = [
+    ("l2_anchoring", st.floats(min_value=0.0, max_value=1e6, allow_nan=False, allow_infinity=False)),
+    ("lr", st.one_of(st.none(), st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False))),
+]
 
 
 class TestMLPBackbone:
@@ -49,11 +58,14 @@ class TestMLPBackbone:
         n_rows=st.integers(min_value=1, max_value=12),
         n_features=st.integers(min_value=1, max_value=8),
         embedding_dim=st.integers(min_value=1, max_value=6),
+        hidden_dims=_HIDDEN_DIMS,
     )
-    def test_embed_output_shape(self, n_rows: int, n_features: int, embedding_dim: int) -> None:
+    def test_embed_output_shape(self, n_rows: int, n_features: int, embedding_dim: int, hidden_dims: List[int]) -> None:
         """``embed`` maps ``(n_rows, n_features)`` to ``(n_rows, embedding_dim)``."""
         rng = np.random.default_rng(0)
-        bb = MLPBackbone.cold_start(n_features=n_features, hidden_dims=[4], embedding_dim=embedding_dim, random_seed=1)
+        bb = MLPBackbone.cold_start(
+            n_features=n_features, hidden_dims=hidden_dims, embedding_dim=embedding_dim, random_seed=1
+        )
         assert bb.embed(rng.normal(size=(n_rows, n_features))).shape == (n_rows, embedding_dim)
 
     def test_embed_is_deterministic(self, rng: np.random.Generator) -> None:
@@ -65,11 +77,12 @@ class TestMLPBackbone:
         np.testing.assert_array_equal(bb.embed(x), bb.embed(x))
 
     @pytest.mark.parametrize("activation", ["relu", "tanh", "gelu", "sigmoid"])
-    def test_serialization_round_trip(self, activation: str, rng: np.random.Generator) -> None:
+    @given(hidden_dims=_HIDDEN_DIMS)
+    def test_serialization_round_trip(self, activation: str, hidden_dims: List[int], rng: np.random.Generator) -> None:
         """A backbone survives ``model_dump_json`` / ``model_validate`` with identical embeddings."""
         bb = MLPBackbone.cold_start(
             n_features=self.n_features,
-            hidden_dims=self.hidden,
+            hidden_dims=hidden_dims,
             embedding_dim=self.embedding_dim,
             activation=activation,
             random_seed=1,
@@ -78,12 +91,33 @@ class TestMLPBackbone:
         x = self._context(rng)
         np.testing.assert_allclose(bb.embed(x), restored.embed(x))
 
+    @pytest.mark.parametrize("knob_name, value_strategy", _TRAINING_KNOBS)
+    @given(data=st.data(), hidden_dims=_HIDDEN_DIMS)
+    def test_training_knobs_survive_reset_and_serialization(
+        self, knob_name: str, value_strategy: st.SearchStrategy, data: st.DataObject, hidden_dims: List[int]
+    ) -> None:
+        """A knob set at ``cold_start`` persists through ``reset`` and a JSON round-trip, at any value."""
+        value = data.draw(value_strategy)
+        bb = MLPBackbone.cold_start(
+            n_features=self.n_features,
+            hidden_dims=hidden_dims,
+            embedding_dim=self.embedding_dim,
+            random_seed=self.backbone_seed,
+            **{knob_name: value},
+        )
+        assert getattr(bb, knob_name) == value
+        assert getattr(bb.reset(), knob_name) == value
+        assert getattr(MLPBackbone.model_validate_json(bb.model_dump_json()), knob_name) == value
+
 
 class TestCmabMetaModel:
     """The unified per-arm-heads (+ optional shared backbone) joint-VI meta-model."""
 
     n_features = 6
     hidden = [4]
+    # Fixed (not hypothesis-drawn) architectures: the tests here run real SVI, so their cost has to stay
+    # bounded — _HIDDEN_DIMS explores the architecture space in TestMLPBackbone, where nothing trains.
+    backbone_hidden_dims = [8]
     embedding_dim = 4
     n_rows = 9
     action_ids: Set[ActionId] = {"a", "b", "c"}
@@ -97,6 +131,10 @@ class TestCmabMetaModel:
     # joint-minibatch config: batch_size < minibatch_n engages the single-plate minibatch path.
     minibatch_size = 24
     minibatch_n = 160
+    # MLPBackbone's l2_anchoring / lr disabled-state sentinels (the field defaults); other values are
+    # hypothesis-generated per test.
+    l2_anchoring_disabled = 0.0
+    lr_freeze = 0.0
 
     # ----------------------------------------------------------------- helpers / fixtures
     def _head_cold_start_kwargs(self, n_features: int = None) -> dict:
@@ -108,8 +146,18 @@ class TestCmabMetaModel:
             "random_seed": self.meta_seed,
         }
 
-    def _build_meta(self, with_backbone: bool, batch_size: Optional[int] = None) -> CmabMetaModelSO:
-        """Build a meta-model, optionally with a shared backbone and/or a minibatch ``batch_size``."""
+    def _build_meta(
+        self,
+        with_backbone: bool,
+        batch_size: Optional[int] = None,
+        l2_anchoring: float = 0.0,
+        lr: Optional[float] = None,
+    ) -> CmabMetaModelSO:
+        """Build a meta-model, optionally with a shared backbone and/or a minibatch ``batch_size``.
+
+        The training knobs live on the ``MLPBackbone``, so they go to its ``cold_start`` here rather
+        than into the meta-model's own ``kwargs``.
+        """
         update_kwargs = {"num_steps": self.num_steps}
         if batch_size is not None:
             update_kwargs["batch_size"] = batch_size
@@ -122,9 +170,11 @@ class TestCmabMetaModel:
         if with_backbone:
             kwargs["backbone"] = MLPBackbone.cold_start(
                 n_features=self.n_features,
-                hidden_dims=[8],
+                hidden_dims=self.backbone_hidden_dims,
                 embedding_dim=self.embedding_dim,
                 random_seed=self.backbone_seed,
+                l2_anchoring=l2_anchoring,
+                lr=lr,
             )
         return CmabMetaModelSO(action_ids=self.action_ids, kwargs=kwargs)
 
@@ -155,7 +205,7 @@ class TestCmabMetaModel:
         """Shared-backbone unified meta-model (heads on the embedding)."""
         backbone = MLPBackbone.cold_start(
             n_features=self.n_features,
-            hidden_dims=[8],
+            hidden_dims=self.backbone_hidden_dims,
             embedding_dim=self.embedding_dim,
             random_seed=self.backbone_seed,
         )
@@ -228,6 +278,150 @@ class TestCmabMetaModel:
         assert any(not np.allclose(b, a) for b, a in zip(w_before, meta.backbone.weight_arrays))
         assert not np.allclose(mu_before, self._head_mu(meta, "a"))
 
+    @settings(deadline=None, max_examples=5)
+    @given(l2_anchoring=st.floats(min_value=1e4, max_value=1e8, allow_nan=False, allow_infinity=False))
+    def test_backbone_l2_anchoring_reduces_drift(self, l2_anchoring: float) -> None:
+        """A positive ``l2_anchoring`` keeps the backbone's weights *and* biases closer to their
+        pre-update values (it anchors every parameter, biases included, unlike L2 weight decay).
+
+        Locally-seeded ``rng``, not the session-scoped fixture: that fixture keeps advancing across
+        examples, so a hypothesis replay would see different data and flag a spurious flaky failure.
+        """
+        rng = np.random.default_rng(0)
+        actions, rewards, context = self._balanced_batch(rng)
+        unanchored = self._build_meta(with_backbone=True, l2_anchoring=self.l2_anchoring_disabled)
+        anchored = self._build_meta(with_backbone=True, l2_anchoring=l2_anchoring)
+        w_initial = [w.copy() for w in unanchored.backbone.weight_arrays]
+        b_initial = [b.copy() for b in unanchored.backbone.bias_arrays]
+        unanchored.update(actions=actions, rewards=rewards, context=context)
+        anchored.update(actions=actions, rewards=rewards, context=context)
+        drift_unanchored_w = sum(np.sum((a - b) ** 2) for a, b in zip(w_initial, unanchored.backbone.weight_arrays))
+        drift_anchored_w = sum(np.sum((a - b) ** 2) for a, b in zip(w_initial, anchored.backbone.weight_arrays))
+        drift_unanchored_b = sum(np.sum((a - b) ** 2) for a, b in zip(b_initial, unanchored.backbone.bias_arrays))
+        drift_anchored_b = sum(np.sum((a - b) ** 2) for a, b in zip(b_initial, anchored.backbone.bias_arrays))
+        assert drift_anchored_w < drift_unanchored_w
+        assert drift_anchored_b < drift_unanchored_b
+
+    def test_backbone_lr_zero_freezes_backbone_exactly(self, rng: np.random.Generator) -> None:
+        """``lr=0.0`` produces exactly zero backbone movement, while heads still train normally."""
+        actions, rewards, context = self._balanced_batch(rng)
+        meta = self._build_meta(with_backbone=True, lr=self.lr_freeze)
+        w_before = [w.copy() for w in meta.backbone.weight_arrays]
+        mu_before = self._head_mu(meta, "a").copy()
+        meta.update(actions=actions, rewards=rewards, context=context)
+        for before, after in zip(w_before, meta.backbone.weight_arrays):
+            np.testing.assert_array_equal(before, after)
+        assert not np.allclose(mu_before, self._head_mu(meta, "a"))
+
+    @settings(deadline=None, max_examples=5)
+    @given(
+        slow_lr=st.floats(min_value=1e-4, max_value=1e-1, allow_nan=False, allow_infinity=False),
+        speedup=st.floats(min_value=2.0, max_value=100.0, allow_nan=False, allow_infinity=False),
+    )
+    def test_backbone_lr_scales_backbone_drift(self, slow_lr: float, speedup: float) -> None:
+        """A smaller ``lr`` produces proportionally less backbone movement, same seed/data.
+
+        Locally-seeded ``rng`` — see :meth:`test_backbone_l2_anchoring_reduces_drift`.
+        """
+        rng = np.random.default_rng(0)
+        actions, rewards, context = self._balanced_batch(rng)
+        fast = self._build_meta(with_backbone=True, lr=slow_lr * speedup)
+        slow = self._build_meta(with_backbone=True, lr=slow_lr)
+        w_initial = [w.copy() for w in fast.backbone.weight_arrays]
+        fast.update(actions=actions, rewards=rewards, context=context)
+        slow.update(actions=actions, rewards=rewards, context=context)
+        drift_fast = sum(np.sum((a - b) ** 2) for a, b in zip(w_initial, fast.backbone.weight_arrays))
+        drift_slow = sum(np.sum((a - b) ** 2) for a, b in zip(w_initial, slow.backbone.weight_arrays))
+        assert drift_slow < drift_fast
+
+    @settings(deadline=None, max_examples=5)
+    @given(
+        l2_anchoring=st.floats(min_value=1e4, max_value=1e8, allow_nan=False, allow_infinity=False),
+        lr=st.floats(min_value=1e-4, max_value=1e-1, allow_nan=False, allow_infinity=False),
+    )
+    def test_backbone_l2_anchoring_and_lr_compose(self, l2_anchoring: float, lr: float) -> None:
+        """Setting both backbone training knobs together doesn't crash and still trains everything.
+
+        Locally-seeded ``rng`` — see :meth:`test_backbone_l2_anchoring_reduces_drift`.
+        """
+        rng = np.random.default_rng(0)
+        actions, rewards, context = self._balanced_batch(rng)
+        meta = self._build_meta(with_backbone=True, l2_anchoring=l2_anchoring, lr=lr)
+        w_before = [w.copy() for w in meta.backbone.weight_arrays]
+        mu_before = self._head_mu(meta, "a").copy()
+        meta.update(actions=actions, rewards=rewards, context=context)
+        assert any(not np.allclose(b, a) for b, a in zip(w_before, meta.backbone.weight_arrays))
+        assert not np.allclose(mu_before, self._head_mu(meta, "a"))
+
+    @pytest.mark.parametrize("knob_name, value_strategy", _TRAINING_KNOBS)
+    @given(data=st.data())
+    def test_backbone_training_knobs_serialization_round_trip(
+        self, knob_name: str, value_strategy: st.SearchStrategy, data: st.DataObject
+    ) -> None:
+        """Backbone training knobs (on the nested ``backbone``) survive a full ``CmabMetaModel`` JSON round
+        trip, for any valid value."""
+        value = data.draw(value_strategy)
+        meta = self._build_meta(with_backbone=True, **{knob_name: value})
+        restored = CmabMetaModelSO.model_validate_json(meta.model_dump_json())
+        assert getattr(restored.backbone, knob_name) == value
+
+    @pytest.mark.parametrize("knob_name, value_strategy", _TRAINING_KNOBS)
+    @given(data=st.data())
+    def test_backbone_training_knobs_reach_backbone_via_cold_start_kwargs(
+        self, knob_name: str, value_strategy: st.SearchStrategy, data: st.DataObject
+    ) -> None:
+        """``backbone_``-prefixed cold-start kwargs thread through onto the built ``MLPBackbone``, prefix
+        stripped, for any valid value."""
+        value = data.draw(value_strategy)
+        kwargs = {
+            "n_features": self.n_features,
+            "hidden_dim_list": self.hidden,
+            "update_kwargs": {"num_steps": self.num_steps},
+            "backbone_hidden_dims": self.backbone_hidden_dims,
+            "backbone_embedding_dim": self.embedding_dim,
+            f"backbone_{knob_name}": value,
+        }
+        meta = CmabMetaModelSO(action_ids=self.valid_subset, kwargs=kwargs)
+        assert getattr(meta.backbone, knob_name) == value
+
+    @given(random_seed=st.integers(min_value=0, max_value=2**31 - 1))
+    def test_backbone_inherits_meta_model_random_seed(self, random_seed: int) -> None:
+        """The backbone falls back to the meta-model's ``random_seed``, so one top-level seed makes the
+        whole model (backbone init included) reproducible; ``backbone_random_seed`` overrides it."""
+        kwargs = {
+            "n_features": self.n_features,
+            "hidden_dim_list": self.hidden,
+            "update_kwargs": {"num_steps": self.num_steps},
+            "backbone_hidden_dims": self.backbone_hidden_dims,
+            "backbone_embedding_dim": self.embedding_dim,
+            "random_seed": random_seed,
+        }
+        meta = CmabMetaModelSO(action_ids=self.valid_subset, kwargs=dict(kwargs))
+        assert meta.backbone.random_seed == random_seed
+
+        overridden = CmabMetaModelSO(
+            action_ids=self.valid_subset, kwargs={**kwargs, "backbone_random_seed": self.backbone_seed}
+        )
+        assert overridden.backbone.random_seed == self.backbone_seed
+
+    @pytest.mark.parametrize("knob_name, value_strategy", _TRAINING_KNOBS)
+    @given(data=st.data())
+    def test_backbone_training_knobs_require_backbone_hidden_dims(
+        self, knob_name: str, value_strategy: st.SearchStrategy, data: st.DataObject
+    ) -> None:
+        """A ``backbone_``-prefixed knob passed via cold-start kwargs without ``backbone_hidden_dims``
+        raises, at any value — the same ``TypeError`` as ``backbone_embedding_dim``/``backbone_activation``.
+        """
+        value = data.draw(value_strategy)
+        kwargs = {
+            "n_features": self.n_features,
+            "hidden_dim_list": self.hidden,
+            "update_kwargs": {"num_steps": self.num_steps},
+            f"backbone_{knob_name}": value,
+        }
+        with pytest.raises(TypeError, match="only apply with a backbone"):
+            CmabMetaModelSO(action_ids=self.valid_subset, kwargs=kwargs)
+
     def test_reset_restores_backbone(self, meta_backbone: CmabMetaModelSO, rng: np.random.Generator) -> None:
         """``reset`` restores the backbone (same seed) after an update."""
         w_initial = [w.copy() for w in meta_backbone.backbone.weight_arrays]
@@ -278,7 +472,7 @@ class TestCmabMetaModel:
         if with_backbone:
             head_kwargs["backbone"] = MLPBackbone.cold_start(
                 n_features=self.n_features,
-                hidden_dims=[8],
+                hidden_dims=self.backbone_hidden_dims,
                 embedding_dim=self.embedding_dim,
                 random_seed=self.backbone_seed,
             )
@@ -320,7 +514,7 @@ class TestCmabMetaModel:
             "hidden_dim_list": self.hidden,
             "update_kwargs": {"method": "fullrank_advi"},
             "backbone_hidden_dims": self.hidden,
-            "embedding_dim": self.embedding_dim,
+            "backbone_embedding_dim": self.embedding_dim,
         }
         with pytest.raises(NotImplementedError, match="advi"):
             CmabMetaModelSO(action_ids=self.valid_subset, kwargs=kwargs)
@@ -382,7 +576,7 @@ class TestCmabMetaModel:
             "random_seed": self.meta_seed,
             "backbone": MLPBackbone.cold_start(
                 n_features=self.n_features,
-                hidden_dims=[8],
+                hidden_dims=self.backbone_hidden_dims,
                 embedding_dim=self.embedding_dim,
                 random_seed=self.backbone_seed,
             ),

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -151,8 +151,12 @@ class TestBetaDecayFactor:
     counts = st.integers(min_value=1, max_value=MAX_COUNT)
     diverging_counts = st.integers(min_value=2, max_value=MAX_COUNT)  # > prior, so decayed != raw
     binary_rewards = st.lists(st.integers(min_value=0, max_value=1), min_size=1)
+    # Highest decay factor that still forgets *measurably*: at 1 - 1e-16 the decayed counts are within
+    # one float of the raw ones, so the two Beta(a, b) draws come out bit-identical and any
+    # "decayed sampling differs from raw sampling" assertion is vacuously false.
+    MAX_FORGETTING_DECAY_FACTOR = 0.999
     decay_factors = st.floats(min_value=MIN_DECAY_FACTOR, max_value=MAX_DECAY_FACTOR)
-    forgetting_decay_factors = st.floats(min_value=MIN_DECAY_FACTOR, max_value=MAX_DECAY_FACTOR, exclude_max=True)
+    forgetting_decay_factors = st.floats(min_value=MIN_DECAY_FACTOR, max_value=MAX_FORGETTING_DECAY_FACTOR)
 
     @given(
         decay_factor=st.one_of(st.none(), decay_factors),
@@ -1122,7 +1126,7 @@ def test_bnn_vi_update_parameters(
     assert callable(model_fn)
 
     # Optimizer is always set for VI (built from defaults or user override)
-    assert bnn._obj_optimizer is not None
+    assert bnn.obj_optimizer is not None
 
     if "early_stopping_kwargs" in update_kwargs:
         assert bnn._get_early_stopping_callback() is not None
@@ -1275,7 +1279,7 @@ def test_lr_scheduler_valid(
             "lr_scheduler_kwargs": lr_scheduler_kwargs,
         },
     )
-    assert bnn._obj_optimizer is not None
+    assert bnn.obj_optimizer is not None
 
 
 @pytest.mark.parametrize(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,10 @@
 import json
 import pickle
 import random
+from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
-from typing import Any, List, Optional, Tuple
+from typing import Any, Iterator, List, Optional, Tuple
+from unittest.mock import patch
 
 import numpy as np
 from bokeh.core.serialization import Serializable
@@ -10,6 +12,7 @@ from pydantic import PositiveInt
 
 from pybandits.base import PyBanditsBaseModel, UnifiedActionId
 from pybandits.base_model import BaseModel
+from pybandits.meta_model import CmabMetaModel
 from pybandits.model import BaseBayesianNeuralNetwork, BaseBayesianNeuralNetworkMO, BnnLayerParams
 from pybandits.quantitative_model import BaseQuantitativeBayesianNeuralNetwork, QuantitativeModel
 
@@ -134,6 +137,22 @@ def mock_joint_svi_update(self, context, arm_to_rows, rewards_arr, quantities) -
     (context/shape validation, counter increments, adaptive window) intact.
     """
     apply_mock_update([self.actions[arm] for arm in arm_to_rows])
+
+
+@contextmanager
+def mocked_cmab_training() -> Iterator[None]:
+    """Skip real SVI in *both* cmab update paths, leaving the surrounding ``update`` plumbing intact.
+
+    ``CmabMetaModel.update`` routes through the joint SVI engine only when a shared backbone is set;
+    with no backbone it dispatches to each head's own ``update`` (and thus ``_update``). Patching only
+    one of the two silently trains the other for real — which costs hours of CI time.
+    """
+    with (
+        patch.object(BaseBayesianNeuralNetwork, "_update", mock_update),
+        patch.object(QuantitativeModel, "_update", mock_update),
+        patch.object(CmabMetaModel, "_joint_svi_update", mock_joint_svi_update),
+    ):
+        yield
 
 
 def pop_from_state(state: str, key: str) -> Tuple[Serializable, str]:


### PR DESCRIPTION
### Changes:

* Add backbone_anchor_strength field to CmabMetaModel — L2 penalty tying each update()'s backbone weights/biases to their pre-call values, the point-estimate analogue of the heads' own KL-to-previous-posterior anchor
  - defaults to 0.0 (disabled), reproducing the prior unanchored behavior exactly
  - addresses unbounded backbone drift under continual small-batch update() calls (e.g. hourly streaming retraining)
* Update CmabMetaModel.__init__() — thread backbone_anchor_strength through the kwargs bag the same way as backbone/random_seed (direct arg or cold-start kwargs)
* Update _declare_backbone() — add the numpyro.factor anchor term when backbone_anchor_strength > 0; applies on both the single-objective/minibatch path (_so_model) and the MO/quantitative full-batch path (_full_batch_model), since both call _declare_backbone
* Add backbone_anchor_strength test coverage to TestCmabMetaModel in tests/test_cmab_meta_model.py
  - zero strength matches default unanchored behavior exactly
  - positive strength measurably reduces backbone drift vs. unanchored, same seed/data
  - serializes/deserializes correctly via model_dump_json/model_validate_json
  - reaches the model via the cold-start kwargs bag (backbone_hidden_dims path), not just the direct constructor arg
  - is a silent no-op when backbone=None, even with a nonzero strength
* Update pyproject.toml — 8.0.0 -> 8.1.0, minor bump for the new backward-compatible field


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added joint shared-backbone training controls: `l2_anchoring` (weight/bias anchoring penalty) and `lr` (independent backbone learning rate).
  * Supports `lr=0.0` to freeze backbone updates while heads continue training.
  * Exposed a public `obj_optimizer` property on Bayesian neural network instances.
* **Bug Fixes**
  * Backbone-only knobs are now validated and error if used without enabling the shared-backbone path.
* **Tests**
  * Expanded coverage for anchoring drift reduction, backbone freezing, knob persistence, and JSON/kwargs propagation.
* **Chores**
  * Bumped package version to 8.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->