### PR TITLE
Update contributing guidelines to match the enforced conventions

### DIFF
--- a/.github/workflows/pull_request_style_check.yml
+++ b/.github/workflows/pull_request_style_check.yml
@@ -18,7 +18,12 @@ jobs:
     name: check conventional commits labels
     runs-on: ubuntu-latest
     steps:
-      - uses: danielchabr/pr-labels-checker@v3.3
+      - uses: mheap/github-action-required-labels@v5
         with:
-          hasSome: bug, documentation, enhancement, skip-changelog
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          mode: minimum
+          count: 1
+          labels: |
+            bug
+            documentation
+            enhancement
+            skip-changelog

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,12 +4,12 @@ Contributing
 In this page we want to explain how to contribute to this library following our standards.
 
 This library aims to be an open and collaborative project released under the MIT license. It is hosted on
-[Github](https://github.com/PlaytikaResearch/pybandits) as  it intends to be supported by an open community
+[GitHub](https://github.com/PlaytikaOSS/pybandits) as  it intends to be supported by an open community
 of contributors.
 
-We want to ensure both code clarity and quality. *pybandits* follows *Flake8* standards. Every component, class and
+We want to ensure both code clarity and quality. *pybandits* follows *Ruff* standards. Every component, class and
 function are tested with *pytest* reaching a line coverage of 90%. All contributors must follow the contributors
-guidelines before to open any pull request for code merge (pre-commit hook, commits squash, *Flake8* compliance, test,
+guidelines before to open any pull request for code merge (pre-commit hook, commits squash, *Ruff* compliance, test,
 coverage, update documentation). *pybandit* also provides a detailed documentation implemented with *Sphinx* where each
 class and function is described. We want to enforce a community-based collaboration with external contributors
 that embrace our open source philosophy.
@@ -18,48 +18,50 @@ Guidelines
 ----------
 We expect developers to work with the following steps before opening a pull request.
 
-* Create a new feature branch from master. <br/> The new branch must follow the name convention
-`pybandits-XXXX feature_name` where `XXXX`= number of the issue linked to this branch and `feature_name`= short
-description of the new feature (e.g. add predict function to sMAB)
+* Create a new feature branch from `develop`, which is the default branch and the base of every pull request.
+<br/> The new branch must follow the name convention `feature/<short_description>` where `<short_description>`=
+short description of the new feature (e.g. `feature/add_predict_function_to_smab`)
 
 * Checkout on the new branch and write the code of the new feature.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-$ git checkout feature/pybandits-XXXX feature_name
+$ git checkout develop
+$ git pull
+$ git checkout -b feature/<short_description>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Run pre-commit hooks before any commit. This will check code style, max-line-length, etc. Code style must respect
-*Flake8* standards.
+*Ruff* standards (`ruff-format` and `ruff`, pinned in `.pre-commit-config.yaml`). This is the same command the CI
+style check runs, so a clean run here means a green check there.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-$ pre-commit
+$ poetry run pre-commit run --all-files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Commit and push your code on the feature branch (as many times as you need)
+* Commit and push your code on the feature branch (as many times as you need). The commit subject is an imperative
+sentence describing the change (e.g. `Add per-update decay_factor`); it carries no ticket prefix.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 $ git add filename
-$ git commit -m 'pybandits-XXXX short_description'
+$ git commit -m 'Add short_description'
 $ git push origin HEAD
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Make sure that all tests must pass successfully. <br/> Tests can be executed with *pytest* running the following
-commands:
+* Make sure that all tests must pass successfully. <br/> Tests are run from the repository root with *pytest*, as the
+CI does:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-$ cd tests
-$ pytest -vv                                      # run all tests
-$ pytest -vv test_testmodule.py                   # run all tests within a module
-$ pytest -vv test_testmodule.py -k test_testname  # run only 1 test
-$ pytest -vv -k 'not time'                        # run all tests but not exec time
+$ poetry run pytest -n auto -vv                                   # run all tests
+$ poetry run pytest -vv tests/test_testmodule.py                  # run all tests within a module
+$ poetry run pytest -vv tests/test_testmodule.py -k test_testname # run only 1 test
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 At this stage you should be at the point where you have completed all your tasks and you are ready for other people to
 review your code.
 
-* Rebase on master with commits squash. <br/> Be careful because `rebase` is an unsafe operation, if you want to know
-more please check [here](https://docs.github.com/en/get-started/using-git/about-git-rebase).
+* Rebase on `develop` with commits squash. <br/> Be careful because `rebase` is an unsafe operation, if you want to
+know more please check [here](https://docs.github.com/en/get-started/using-git/about-git-rebase).
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-$ git checkout master
+$ git checkout develop
 $ git pull
-$ git checkout feature/pybandits-<XXXX><feature_name>
-$ git rebase --interactive master
+$ git checkout feature/<short_description>
+$ git rebase --interactive develop
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In `rebase` the first line must contain `pick`. In all the other lines delete `pick` and write `fixup`.
 Then save the file.
@@ -73,7 +75,7 @@ empty line between the title and `### Changes`; to have an empty line before the
 to have the markdown correctly rendered).
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-pybandits-XXXX short_description
+Add short_description
 
  ### Changes
 
@@ -85,4 +87,13 @@ pybandits-XXXX short_description
 <default message>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* If all steps above were successfully completed, you can open a pull request.
+* If all steps above were successfully completed, you can open a pull request against `develop`. Two conventions are
+enforced on the pull request itself:
+
+  * The title follows the same imperative form as the commit subject, and the description follows
+  [the pull request template](.github/pull_request_template.md).
+
+  * The pull request must carry at least one of the labels `bug`, `documentation`, `enhancement` or `skip-changelog`.
+  The `check conventional commits labels` job fails until one is present, and re-runs whenever a label is added or
+  removed. Contributors without write access cannot apply labels themselves, so ask a maintainer in the pull
+  request.


### PR DESCRIPTION
### Changes:
* Update `CONTRIBUTING.md` so every instruction matches what the repository enforces today. Each correction below is
  checked against a file in the repo rather than against convention:

  | guideline says | repository | source |
  |---|---|---|
  | branch from `master` | `develop` is the default branch; no `master` exists | repo branch list |
  | *Flake8* standards (3 mentions) | `ruff-format` + `ruff` v0.11.0; no flake8 config anywhere | `.pre-commit-config.yaml`, `pyproject.toml` |
  | `git commit -m 'pybandits-XXXX short_description'` | plain imperative subject, no ticket prefix | merged subjects on `develop` |
  | `git checkout feature/pybandits-XXXX feature_name` | that reads as `<branch> <pathspec>` and has no `-b`, so it cannot create a branch | git behaviour |
  | `cd tests` then `pytest -vv` | run from the repository root | `continuous_integration.yml` |
  | `pytest -k 'not time'` for exec-time tests | no exec-time test remains | `tests/` |
  | `PlaytikaResearch/pybandits` | `PlaytikaOSS/pybandits` (old path still redirects) | repo metadata |

* Document two pull request conventions that are enforced but were unwritten: the title form and
  `.github/pull_request_template.md` for the description, and the label that
  `check conventional commits labels` requires.

  That label rule is the one worth having written down. `pull_request_style_check.yml` requires one of
  `bug` / `documentation` / `enhancement` / `skip-changelog`, and a contributor without write access cannot apply
  one — `AddLabelsToLabelable` is refused. So the check is red on arrival with nothing in the repository explaining
  why or what to do about it. The new text says to ask a maintainer, and notes the job re-runs on `labeled`.

* Tests added or updated: none — documentation only, no code paths touched.
* Documentation updated: this is the documentation change.

Opened separately from #156 rather than folded into it, since it is unrelated to that PR's contents and #156 is
mid-review. Prompted by @shaharbar1's note there.

I stayed off anything that is a process preference rather than a factual mismatch — the squash-and-rebase flow and
the commit-message template are unchanged apart from the branch name and the ticket prefix.

*Written with AI assistance; the diff and every claim in the table above were verified by me against the files cited.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines to match the current repository workflow and links.
  * Refreshed tooling guidance by switching linting references from Flake8 to Ruff.
  * Clarified branching, required pull request target (against `develop`), and title/description conventions.
  * Added required pull request label enforcement, with a note that related CI validation will fail until a label is applied.
  * Updated testing, rebasing, and command examples to reflect the current process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->